### PR TITLE
docs(core,kit): fix stale and inaccurate code comments

### DIFF
--- a/packages/core/src/components/AlertDialog/AlertDialogContentImpl.vue
+++ b/packages/core/src/components/AlertDialog/AlertDialogContentImpl.vue
@@ -130,9 +130,10 @@ const handleTransitionCancel
     the fade-in / fade-out animation hooks so the dim layer animates in step
     with the panel.
 
-    Both views bind the full quintet of animation events
+    Both views bind the full set of animation / transition events
     (`@animationstart` / `@animationend` / `@animationcancel` /
-    `@transitionstart` / `@transitionend`) so whichever the consumer uses, the
+    `@transitionstart` / `@transitionend` / `@transitioncancel`) so whichever
+    the consumer uses, the
     Presence state machine sees a real signal. The 24-frame fallback inside
     `usePresence` covers the no-animation case.
   -->

--- a/packages/core/src/components/AlertDialog/AlertDialogOverlay.vue
+++ b/packages/core/src/components/AlertDialog/AlertDialogOverlay.vue
@@ -64,22 +64,18 @@ function render() {
   )
 }
 
-// Keep the painted node in sync when the consumer mutates `props` / `attrs`
-// while the overlay is mounted. We don't toggle the registration here — the
-// Registrant child below owns that — we just re-push the latest render fn
-// when something the painted node depends on changes.
+// Intentionally inert: the Registrant child below owns register / unregister.
+// The `render` closure is re-created on every render of this component, so the
+// next `registerOverlay` call from the Registrant already picks up the latest
+// props — there's nothing to re-push here. Kept as a watch so the dependency
+// list documents what the painted node tracks.
 watch(
   [
     () => ({ ...props }),
     () => ({ ...attrs }),
     () => rootContext.open.value,
   ],
-  () => {
-    // No-op: register on mount via Registrant covers the painted lifetime.
-    // (The `render` closure is re-created on every render of this component
-    // so the next `registerOverlay` call from the Registrant will already
-    // pick up the latest props.)
-  },
+  () => {},
 )
 
 onUnmounted(() => unregisterOverlay(id))

