### PR TITLE
fix(license): declare MIT AND Apache-2.0 for bundled Apache portions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@vyui/root",
   "private": true,
+  "license": "MIT AND Apache-2.0",
   "type": "module",
   "scripts": {
     "dev": "pnpm -r run dev",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "version": "0.0.3",
   "description": "Lynx-native component primitives, ported from reka-ui",
-  "license": "MIT",
+  "license": "MIT AND Apache-2.0",
   "sideEffects": [
     "**/*.css",
     "**/*.vue.js",


### PR DESCRIPTION
Tighten license metadata so the published SPDX expression matches what's actually bundled, for automated scanners (FOSSA, Snyk, etc.).

- `@vyui/core`: `MIT` → `MIT AND Apache-2.0` (only published package bundling Apache-2.0-adapted code per NOTICE; all affected paths are under `packages/core/src`)
- root `package.json`: add `license: MIT AND Apache-2.0` for repo-level scanner accuracy (still private)
- `kit`/`testing-utils`/`shared-build-config`: unchanged as MIT — no Apache portions in their source; `kit` consumes `core` as an externalized peerDependency, so its artifact stays pure MIT

Labeling correctness only — no change to usage rights.