### PR TITLE
docs: rolling core/kit changelog timeline + roadmap refresh

### DIFF
--- a/apps/docs/app/pages/changelog.vue
+++ b/apps/docs/app/pages/changelog.vue
@@ -1,120 +1,133 @@
 <script setup lang="ts">
-const appConfig = useAppConfig()
+const { data: entries } = await useAsyncData('changelog', () =>
+  queryCollection('changelog').order('date', 'DESC').all(),
+)
 
-interface UnghRelease {
-  name?: string
-  tag: string
-  publishedAt: string
-  markdown: string
+const dateFormatter = new Intl.DateTimeFormat('en-US', {
+  day: 'numeric',
+  month: 'short',
+  year: 'numeric',
+})
+
+function formatDate(date: string) {
+  // Parse as UTC so the displayed day doesn't drift across timezones.
+  return dateFormatter.format(new Date(`${date}T00:00:00Z`))
 }
-
-// Post-alpha gate: once we ship 0.1.0 the 0.0.x pre-alpha releases stop being
-// relevant. Uncomment MIN_VERSION + the `.filter` below to only show the
-// changelog from 0.1.0 onward.
-// const MIN_VERSION = [0, 1, 0]
-// function gteMinVersion(version: string) {
-//   const parts = version.split('.').map(n => Number.parseInt(n, 10) || 0)
-//   for (let i = 0; i < MIN_VERSION.length; i++) {
-//     if ((parts[i] ?? 0) > MIN_VERSION[i]) return true
-//     if ((parts[i] ?? 0) < MIN_VERSION[i]) return false
-//   }
-//   return true
-// }
-
-const PACKAGES = [
-  { key: 'core', label: '@vyui/core', prefix: '@vyui/core@' },
-  { key: 'kit', label: '@vyui/kit', prefix: '@vyui/kit@' },
-] as const
-
-const { data: releases } = await useFetch(
-  computed(() => `https://ungh.cc/repos/${appConfig.repository}/releases`),
-  {
-    transform: (data: { releases: UnghRelease[] }) => data.releases,
-  },
-)
-
-const columns = computed(() =>
-  PACKAGES.map(pkg => ({
-    ...pkg,
-    versions: (releases.value ?? [])
-      .filter(release => release.tag.startsWith(pkg.prefix))
-      // .filter(release => gteMinVersion(release.tag.slice(pkg.prefix.length)))
-      .map(release => ({
-        tag: release.tag,
-        title: release.tag.slice(pkg.prefix.length),
-        date: release.publishedAt,
-        markdown: release.markdown,
-      })),
-  })),
-)
 
 useSeoMeta({
   title: 'Changelog',
-  description: 'Release notes for Vy UI — @vyui/core and @vyui/kit.',
+  description: 'Release notes for Vy UI — @vyui/core and @vyui/kit, side by side as the project evolves.',
 })
 </script>
 
 <template>
   <UContainer>
     <div class="py-12 sm:py-16">
-      <div class="mb-12 max-w-2xl">
+      <div class="mx-auto mb-12 max-w-2xl text-center">
         <h1 class="text-highlighted text-4xl font-semibold tracking-tight sm:text-5xl">
           Changelog
         </h1>
         <p class="text-muted mt-3 text-base sm:text-lg">
-          Release notes for <code class="text-highlighted">@vyui/core</code> and <code class="text-highlighted">@vyui/kit</code>, pulled directly from GitHub releases.
+          What's shipping across <code class="text-highlighted">@vyui/core</code> and
+          <code class="text-highlighted">@vyui/kit</code> — one rolling timeline, newest first.
         </p>
       </div>
 
-      <div class="grid grid-cols-1 gap-10 lg:grid-cols-2 lg:gap-12">
-        <section
-          v-for="column in columns"
-          :key="column.key"
-        >
-          <h2 class="text-highlighted mb-6 font-mono text-lg font-semibold">
-            {{ column.label }}
-          </h2>
+      <UAlert
+        v-if="!entries?.length"
+        icon="i-lucide-flask-conical"
+        color="warning"
+        variant="subtle"
+        title="No entries yet"
+        description="Vy UI is pre-alpha. This page fills in as core and kit evolve."
+      />
 
-          <UAlert
-            v-if="!column.versions.length"
-            icon="i-lucide-flask-conical"
-            color="warning"
-            variant="subtle"
-            title="No releases yet"
-            :description="`No ${column.label} releases have been cut yet.`"
-          />
+      <template v-else>
+        <!-- Rail headers (desktop only) -->
+        <div class="text-muted mb-6 hidden grid-cols-[1fr_auto_1fr] items-center gap-x-12 text-sm font-medium md:grid">
+          <div class="flex items-center justify-end gap-2">
+            <UIcon
+              name="i-lucide-box"
+              class="text-primary size-4"
+            />
+            <code class="text-highlighted">@vyui/core</code>
+          </div>
+          <div class="size-3" />
+          <div class="flex items-center gap-2">
+            <UIcon
+              name="i-lucide-palette"
+              class="text-info size-4"
+            />
+            <code class="text-highlighted">@vyui/kit</code>
+          </div>
+        </div>
 
-          <UChangelogVersions
-            v-else
-            :indicator-motion="false"
-            :ui="{
-              root: 'pb-8',
-              indicator: 'inset-y-0',
-            }"
-          >
-            <UChangelogVersion
-              v-for="version in column.versions"
-              :key="version.tag"
-              v-bind="version"
-              :ui="{
-                root: 'flex items-start',
-                container: 'max-w-2xl min-w-0',
-                header: 'border-b border-default pb-4',
-                title: 'text-3xl',
-                date: 'text-xs/9 text-highlighted font-mono',
-                indicator: 'sticky top-16 pt-8 -mt-8',
-              }"
+        <div class="relative">
+          <!-- Center spine -->
+          <div class="bg-border absolute inset-y-0 left-[7px] w-px md:left-1/2 md:-translate-x-1/2" />
+
+          <ul class="space-y-10">
+            <li
+              v-for="entry in entries"
+              :key="entry.path"
+              class="relative md:grid md:grid-cols-2 md:gap-x-12"
             >