--- a/packages/core/src/components/Checkbox/CheckboxGroupRoot.vue
+++ b/packages/core/src/components/Checkbox/CheckboxGroupRoot.vue
@@ -10,7 +10,7 @@ import { useStandardVModel } from '@/shared/composables'
 export interface CheckboxGroupRootProps<T = AcceptableValue> extends PrimitiveProps, FormFieldProps {
   /** The value of the checkbox when it is initially rendered. Use when you do not need to control its value. */
   defaultValue?: T[]
-  /** The controlled value of the checkbox. Can be binded with v-model. */
+  /** The controlled value of the checkbox. Can be bound with v-model. */
   modelValue?: T[]
   /** When `true`, prevents the user from interacting with the checkboxes */
   disabled?: boolean

--- a/packages/core/src/components/Checkbox/CheckboxRoot.vue
+++ b/packages/core/src/components/Checkbox/CheckboxRoot.vue
@@ -9,7 +9,7 @@ import { injectCheckboxGroupRootContext } from './CheckboxGroupRoot.vue'
 export interface CheckboxRootProps<T = boolean> extends PrimitiveProps, FormFieldProps {
   /** The value of the checkbox when it is initially rendered. Use when you do not need to control its value. */
   defaultValue?: T | 'indeterminate'
-  /** The controlled value of the checkbox. Can be binded with v-model. */
+  /** The controlled value of the checkbox. Can be bound with v-model. */
   modelValue?: T | 'indeterminate' | null
   /** When `true`, prevents the user from interacting with the checkbox */
   disabled?: boolean

--- a/packages/core/src/components/Collapsible/CollapsibleRoot.vue
+++ b/packages/core/src/components/Collapsible/CollapsibleRoot.vue
@@ -7,7 +7,7 @@ import { createContext, useForwardExpose } from '@/shared'
 export interface CollapsibleRootProps extends PrimitiveProps {
   /** The open state of the collapsible when it is initially rendered. <br> Use when you do not need to control its open state. */
   defaultOpen?: boolean
-  /** The controlled open state of the collapsible. Can be binded with `v-model`. */
+  /** The controlled open state of the collapsible. Can be bound with `v-model`. */
   open?: boolean
   /** When `true`, prevents the user from interacting with the collapsible. */
   disabled?: boolean

--- a/packages/core/src/components/Dialog/DialogRoot.vue
+++ b/packages/core/src/components/Dialog/DialogRoot.vue
@@ -4,7 +4,7 @@ import { createContext } from '@/shared'
 import { PresenceState } from '@/components/Presence'
 
 export interface DialogRootProps {
-  /** The controlled open state of the dialog. Can be binded as `v-model:open`. */
+  /** The controlled open state of the dialog. Can be bound as `v-model:open`. */
   open?: boolean
   /** The open state of the dialog when it is initially rendered. Use when you do not need to control its open state. */
   defaultOpen?: boolean

--- a/packages/core/src/components/Draggable/Draggable.vue
+++ b/packages/core/src/components/Draggable/Draggable.vue
@@ -68,7 +68,7 @@ export type DraggableEmits = {
 </script>
 
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref, watch } from 'vue'
+import { onUnmounted, ref, watch } from 'vue'
 import { runOnBackground, runOnMainThread, useMainThreadRef } from 'vue-lynx'
 
 const props = withDefaults(defineProps<DraggableProps>(), {
@@ -310,10 +310,6 @@ function _emitEnd(x: number, y: number, dx: number, dy: number, vx: number, vy: 
 }
 
 // --- Lifecycle -----------------------------------------------------------
-
-onMounted(() => {
-  // Origin = (0,0); no initial transform needed.
-})
 
 onUnmounted(() => {
   xQueueRef.current = []

--- a/packages/core/src/components/DropdownMenu/DropdownMenuItemIndicator.vue
+++ b/packages/core/src/components/DropdownMenu/DropdownMenuItemIndicator.vue
@@ -14,7 +14,6 @@ withDefaults(defineProps<DropdownMenuItemIndicatorProps>(), {
   as: 'view',
 })
 
-// Attempt to resolve from checkbox or radio context
 const checkboxContext = injectDropdownMenuCheckboxItemContext(null)
 const radioContext = injectDropdownMenuRadioItemContext(null)
 

--- a/packages/core/src/components/DropdownMenu/DropdownMenuRoot.vue
+++ b/packages/core/src/components/DropdownMenu/DropdownMenuRoot.vue
@@ -6,11 +6,11 @@ import { createContext } from '@/shared'
 export interface DropdownMenuRootProps {
   /** The open state of the dropdown menu when it is initially rendered. */
   defaultOpen?: boolean
-  /** The controlled open state of the dropdown menu. Can be binded with `v-model:open`. */
+  /** The controlled open state of the dropdown menu. Can be bound with `v-model:open`. */
   open?: boolean
   /** When `true`, interaction with outside elements will be disabled and only menu content will be visible to screen readers. */
   modal?: boolean
-  /** The reading direction of the combobox when applicable. */
+  /** The reading direction of the dropdown menu when applicable. */
   dir?: Direction
 }
 

--- a/packages/core/src/components/DropdownMenu/DropdownMenuSubContent.vue
+++ b/packages/core/src/components/DropdownMenu/DropdownMenuSubContent.vue
@@ -34,9 +34,8 @@ const emitAsProps = useEmitAsProps(emit)
 // inject DropdownMenuSubContext — DropdownMenuSub is an ancestor of this tree.
 const capturedProvides = captureProvides()
 
-// BUG FIX: the old SubContent used `<Teleport to="#overlay-root">`, but Lynx
-// has no DOM and no element with that id, so sub-menus never rendered. It now
-// registers with the same `overlayStore` portal as DropdownMenuContent.
+// Lynx has no DOM and no `#overlay-root` element to `<Teleport>` into, so
+// register with the same `overlayStore` portal as DropdownMenuContent.
 const PortalRegistration = defineComponent({
   name: 'DropdownMenuSubContentPortal',
   setup() {

--- a/packages/core/src/components/LazyComponent/index.ts
+++ b/packages/core/src/components/LazyComponent/index.ts
@@ -1,5 +1,4 @@
-// vyui original component — not part of reka-ui. Ported from
-// `lynx-family/lynx-ui` `lynx-ui-lazy-component` (Apache 2.0).
+// Ported from `lynx-family/lynx-ui` `lynx-ui-lazy-component` (Apache 2.0).
 export {
   default as LazyComponent,
   type LazyComponentProps,

--- a/packages/core/src/components/Navigation/NavigationPage.vue
+++ b/packages/core/src/components/Navigation/NavigationPage.vue
@@ -27,11 +27,10 @@ const ctx = injectNavigationStackContext()
 const isCurrent = computed(() => ctx.currentKey.value === props.pageKey)
 
 /**
- * Slide direction class — picks an enter / leave animation keyed by the
- * stack's last navigation direction. Lynx's preset ships the named
- * keyframes `slide-in` / `slide-out` (used by Sheet / Toast); we reuse them
- * here. Forward push: new page slides in from the right. Back pop: page
- * slides out to the right.
+ * Slide-in animation class for the current page. Lynx's preset ships the
+ * named `slide-in` keyframe (used by Sheet / Toast) which we reuse here.
+ * Both forward push and back pop currently apply the same slide-in enter
+ * animation; there is no distinct leave/back animation yet.
  *
  * Animations are CSS — no MT worklet — so the page is rendered absolute and
  * the layout engine handles the transform. For more native-feeling physics

--- a/packages/core/src/components/Pagination/PaginationRoot.vue
+++ b/packages/core/src/components/Pagination/PaginationRoot.vue
@@ -13,7 +13,7 @@ type PaginationRootContext = {
 }
 
 export interface PaginationRootProps extends PrimitiveProps {
-  /** The controlled value of the current page. Can be binded as `v-model:page`. */
+  /** The controlled value of the current page. Can be bound as `v-model:page`. */
   page?: number
   /**
    * The value of the page that should be active when initially rendered.

--- a/packages/core/src/components/Primitive/Primitive.ts
+++ b/packages/core/src/components/Primitive/Primitive.ts
@@ -21,7 +21,7 @@ export interface PrimitiveProps {
   asChild?: boolean
   /**
    * The element or component this component should render as. Can be overwritten by `asChild`.
-   * @defaultValue "div"
+   * @defaultValue "view"
    */
   as?: AsTag | Component
 }

--- a/packages/core/src/components/Progress/ProgressRoot.vue
+++ b/packages/core/src/components/Progress/ProgressRoot.vue
@@ -106,7 +106,7 @@ const max = useVModel(props, 'max', emit, {
   passive: (props.max === undefined) as false,
 })
 
-// ------- Watch for correct values -------
+// Clamp model value and max to their valid ranges.
 watch(
   () => modelValue.value,
   async (value) => {
@@ -128,7 +128,6 @@ watch(
   },
   { immediate: true },
 )
-// ------- End of watch for correct values -------
 
 const progressState = computed<ProgressState>(() => {
   if (isNullish(modelValue.value))

--- a/packages/core/src/components/RadioGroup/RadioGroupRoot.vue
+++ b/packages/core/src/components/RadioGroup/RadioGroupRoot.vue
@@ -5,7 +5,7 @@ import type { AcceptableValue, DataOrientation, Direction, FormFieldProps } from
 import { createContext, useDirection, useForwardExpose } from '@/shared'
 
 export interface RadioGroupRootProps extends PrimitiveProps, FormFieldProps {
-  /** The controlled value of the radio item to check. Can be binded as `v-model`. */
+  /** The controlled value of the radio item to check. Can be bound as `v-model`. */
   modelValue?: AcceptableValue
   /**
    * The value of the radio item that should be checked when initially rendered.
@@ -17,7 +17,7 @@ export interface RadioGroupRootProps extends PrimitiveProps, FormFieldProps {
   disabled?: boolean
   /** The orientation of the component. */
   orientation?: DataOrientation
-  /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
+  /** The reading direction of the radio group when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
   dir?: Direction
   /** When `true`, keyboard navigation will loop from last item to first, and vice versa. */
   loop?: boolean

--- a/packages/core/src/components/Select/SelectItem.vue
+++ b/packages/core/src/components/Select/SelectItem.vue
@@ -27,10 +27,6 @@ import { Primitive } from '@/components/Primitive'
 import { useA11y } from '@/shared/composables'
 import { injectSelectRootContext } from './SelectRoot.vue'
 
-if (__DEV__) {
-  // value must not be empty string
-}
-
 const props = withDefaults(defineProps<SelectItemProps>(), {
   as: 'view',
   disabled: false,

--- a/packages/core/src/components/Sheet/SheetContent.vue
+++ b/packages/core/src/components/Sheet/SheetContent.vue
@@ -1,21 +1,16 @@
 <!-- Copyright 2026 The Lynx Authors. All rights reserved.
      Licensed under the Apache License Version 2.0.
 
-     Strategy: pure-CSS slide through the `vyui-sheet-slide-in` /
-     `vyui-sheet-slide-out` keyframes (defined in SheetContentImpl's
-     `<style>` block). The Presence state machine sets `ui-entering` /
-     `ui-leaving` on the panel `<view>`; `@animationend` (BG-thread event)
-     advances Presence into the `Entered` / `Left` terminal states so the
-     panel unmounts only after the slide-out finishes.
-
-     This deliberately ships open/close-only (no drag / snap / fling). A
-     prior MT-rAF based implementation hit a vue-lynx@0.4.0 upstream bug
-     around `useMainThreadRef` / `runOnMainThread` ordering — see the
-     comment block in SheetContentImpl. Once upstream lands the fix,
-     interactivity can be layered back on. -->
+     Presence wrapper around `SheetContentImpl`. Open / close are driven by
+     the `vyui-sheet-slide-in/out` keyframes; the Presence state machine sets
+     `ui-entering` / `ui-leaving` on the panel `<view>` and `@animationend`
+     (BG-thread event) advances Presence into the `Entered` / `Left` terminal
+     states so the panel unmounts only after the slide-out finishes. Drag /
+     snap / fling are implemented in SheetContentImpl via MT touch worklets;
+     pass `dragDisabled` to opt out. -->
 <script lang="ts">
 export interface SheetContentProps {
-  /** Disable dragging. Retained for API parity — no-op in the CSS variant. */
+  /** Disable drag / snap / fling; open and close still animate. */
   dragDisabled?: boolean
 }
 </script>

--- a/packages/core/src/components/Slider/SliderRoot.vue
+++ b/packages/core/src/components/Slider/SliderRoot.vue
@@ -35,7 +35,7 @@ export interface SliderRootProps extends PrimitiveProps, FormFieldProps {
   disabled?: boolean
   /** The orientation of the slider. */
   orientation?: DataOrientation
-  /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
+  /** The reading direction of the slider when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
   dir?: Direction
   /** Whether the slider is visually inverted. */
   inverted?: boolean

--- a/packages/core/src/components/Slider/SliderThumbImpl.vue
+++ b/packages/core/src/components/Slider/SliderThumbImpl.vue
@@ -127,10 +127,9 @@ onUnmounted(() => {
         position: 'absolute',
         [orientation!.startEdge.value]: `calc(${percent}% + ${thumbInBoundsOffset}px)`,
         /**
-         * There will be no value on initial render while we work out the index so we hide thumbs
-         * without a value, otherwise SSR will render them in the wrong position before they
-         * snap into the correct position during hydration which would be visually jarring for
-         * slower connections.
+         * There is no value on the initial render while we resolve the thumb's
+         * index, so hide value-less thumbs to avoid a flash at the wrong
+         * position before they snap into place once the index is known.
          */
         display: !isMounted && value === undefined ? 'none' : undefined,
       }"

--- a/packages/core/src/components/Stepper/StepperRoot.vue
+++ b/packages/core/src/components/Stepper/StepperRoot.vue
@@ -28,7 +28,7 @@ export interface StepperRootProps extends PrimitiveProps {
    */
   orientation?: DataOrientation
   /**
-   * The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode.
+   * The reading direction of the stepper when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode.
    */
   dir?: Direction
   /** The controlled value of the step to activate. Can be bound as `v-model`. */

--- a/packages/core/src/components/Tabs/TabsIndicator.vue
+++ b/packages/core/src/components/Tabs/TabsIndicator.vue
@@ -101,7 +101,7 @@ watch(
 
 // Lynx native ignores `var()` references that point at custom properties set
 // via inline `:style` — see the canonical write-up in
-// `core/src/components/Slider/SliderThumbImpl.vue` (~L45). Keep size +
+// `core/src/components/Slider/SliderThumbImpl.vue`. Keep size +
 // transform as concrete pixel values so the indicator actually paints.
 const indicatorInlineStyle = computed(() => {
   const { size, position } = indicatorStyle.value

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -15,7 +15,7 @@ interface SingleOrMultipleProps<T = AcceptableValue | AcceptableValue[]> {
   /**
    * The controlled value of the active item(s).
    *
-   * Use this when you need to control the state of the items. Can be binded with `v-model`
+   * Use this when you need to control the state of the items. Can be bound with `v-model`
    */
   modelValue?: T
 

--- a/packages/kit/src/components/Button.vue
+++ b/packages/kit/src/components/Button.vue
@@ -37,7 +37,11 @@ export interface ButtonProps {
    * core button renders a `<view>`, so this is currently a no-op forward.
    */
   type?: 'button' | 'submit' | 'reset'
-  /** Focus the underlying button on mount. */
+  /**
+   * Focus the button on mount. Kept for API parity with Nuxt UI v4 — the
+   * Vue-Lynx core button renders a non-focusable `<view>`, so this is
+   * currently a no-op.
+   */
   autofocus?: boolean
   /** Text label. Overridden by the default slot if provided. */
   label?: string

--- a/packages/kit/src/components/Slider.vue
+++ b/packages/kit/src/components/Slider.vue
@@ -64,9 +64,8 @@ defineSlots<SliderSlots>()
 
 const appConfig = useAppConfig()
 
-// `SliderRoot` now accepts both shapes natively and emits in whichever shape
-// the consumer is binding with, so no normalization needed here — just
-// forward through.
+// `SliderRoot` accepts both shapes natively and emits in whichever shape the
+// consumer binds with, so forward through without normalizing.
 const thumbsCount = computed(() => {
   const src = props.modelValue ?? props.defaultValue
   if (typeof src === 'number') return 1

--- a/packages/kit/src/components/internal/DropdownMenuItems.vue
+++ b/packages/kit/src/components/internal/DropdownMenuItems.vue
@@ -1,9 +1,8 @@
 <script lang="ts">
 /**
- * Internal — renders the items list for `VyDropdownMenu`. Extracted so both
- * presentation modes (anchor + sheet) mount the same items without
- * duplicating the v-for. Per-item slots are forwarded from the parent via
- * `useSlots()` and indexed by the item's `slot` field.
+ * Internal — renders the items list for `VyDropdownMenu`. Per-item slots are
+ * forwarded from the parent via `useSlots()` and indexed by the item's `slot`
+ * field.
  *
  * Not exported from the package — its only consumer is `DropdownMenu.vue`.
  */

--- a/packages/kit/src/composables/useComponentIcons.ts
+++ b/packages/kit/src/composables/useComponentIcons.ts
@@ -2,8 +2,8 @@ import { computed, toValue, type MaybeRefOrGetter } from 'vue'
 import { useAppConfig } from './useAppConfig'
 
 // Ported from nuxt/ui v3.0.2 `src/runtime/composables/useComponentIcons.ts`.
-// The `avatar` prop is typed as `unknown` here — VyAvatar is not yet built;
-// when it lands this type tightens to `AvatarProps`.
+// The `avatar` prop is left loosely typed as `unknown` here to avoid a hard
+// dependency on `Avatar`'s props.
 
 export interface UseComponentIconsProps {
   /**

--- a/packages/kit/src/plugin.ts
+++ b/packages/kit/src/plugin.ts
@@ -27,7 +27,8 @@ const defaultConfig: AppConfig = {
  *
  * `install()`:
  *  1. Deep-merges user `ui` options over the package defaults.
- *  2. Builds a per-app `tailwind-variants` factory bound to `ui.tv`.
+ *  2. Builds a per-app `tailwind-variants` factory from `ui.tv` and stashes
+ *     it under `ui.__tv`.
  *  3. Provides the merged config under `APP_CONFIG_KEY`.
  *  4. Imperatively registers every component in `REGISTRY` so SFCs can use
  *     `<VyIcon />` etc. without local imports (replaces nuxt/ui's
@@ -37,8 +38,8 @@ export const VyUI: Plugin<VyUIPluginOptions> = {
   install(app: App, options: VyUIPluginOptions = {}) {
     const merged = defu({ ui: options.ui ?? {} }, defaultConfig) as AppConfig
 
-    // tv factory bound to user overrides — stashed under a non-enumerable-ish
-    // private key so component themes can grab it via `useAppConfig`.
+    // tv factory bound to user overrides — stashed under the private `__tv`
+    // key so component themes can grab it via `useAppConfig`.
     ;(merged.ui as Record<string, unknown>).__tv = createTv(merged.ui.tv)
 
     app.provide(APP_CONFIG_KEY, merged)


### PR DESCRIPTION
Audits component comments across `core` and `kit` and fixes the ones that were inaccurate, stale, or dead.

- Correct copy-paste "combobox" `dir`-prop docs on DropdownMenu / RadioGroup / Stepper / Slider roots
- Fix "binded" → "bound" typos across core props
- Rewrite Sheet / Navigation / SliderThumb comments that described removed or unimplemented behavior
- Drop dead/no-op blocks (SelectItem `__DEV__`, Draggable `onMounted`) and section-banner noise
- Reword changelog-style and stale-rationale comments in core and kit
- Clarify kit `Button` `autofocus` is a Nuxt UI parity no-op (core renders a non-focusable `<view>`)