### PR TITLE
fix(docs): correct UPageCTA name, mark web event parity as roadmap

### DIFF
--- a/apps/docs/app/components/LandingCta.vue
+++ b/apps/docs/app/components/LandingCta.vue
@@ -17,7 +17,7 @@ const links = [
 </script>
 
 <template>
-  <UPageCta
+  <UPageCTA
     class="border-t border-default"
     title="Component docs are on the way"
     description="A per-component reference with props, slots, events, and live demos is the next thing being built. Until then, the source is the documentation."

--- a/apps/docs/app/components/LandingTargets.vue
+++ b/apps/docs/app/components/LandingTargets.vue
@@ -13,7 +13,7 @@ const features = [
   {
     icon: 'i-lucide-globe',
     title: 'Web',
-    description: 'Lynx Web target compiles to a browser bundle for previews and progressive rollouts.',
+    description: 'Lynx Web target compiles to a browser bundle. Full event parity with native (tap/hover vs click) is on the roadmap.',
   },
 ]
 </script>

--- a/apps/docs/content/4.roadmap.md
+++ b/apps/docs/content/4.roadmap.md
@@ -23,3 +23,4 @@ Expect breaking changes. Things will break. Don't ship this to production yet.
 - **Component documentation** — per-component reference, props, examples, demos — generated from real source so it stays in sync.
 - **Starter templates**.
 - **Cross-target testing (iOS / Android / Web)**.
+- **Web event parity** — normalise interaction events across targets so the same component handles native `tap`/long-press and web `click`/`hover` without per-target code.


### PR DESCRIPTION
Fixes the docs landing page and clarifies web target status.

- Rename `UPageCta` → `UPageCTA` (correct Nuxt UI v4 component name; resolves the failed-resolution warning)
- Web target card: note it compiles, with event parity (tap/hover vs click) called out as roadmap
- Add **Web event parity** item to the roadmap page