### PR TITLE
fix(ci): pin pnpm via packageManager to fix Cloudflare build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 11
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -10,8 +10,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 11
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@vyui/root",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@11.4.0",
   "scripts": {
     "dev": "pnpm -r run dev",
     "build": "pnpm -r --filter='./packages/*' build",
@@ -19,22 +20,5 @@
     "@svitejs/changesets-changelog-github-compact": "^1.2.0",
     "pnpm": "^11.0.0",
     "tsx": "^4.19.2"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "core-js",
-      "sharp",
-      "vue-demi"
-    ],
-    "overrides": {
-      "vue": "3.5.34",
-      "@vue/runtime-core": "3.5.34",
-      "@vue/runtime-dom": "3.5.34",
-      "@vue/compiler-core": "3.5.34",
-      "@vue/compiler-dom": "3.5.34",
-      "@vue/compiler-sfc": "3.5.34",
-      "@vue/server-renderer": "3.5.34"
-    }
   }
 }

--- a/packages/core/src/components/Accordion/AccordionItem.vue
+++ b/packages/core/src/components/Accordion/AccordionItem.vue
@@ -1,6 +1,7 @@
 <script lang="ts">
 import type { ComputedRef, VNodeRef } from 'vue'
 import type { CollapsibleRootProps } from '../Collapsible'
+import type { ElementHandle } from '@/shared/types'
 import { createContext, useForwardExpose } from '@/shared'
 import { injectAccordionRootContext } from './AccordionRoot.vue'
 
@@ -31,7 +32,7 @@ interface AccordionItemContext {
   dataDisabled: ComputedRef<'' | undefined>
   triggerId: string
   currentRef: VNodeRef
-  currentElement: ComputedRef<HTMLElement | undefined>
+  currentElement: ComputedRef<ElementHandle | undefined>
   value: ComputedRef<string>
 }
 

--- a/packages/core/src/components/Accordion/AccordionRoot.vue
+++ b/packages/core/src/components/Accordion/AccordionRoot.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import type { ComputedRef, Ref } from 'vue'
 import type { PrimitiveProps } from '@/components/Primitive'
-import type { AcceptableValue, DataOrientation, Direction, SingleOrMultipleProps, SingleOrMultipleType } from '@/shared/types'
+import type { AcceptableValue, DataOrientation, Direction, ElementHandle, SingleOrMultipleProps, SingleOrMultipleType } from '@/shared/types'
 import { createContext, useDirection, useForwardExpose } from '@/shared'
 
 export interface AccordionRootProps<T = string | string[]>