-              <template #body>
-                <MDC
-                  v-if="version.markdown"
-                  :value="version.markdown"
-                />
-              </template>
-            </UChangelogVersion>
-          </UChangelogVersions>
-        </section>
-      </div>
+              <!-- Node on the spine -->
+              <span
+                class="ring-bg absolute top-2 left-[7px] z-10 size-3.5 -translate-x-1/2 rounded-full ring-4 md:left-1/2"
+                :class="entry.package === 'core' ? 'bg-primary' : 'bg-info'"
+              />
+
+              <div
+                :class="[
+                  'pl-8 md:pl-0',
+                  entry.package === 'core'
+                    ? 'md:col-start-1 md:pr-2 md:text-right'
+                    : 'md:col-start-2 md:pl-2',
+                ]"
+              >
+                <UCard
+                  variant="subtle"
+                  :ui="{ body: 'sm:p-5' }"
+                >
+                  <div
+                    class="flex items-center gap-2"
+                    :class="entry.package === 'core' && 'md:flex-row-reverse'"
+                  >
+                    <UBadge
+                      :color="entry.package === 'core' ? 'primary' : 'info'"
+                      variant="subtle"
+                      size="sm"
+                    >
+                      @vyui/{{ entry.package }}
+                    </UBadge>
+                    <UBadge
+                      color="neutral"
+                      variant="outline"
+                      size="sm"
+                      class="font-mono"
+                    >
+                      {{ entry.version }}
+                    </UBadge>
+                  </div>
+
+                  <time class="text-dimmed mt-3 block font-mono text-xs">
+                    {{ formatDate(entry.date) }}
+                  </time>
+
+                  <h2 class="text-highlighted mt-1 text-lg font-semibold">
+                    {{ entry.title }}
+                  </h2>
+
+                  <div class="text-muted mt-2 text-sm [&_a]:text-primary [&_code]:text-highlighted">
+                    <ContentRenderer :value="entry" />
+                  </div>
+                </UCard>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </template>
     </div>
   </UContainer>
 </template>

