### PR TITLE
chore: package metadata, supply-chain hardening, gated publishing

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,7 @@
   "changelog": [
     "@svitejs/changesets-changelog-github-compact",
     {
-      "repo": "KealanAU/leka-ui"
+      "repo": "KealanAU/vyui"
     }
   ],
   "commit": false,
@@ -15,7 +15,8 @@
   "ignore": [
     "@vyui/native-demo",
     "@vyui/kit-demo",
-    "@vyui/phase5-debug",
+    "@vyui/linear-demo",
+    "@vyui/docs",
     "@vyui/testing-utils"
   ],
   "privatePackages": {

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  # Keep SHA-pinned GitHub Actions current. Dependabot bumps the pinned commit
+  # SHAs (and the trailing `# vX.Y.Z` comment) via PRs, so pinning never goes
+  # stale — you review and merge instead of trusting a mutable tag.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,9 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: 'pnpm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
+  # Manual-only: publishing never happens on a merge to main. Trigger from the
+  # Actions tab (Release -> Run workflow) when you explicitly want to ship.
+  workflow_dispatch:
 
 # Default to minimum permissions; raise per-job as needed.
 permissions: {}
@@ -17,7 +17,12 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: github.repository == 'KealanAU/leka-ui'
+    if: github.repository == 'KealanAU/vyui'
+    # Gate publishing behind a protected environment. Configure `npm-publish`
+    # under Settings -> Environments with required reviewers (admins only) and
+    # store NPM_TOKEN as an environment secret. The job pauses for approval
+    # before any publish step runs, and the token is unavailable otherwise.
+    environment: npm-publish
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: false
@@ -29,20 +34,25 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
+      # No `cache: 'pnpm'` here: the publish job runs with privileged secrets and
+      # must not consume a store cache that a lower-privilege job could poison.
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
-          cache: 'pnpm'
+
+      # OIDC trusted publishing needs npm >= 11.5.1; Node 22 ships npm 10.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm i -g npm@latest
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -50,8 +60,12 @@ jobs:
       - name: Build packages
         run: pnpm -r build
 
+      # Tokenless publish via npm OIDC Trusted Publishing — no NPM_TOKEN exists to
+      # be harvested or cached. `id-token: write` (above) mints a short-lived,
+      # per-run credential; npmjs.com must have a Trusted Publisher configured for
+      # each package pointing at this repo + workflow. See SECURITY notes / README.
       - name: Create Release PR or Publish
-        uses: changesets/action@v1
+        uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
         with:
           version: pnpm version-packages
           publish: pnpm release
@@ -59,4 +73,3 @@ jobs:
           commit: 'chore: release packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -8,9 +8,9 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: 'pnpm'

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,5 @@
 minimum-release-age=10080
 verify-deps-before-run=false
+# Never run pre/post lifecycle scripts of dependencies (postinstall et al.) —
+# the primary Shai-Hulud-style supply-chain infection vector.
+enable-pre-post-scripts=false

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,28 @@
   "version": "0.0.3",
   "description": "Lynx-native component primitives, ported from reka-ui",
   "license": "MIT AND Apache-2.0",
+  "author": "Kealan Clarke",
+  "homepage": "https://vyui.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/KealanAU/vyui.git",
+    "directory": "packages/core"
+  },
+  "bugs": {
+    "url": "https://github.com/KealanAU/vyui/issues"
+  },
+  "keywords": [
+    "vue",
+    "lynx",
+    "vue-lynx",
+    "headless",
+    "ui",
+    "components",
+    "primitives",
+    "accessibility",
+    "a11y",
+    "reka-ui"
+  ],
   "sideEffects": [
     "**/*.css",
     "**/*.vue.js",

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -4,6 +4,26 @@
   "version": "0.0.1",
   "description": "Styled Vue-Lynx components built on @vyui/core",
   "license": "MIT",
+  "author": "Kealan Clarke",
+  "homepage": "https://vyui.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/KealanAU/vyui.git",
+    "directory": "packages/kit"
+  },
+  "bugs": {
+    "url": "https://github.com/KealanAU/vyui/issues"
+  },
+  "keywords": [
+    "vue",
+    "lynx",
+    "vue-lynx",
+    "ui",
+    "components",
+    "design-system",
+    "tailwind",
+    "tailwind-variants"
+  ],
   "//sideEffects": "INVARIANT: no `'main thread'` worklets in @vyui/kit — all worklet logic lives in @vyui/core. If you add a worklet here, widen sideEffects to [\"src/**/*.vue\",\"src/**/*.ts\",\"dist/**/*.js\"] and wire pluginVyuiWorklet into rslib.config.ts like packages/core, or rspack will tree-shake the vue-lynx MT side-effect imports and downstream consumers will crash with `bind of undefined`.",
   "sideEffects": false,
   "files": [

--- a/packages/testing-utils/package.json
+++ b/packages/testing-utils/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@vyui/testing-utils",
   "type": "module",
+  "private": true,
   "version": "0.1.0",
   "description": "Shared test helpers for vyui — LynxTestingEnv setup + render utilities",
   "license": "MIT",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,10 +2,11 @@ packages:
   - 'packages/*'
   - 'apps/examples/*'
   - 'apps/docs'
-allowBuilds:
-  '@parcel/watcher': true
-  better-sqlite3: true
-  core-js: false
-  esbuild: true
-  sharp: true
-  vue-demi: false
+# Allowlist of dependencies permitted to run install/build (lifecycle) scripts.
+# Everything else is blocked by default (pnpm 10+), so a poisoned dependency
+# cannot auto-execute a postinstall to harvest secrets. Keep this list minimal.
+onlyBuiltDependencies:
+  - '@parcel/watcher'
+  - better-sqlite3
+  - esbuild
+  - sharp


### PR DESCRIPTION
Makes the packages auditable and locks down the release path. Also unblocks publishing (the release workflow could never fire before).

- core/kit: add `repository`, `homepage` (vyui.dev), `bugs`, `author`, `keywords` — npm now links back to source, docs, and issues
- mark `@vyui/testing-utils` private — it was unintentionally publishable (`ignore` only skips versioning, not publish)
- fix stale repo refs `leka-ui` -> `vyui` in changeset config and `release.yml` (the wrong gate is why releases never ran)
- drop non-existent `@vyui/phase5-debug` from changeset ignore (was failing changeset validation)
- `release.yml`: manual-only via `workflow_dispatch`, gated behind `npm-publish` environment, tokenless OIDC trusted publishing (no `NPM_TOKEN`), SHA-pinned actions, no store cache in the publish job
- pnpm: canonical `onlyBuiltDependencies` allowlist + `enable-pre-post-scripts=false` — blocks dependency lifecycle scripts (Shai-Hulud vector)
- add Dependabot for github-actions to keep SHA pins current

Already published from this branch: `@vyui/core@0.0.3`, `@vyui/kit@0.0.1`.

Follow-up (manual, off-repo): configure npm Trusted Publishers for both packages, create the `npm-publish` environment with required reviewers, delete the repo `NPM_TOKEN` secret.