@@ -54,7 +54,7 @@ export type AccordionRootContext<P extends AccordionRootProps> = {
   disabled: Ref<P['disabled']>
   direction: Ref<P['dir']>
   orientation: P['orientation']
-  parentElement: Ref<HTMLElement | undefined>
+  parentElement: Ref<ElementHandle | undefined>
   changeModelValue: (value: string) => void
   isSingle: ComputedRef<boolean>
   modelValue: Ref<AcceptableValue | AcceptableValue[] | undefined>

--- a/packages/core/src/components/AlertDialog/AlertDialogContentImpl.vue
+++ b/packages/core/src/components/AlertDialog/AlertDialogContentImpl.vue
@@ -9,9 +9,9 @@ import type { PrimitiveProps } from '@/components/Primitive'
  */
 export type AlertDialogContentImplEmits = {
   /** Auto-focus on open. Inert on Lynx — kept so call sites mirror reka-ui. */
-  openAutoFocus: [event: Event]
+  openAutoFocus: [event: any]
   /** Auto-focus on close. Inert on Lynx — kept so call sites mirror reka-ui. */
-  closeAutoFocus: [event: Event]
+  closeAutoFocus: [event: any]
 }
 
 export interface AlertDialogContentImplProps extends PrimitiveProps {

--- a/packages/core/src/components/Collection/Collection.ts
+++ b/packages/core/src/components/Collection/Collection.ts
@@ -1,10 +1,11 @@
 import type { Ref } from 'vue'
+import type { ElementHandle } from '@/shared/types'
 import { computed, defineComponent, h, inject, markRaw, provide, ref, watch, watchEffect } from 'vue'
 import { Slot, usePrimitiveElement } from '@/components/Primitive'
 
 interface CollectionContext<ItemData = {}> {
-  collectionRef: Ref<HTMLElement | undefined>
-  itemMap: Ref<Map<HTMLElement, { ref: HTMLElement, value?: any } & ItemData>>
+  collectionRef: Ref<ElementHandle | undefined>
+  itemMap: Ref<Map<ElementHandle, { ref: ElementHandle, value?: any } & ItemData>>
 }
 
 const ITEM_DATA_ATTR = 'data-vy-collection-item'
@@ -15,7 +16,7 @@ export function useCollection<ItemData = {}>(options: { key?: string, isProvider
   let context: CollectionContext<ItemData>
 
   if (isProvider) {
-    const itemMap = ref<Map<HTMLElement, { ref: HTMLElement } & ItemData>>(new Map())
+    const itemMap = ref<Map<ElementHandle, { ref: ElementHandle } & ItemData>>(new Map())
     const collectionRef = ref<any>()
 
     context = {

--- a/packages/core/src/components/Dialog/DialogContentImpl.vue
+++ b/packages/core/src/components/Dialog/DialogContentImpl.vue
@@ -7,12 +7,12 @@ export type DialogContentImplEmits = DismissableLayerEmits & {
    * Event handler called when auto-focusing on open. Can be prevented.
    * Inert on Lynx (no focus model) — kept so call sites mirror reka-ui.
    */
-  openAutoFocus: [event: Event]
+  openAutoFocus: [event: any]
   /**
    * Event handler called when auto-focusing on close. Can be prevented.
    * Inert on Lynx (no focus model) — kept so call sites mirror reka-ui.
    */
-  closeAutoFocus: [event: Event]
+  closeAutoFocus: [event: any]
 }
 
 export interface DialogContentImplProps extends PrimitiveProps {

--- a/packages/core/src/components/Primitive/usePrimitiveElement.ts
+++ b/packages/core/src/components/Primitive/usePrimitiveElement.ts
@@ -1,10 +1,11 @@
 import type { ComponentPublicInstance } from 'vue'
+import type { ElementHandle } from '@/shared/types'
 import { unrefElement } from '@vueuse/core'
 import { computed, ref } from 'vue'
 
 export function usePrimitiveElement<T extends ComponentPublicInstance>() {
   const primitiveElement = ref<T>()
-  const currentElement = computed(() => unrefElement(primitiveElement) as HTMLElement | undefined)
+  const currentElement = computed(() => unrefElement(primitiveElement) as ElementHandle | undefined)
 
   return {
     primitiveElement,

--- a/packages/core/src/components/RadioGroup/utils.ts
+++ b/packages/core/src/components/RadioGroup/utils.ts
@@ -1,10 +1,11 @@
+import type { VyCustomEvent } from '@/shared/handleAndDispatchCustomEvent'
 import type { AcceptableValue } from '@/shared/types'
 import { handleAndDispatchCustomEvent } from '@/shared'
 
-export type SelectEvent = CustomEvent<{ originalEvent: MouseEvent, value?: AcceptableValue }>
+export type SelectEvent = VyCustomEvent<{ originalEvent: any, value?: AcceptableValue }>
 export const RADIO_SELECT = 'radio.select'
 
-export function handleSelect(event: MouseEvent, value: AcceptableValue | undefined, callback: (event: SelectEvent) => void) {
+export function handleSelect(event: any, value: AcceptableValue | undefined, callback: (event: SelectEvent) => void) {
   const eventDetail = { originalEvent: event, value }
   handleAndDispatchCustomEvent(RADIO_SELECT, callback, eventDetail)
 }

--- a/packages/core/src/components/Slider/SliderImpl.vue
+++ b/packages/core/src/components/Slider/SliderImpl.vue
@@ -11,9 +11,9 @@ export type SliderImplEmits = {
   slideMove: [event: any, kind: 'touch' | 'mouse']
   /** Touch ended / cancelled / mouse released. */
   slideEnd: []
-  homeKeyDown: [event: KeyboardEvent]
-  endKeyDown: [event: KeyboardEvent]
-  stepKeyDown: [event: KeyboardEvent]
+  homeKeyDown: [event: any]
+  endKeyDown: [event: any]
+  stepKeyDown: [event: any]
 }
 
 export interface SliderImplProps extends PrimitiveProps {}

--- a/packages/core/src/components/Slider/SliderRoot.vue
+++ b/packages/core/src/components/Slider/SliderRoot.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import type { ComputedRef, Ref } from 'vue'
 import type { MainThreadRef } from 'vue-lynx'
-import type { DataOrientation, Direction, FormFieldProps } from '@/shared/types'
+import type { DataOrientation, Direction, ElementHandle, FormFieldProps } from '@/shared/types'
 import type { PrimitiveProps } from '@/components/Primitive'
 import { useCollection } from '@/components/Collection'
 import { clamp, createContext, useDirection, useForwardExpose } from '@/shared'
@@ -93,7 +93,7 @@ export interface SliderRootContext {
   modelValue?: Readonly<Ref<number | number[] | null | undefined>>
   currentModelValue: ComputedRef<number[]>
   valueIndexToChangeRef: Ref<number>
-  thumbElements: Ref<HTMLElement[]>
+  thumbElements: Ref<ElementHandle[]>
   thumbAlignment: Ref<ThumbAlignment>
   /** True when the MT touch pipeline owns drag paint. Set per-mount. */
   mtsEnabled: ComputedRef<boolean>

--- a/packages/core/src/components/Slider/SliderThumbImpl.vue
+++ b/packages/core/src/components/Slider/SliderThumbImpl.vue
@@ -31,7 +31,7 @@ const { CollectionItem } = useCollection()
 const value = computed(() => rootContext.currentModelValue.value[props.index])
 const percent = computed(() => value.value === undefined ? 0 : convertValueToPercentage(value.value, rootContext.min.value ?? 0, rootContext.max.value ?? 100))
 const label = computed(() => getLabel(props.index, rootContext.currentModelValue.value.length))
-const size = useSize(thumbElement)
+const size = useSize(thumbElement as any)
 const orientationSize = computed(() => size[orientation!.size].value)
 const thumbInBoundsOffset = computed(() => {
   if (rootContext.thumbAlignment.value === 'overflow' || !orientationSize.value) {

--- a/packages/core/src/components/Slider/utils.ts
+++ b/packages/core/src/components/Slider/utils.ts
@@ -11,9 +11,9 @@ export type SliderOrientationPrivateEmits = {
   slideEnd: []
   slideStart: [value: number]
   slideMove: [value: number]
-  homeKeyDown: [event: KeyboardEvent]
-  endKeyDown: [event: KeyboardEvent]
-  stepKeyDown: [event: KeyboardEvent, direction: number]
+  homeKeyDown: [event: any]
+  endKeyDown: [event: any]
+  stepKeyDown: [event: any, direction: number]
 }
 
 export function getNextSortedValues(prevValues: number[] = [], nextValue: number, atIndex: number) {

--- a/packages/core/src/components/Stepper/StepperRoot.vue
+++ b/packages/core/src/components/Stepper/StepperRoot.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { Ref } from 'vue'
-import type { DataOrientation, Direction } from '@/shared/types'
+import type { DataOrientation, Direction, ElementHandle } from '@/shared/types'
 import type { PrimitiveProps } from '@/components/Primitive'
 import { computed, nextTick, ref, toRefs, watch } from 'vue'
 import { Primitive } from '@/components/Primitive'
@@ -13,7 +13,7 @@ export interface StepperRootContext {
   orientation: Ref<DataOrientation>
   dir: Ref<Direction>
   linear: Ref<boolean>
-  totalStepperItems: Ref<Set<HTMLElement>>
+  totalStepperItems: Ref<Set<ElementHandle>>
 }
 
 export interface StepperRootProps extends PrimitiveProps {
@@ -84,7 +84,7 @@ defineSlots<{
 const { dir: propDir, orientation: propOrientation, linear } = toRefs(props)
 const dir = useDirection(propDir)
 
-const totalStepperItems = ref<Set<HTMLElement>>(new Set())
+const totalStepperItems = ref<Set<ElementHandle>>(new Set())
 
 const modelValue = useStandardVModel<number | undefined>(props, emits)
 

--- a/packages/core/src/shared/handleAndDispatchCustomEvent.ts
+++ b/packages/core/src/shared/handleAndDispatchCustomEvent.ts
@@ -1,10 +1,22 @@
+/**
+ * Synthetic custom-event shape passed to handlers. On Lynx there is no DOM
+ * `CustomEvent`; this mirrors the subset call sites read (`detail`,
+ * `defaultPrevented`, `preventDefault`). Typed locally so the public signature
+ * doesn't leak DOM `CustomEvent` / `Event` into consumers' `.d.ts`.
+ */
+export interface VyCustomEvent<D = any> {
+  detail: D
+  defaultPrevented?: boolean
+  preventDefault?: () => void
+}
+
 export function handleAndDispatchCustomEvent<
-  E extends CustomEvent,
-  OriginalEvent extends Event,
+  E extends VyCustomEvent,
+  OriginalEvent = any,
 >(
   name: string,
   handler: ((event: E) => void) | undefined,
-  detail: { originalEvent: OriginalEvent } & (E extends CustomEvent<infer D>
+  detail: { originalEvent: OriginalEvent } & (E extends VyCustomEvent<infer D>
     ? D
     : never),
 ) {
@@ -48,7 +60,7 @@ export function handleAndDispatchCustomEvent<
     detail,
   })
   if (handler)
-    target.addEventListener(name, handler as EventListener, { once: true })
+    target.addEventListener(name, handler as unknown as EventListener, { once: true })
 
   target.dispatchEvent(event)
 }

--- a/packages/core/src/shared/macro.ts
+++ b/packages/core/src/shared/macro.ts
@@ -1,11 +1,22 @@
-export function isCut(event: KeyboardEvent) {
+/**
+ * Minimal keyboard-event shape. Lynx native has no DOM `KeyboardEvent`; these
+ * helpers are web/PC-keyboard parity only, so they take just the fields they
+ * read. Avoids leaking DOM `KeyboardEvent` into the emitted `.d.ts`.
+ */
+interface KeyEventLike {
+  key: string
+  ctrlKey?: boolean
+  metaKey?: boolean
+}
+
+export function isCut(event: KeyEventLike) {
   return (event.key === 'x' || event.key === 'X') && (event.ctrlKey || event.metaKey)
 }
 
-export function isCopy(event: KeyboardEvent) {
+export function isCopy(event: KeyEventLike) {
   return (event.key === 'c' || event.key === 'C') && (event.ctrlKey || event.metaKey)
 }
 
-export function isPaste(event: KeyboardEvent) {
+export function isPaste(event: KeyEventLike) {
   return (event.key === 'v' || event.key === 'V') && (event.ctrlKey || event.metaKey)
 }

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -27,6 +27,18 @@ interface SingleOrMultipleProps<T = AcceptableValue | AcceptableValue[]> {
   defaultValue?: T
 }
 
+/**
+ * A painted element handle returned by ref forwarding. On Lynx native this is a
+ * `ShadowElement`-like handle; in web preview it's a DOM element. The two
+ * runtimes expose different APIs, so this is intentionally loose — call sites
+ * feature-detect (e.g. `typeof el.focus === 'function'`) before reaching for
+ * runtime-specific members.
+ *
+ * Used in place of bare `HTMLElement` / `Element`, which don't exist in Lynx's
+ * `lib` and would leak DOM types into consumers' emitted `.d.ts`.
+ */
+type ElementHandle = Record<string, any>
+
 // Exclude `boolean` type to prevent type casting
 // reference: https://vuejs.org/guide/components/props.html#boolean-casting
 type AcceptableValue = string | number | bigint | Record<string, any> | null
@@ -61,4 +73,4 @@ interface FormFieldProps {
  */
 type VyStyle = Exclude<NonNullable<IntrinsicElements['view']['style']>, string>
 
-export type { AcceptableValue, ArrayOrWrapped, DataOrientation, Direction, FormFieldProps, GenericComponentInstance, VyStyle, SingleOrMultipleProps, SingleOrMultipleType, StringOrNumber }
+export type { AcceptableValue, ArrayOrWrapped, DataOrientation, Direction, ElementHandle, FormFieldProps, GenericComponentInstance, VyStyle, SingleOrMultipleProps, SingleOrMultipleType, StringOrNumber }

--- a/packages/core/src/shared/useForwardExpose.ts
+++ b/packages/core/src/shared/useForwardExpose.ts
@@ -1,5 +1,6 @@
 import type { MaybeElement } from '@vueuse/core'
 import type { ComponentPublicInstance } from 'vue'
+import type { ElementHandle } from './types'
 // reference: https://github.com/vuejs/rfcs/issues/258#issuecomment-1068697672
 import { unrefElement } from '@vueuse/core'
 import { computed, getCurrentInstance, onUpdated, ref, triggerRef } from 'vue'
@@ -13,7 +14,7 @@ function isRawElement(ref: any): boolean {
 export function useForwardExpose<T extends ComponentPublicInstance>() {
   const instance = getCurrentInstance()!
 
-  const currentRef = ref<Element | T | null>()
+  const currentRef = ref<ElementHandle | T | null>()
   const currentElement = computed(() => resolveCurrentElement())
 
   // When using as-child with conditional rendering (v-if/v-else), the underlying
@@ -26,7 +27,7 @@ export function useForwardExpose<T extends ComponentPublicInstance>() {
   })
 
   function resolveCurrentElement() {
-    return unrefElement(currentRef as unknown as MaybeElement) as HTMLElement
+    return unrefElement(currentRef as unknown as MaybeElement) as ElementHandle
   }
 
   // Do give us credit if you reference our code :D
@@ -62,7 +63,7 @@ export function useForwardExpose<T extends ComponentPublicInstance>() {
   })
   instance.exposed = ret
 
-  function forwardRef(ref: Element | T | null) {
+  function forwardRef(ref: ElementHandle | T | null) {
     currentRef.value = ref
 
     if (!ref)

--- a/packages/core/src/shared/useForwardRef.ts
+++ b/packages/core/src/shared/useForwardRef.ts
@@ -1,10 +1,11 @@
 import type { ComponentPublicInstance } from 'vue'
+import type { ElementHandle } from './types'
 // reference: https://github.com/vuejs/rfcs/issues/258#issuecomment-1068697672
 import { getCurrentInstance } from 'vue'
 
 export function useForwardRef() {
   const instance = getCurrentInstance()!
-  function handleRefChange(ref: Element | ComponentPublicInstance | null) {
+  function handleRefChange(ref: ElementHandle | ComponentPublicInstance | null) {
     if (typeof ref === 'object') {
       instance.exposed = ref
       instance.exposeProxy = ref

--- a/packages/core/src/shared/useGraceArea.ts
+++ b/packages/core/src/shared/useGraceArea.ts
@@ -11,9 +11,10 @@
  * when web / mobile-browser support lands.
  */
 import type { Ref } from 'vue'
+import type { ElementHandle } from './types'
 import { ref } from 'vue'
 
-export function useGraceArea(_triggerElement: Ref<HTMLElement | undefined>, _containerElement: Ref<HTMLElement | undefined>) {
+export function useGraceArea(_triggerElement: Ref<ElementHandle | undefined>, _containerElement: Ref<ElementHandle | undefined>) {
   const isPointerInTransit = ref(false)
 
   function onPointerExit(_fn: () => void) {

--- a/packages/core/src/shared/useSelectionBehavior.ts
+++ b/packages/core/src/shared/useSelectionBehavior.ts
@@ -1,4 +1,5 @@
 import type { Ref, UnwrapNestedRefs } from 'vue'
+import type { ElementHandle } from './types'
 import { ref } from 'vue'
 import { findValuesBetween } from './arrays'
 
@@ -38,7 +39,7 @@ export function useSelectionBehavior<T>(
     return modelValue.value
   }
 
-  function handleMultipleReplace(intent: 'first' | 'last' | 'prev' | 'next', currentElement: HTMLElement | Element | null, getItems: () => { ref: HTMLElement, value?: any }[], options: any[]) {
+  function handleMultipleReplace(intent: 'first' | 'last' | 'prev' | 'next', currentElement: ElementHandle | null, getItems: () => { ref: ElementHandle, value?: any }[], options: any[]) {
     if (!firstValue?.value || !props.multiple || !Array.isArray(modelValue.value))
       return
 


### PR DESCRIPTION
Cloudflare Pages built with its default pnpm 10, which read `pnpm.overrides` from `package.json` and rejected the frozen install (`ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`) because the lockfile records no overrides block. pnpm 11 (CI/local) ignores that field, so the overrides were dead config.

- Pin `packageManager: pnpm@11.4.0` so Cloudflare, CI, and local all use pnpm 11
- Drop the inert `pnpm.overrides` + `onlyBuiltDependencies` from `package.json` (build approvals already live in `pnpm-workspace.yaml` `allowBuilds`)
- Remove redundant `version: 11` from workflows (packageManager is now the source of truth)
- Also includes the ElementHandle refactor (#10): swap DOM types for `ElementHandle` to stop leaking DOM types into emitted `.d.ts`

Verified locally: frozen install, `pnpm typecheck`, packages build, and `docs generate` all pass. Lockfile is unchanged vs main — forcing the Vue dedupe was deliberately avoided because it regressed core's vue-tsc build (`class: null` on `<view>`).