--- a/apps/docs/content.config.ts
+++ b/apps/docs/content.config.ts
@@ -10,7 +10,7 @@ export default defineContentConfig({
       type: 'page',
       source: {
         include: '**',
-        exclude: ['index.md'],
+        exclude: ['index.md', 'changelog/**'],
       },
       schema: z.object({
         links: z.array(z.object({
@@ -19,6 +19,18 @@ export default defineContentConfig({
           to: z.string(),
           target: z.string().optional(),
         })).optional(),
+      }),
+    }),
+    changelog: defineCollection({
+      type: 'page',
+      source: 'changelog/**',
+      schema: z.object({
+        // 'core' renders on the left rail, 'kit' on the right.
+        package: z.enum(['core', 'kit']),
+        // ISO date (YYYY-MM-DD) — drives the interleaved timeline order.
+        date: z.string(),
+        // Release badge label, e.g. 'v0.0.3', 'Workspace'.
+        version: z.string(),
       }),
     }),
   },

--- a/apps/docs/content/6.roadmap.md
+++ b/apps/docs/content/6.roadmap.md
@@ -5,21 +5,27 @@ navigation:
   icon: i-lucide-map
 ---
 
-Vy UI is pre-alpha. The list below is aspirational — none of it ships yet. It shows where the project is headed.
+Vy UI is pre-alpha. Most of the list below is aspirational — it shows where the project is headed. For what has actually landed, see the [Changelog](/changelog).
 
 ::callout{icon="i-lucide-flask-conical" color="warning"}
 Expect breaking changes. Things will break. Don't ship this to production yet.
 ::
 
+## Recently shipped
+
+- **Swiper primitive** — headless swipe gestures with momentum, rubber-banding, and snapping, on a shared gesture engine.
+- **Core primitives** — Accordion, Rating, and Toggle, published to npm as `@vyui/core`.
+- **Styled `@vyui/kit` components** — Button, Switch, and Tabs composed on core primitives, published to npm as `@vyui/kit`.
+- **`llms.txt`** — generated from the docs so assistants stay in sync.
+
 ## In progress
 
-- **`@vyui/core` primitives** — published as `^0.0.2` with a known MT-loader regression awaiting an upstream fix.
+- **`@vyui/core` primitives** — published as `^0.0.3` with a known MT-loader regression awaiting an upstream fix.
 
 ## Planned
 
-- **`@vyui/kit` on npm** — styled-component package, currently workspace-only.
-- **`@vyui/cli`** _(post-alpha)_ — shadcn-style CLI for adding individual styled components — `npx @vyui add button`.
-- **Hosted registry** _(post-alpha)_ — `vyui.dev/registry/*` JSON manifests with source, dependencies, file destinations. Backs the CLI; both land after 0.1.0.
+- **`@vyui/cli`** — shadcn-style CLI for adding individual styled components — `npx @vyui add button`.
+- **Hosted registry** — `vyui.dev/registry/*` JSON manifests with source, dependencies, file destinations.
 - **Component documentation** — per-component reference, props, examples, demos — generated from real source so it stays in sync.
 - **Starter templates**.
 - **Cross-target testing (iOS / Android / Web)**.

--- a/apps/docs/content/changelog/core-0.0.1.md
+++ b/apps/docs/content/changelog/core-0.0.1.md
@@ -1,0 +1,9 @@
+---
+title: First release
+description: The first headless, accessible primitives land on npm — behaviour only, bring your own styles.
+date: 2026-05-28
+package: core
+version: v0.0.1
+---
+
+`@vyui/core` publishes its first primitives: behavioural, accessible building blocks that run natively on Lynx and on the web from a single Vue codebase. Zero styling — compose them yourself or reach for `@vyui/kit`.

--- a/apps/docs/content/changelog/core-0.0.2.md
+++ b/apps/docs/content/changelog/core-0.0.2.md
@@ -1,0 +1,9 @@
+---
+title: Performance & packaging
+description: Faster icon resolution and a leaner, hardened package ahead of wider testing.
+date: 2026-05-29
+package: core
+version: v0.0.2
+---
+
+Icon resolution is memoized across instances to cut repeated work, with dependency pruning and packaging hardening to keep `@vyui/core` lean and safe to install.

--- a/apps/docs/content/changelog/core-0.0.3.md
+++ b/apps/docs/content/changelog/core-0.0.3.md
@@ -1,0 +1,9 @@
+---
+title: Lynx-native a11y & shared gestures
+description: Accessibility now resolves through Lynx-native APIs, and gesture physics moves into one shared engine.
+date: 2026-05-30
+package: core
+version: v0.0.3
+---
+
+Accessibility is wired through Lynx-native APIs instead of DOM assumptions, and the Swiper's gesture physics is extracted into a shared engine behind `useDragGesture` with a generic `pickSnap` helper — ready to power any swipe-driven primitive.

--- a/apps/docs/content/changelog/kit-scaffold.md
+++ b/apps/docs/content/changelog/kit-scaffold.md
@@ -1,0 +1,9 @@
+---
+title: Kit scaffolded
+description: The styled-component package joins the monorepo alongside core and the docs site.
+date: 2026-05-28
+package: kit
+version: Initial
+---
+
+`@vyui/kit` is scaffolded as part of the monorepo, sitting alongside `@vyui/core` and the documentation site — the home for opinionated, themed components.

--- a/apps/docs/content/changelog/kit-styled.md
+++ b/apps/docs/content/changelog/kit-styled.md
@@ -1,0 +1,9 @@
+---
+title: Styled Button, Switch & Tabs
+description: The first styled components land on npm — composed on core primitives, themed and ready to drop in.
+date: 2026-05-30
+package: kit
+version: v0.0.1
+---
+
+`@vyui/kit` publishes its first styled components — **Button**, **Switch**, and **Tabs** — composed on top of `@vyui/core` primitives. Available now on npm as `@vyui/kit@0.0.1`.


### PR DESCRIPTION
Rebuilds the Changelog into a rolling, two-sided timeline (core left, kit right) like the Nuxt changelog template, and refreshes the roadmap.

- Changelog is now a center-spine timeline: `@vyui/core` on the left rail, `@vyui/kit` on the right, interleaved newest-first by date.
- Collapses to a single labelled column on mobile.
- Entries are markdown content files under `content/changelog/` via a new `changelog` collection — add a release by dropping in a file with `package`/`date`/`version` frontmatter.
- Seeded with real versions: core `v0.0.1`/`v0.0.2`/`v0.0.3` and kit `v0.0.1` (both on npm).
- Roadmap: added a "Recently shipped" section and a Changelog link; dropped the stale "kit is workspace-only" item.

Docs-only — no package changes.
