### PR TITLE
feat(core): land useDragGesture + local vue-lynx worklet-loader patch

### DIFF
--- a/docs/upstream/vue-lynx-mt-worklet-import-issue.md
+++ b/docs/upstream/vue-lynx-mt-worklet-import-issue.md
@@ -1,0 +1,69 @@
+# `worklet-loader-mt`: non-relative imports silently dropped from MT module graph, breaking aliased/package worklets at runtime
+
+## Summary
+
+`extractLocalImports` in `plugin/dist/loaders/worklet-loader-mt.js` builds the main-thread (MT) module graph by re-emitting a processed module's imports as side-effect imports — but it filters specifiers with a regex that requires them to start with `.`. Any import using a path alias (`@/…`, `~/…`, tsconfig `paths`) or a bare package specifier (`@scope/pkg`) is silently excluded. The result is a `'main thread'` worklet that exists in the background bundle but whose `registerWorkletInternal(…)` call is never emitted into the MT bundle; at runtime, `_workletMap[id].bind(this)` throws `TypeError: cannot read property 'bind' of undefined`.
+
+---
+
+## Loader behavior / root cause
+
+- The culprit is `extractLocalImports(source)` in `plugin/dist/loaders/worklet-loader-mt.js`.
+- It matches import specifiers using exactly two regexes:
+  - `const fromRe = /from\s+['"](\.[^'"]+)['"]/g;`
+  - `const bareRe = /import\s+['"](\.[^'"]+)['"]/g;`
+- The capture group `(\.[^'"]+)` requires the first character of the specifier to be a literal `.`, so only relative paths (`./foo`, `../bar`) match.
+- Path-aliased imports (`@/gesture`, `~/utils`, `#components/…`) and bare package specifiers (`@vyui/core`, `vue-lynx`) are never captured and never re-emitted into the MT module.
+- When the MT loader processes a `.vue` SFC or a `.ts` file that *is* reached via a non-relative import, it produces an MT module whose import list is empty — the aliased dependency is simply absent from the MT graph.
+- Because the dependency is never listed, `registerWorkletInternal("main-thread", "<id>", …)` for worklets defined in that dependency is never written into the MT bundle.
+- At runtime, `_workletMap[id].bind(this)` (in `@lynx-js/react/worklet-runtime/dist/main.js`) throws `TypeError: cannot read property 'bind' of undefined` on the first interaction that triggers the worklet.
+
+---
+
+## Why `sideEffects` / tree-shaking can't fix it
+
+- This is **not** a tree-shaking or `package.json#sideEffects` problem; those mechanisms operate at the bundler stage and cannot fix it.
+- The filtering happens at the **loader stage**, when the MT module's import list is generated — one stage before bundling and dead-code elimination run.
+- Because the aliased/bare import is never written into the MT module source at all, rspack/webpack's tree-shaking has nothing in the MT graph to evaluate: the import statement doesn't exist to be kept or dropped.
+- Therefore, no combination of `sideEffects: false`, `/*#__PURE__*/` annotations, or bundler DCE settings can rescue the registration — the code path is excluded earlier, at import extraction.
+
+---
+
+## Reproduction
+
+- Define a `'main thread'` worklet in a module `gesture.ts` (a touch handler that mutates a `useMainThreadRef` and updates a transform style via `runOnMainThread`).
+- Import it into an SFC using a **path alias** configured in tsconfig `paths` (e.g. `import { useGesture } from '@/gesture'`) and bind it with `:main-thread-bindtouchstart`.
+- Build and run on device → tap triggers `TypeError: cannot read property 'bind' of undefined`.
+- Change **only** the import specifier to a relative path (`import { useGesture } from './gesture'`) — no other code changes — and rebuild → worklet registers and runs correctly.
+- Static confirmation (bundle inspection):
+  - With alias: the built `main.web.bundle` contains `_workletMap["main-thread/<id>"]` references with no matching `registerWorkletInternal("main-thread","<id>",…)` call (unresolved count > 0).
+  - With relative: the same ids appear in the registered set (unresolved count → 0).
+- The diagnostic is unambiguous: only the specifier *form* changes; everything else is identical.
+
+---
+
+## Impact
+
+- **Breaks aliased imports (near-universal pattern):** Any shared composable or module that defines `'main thread'` worklets and is consumed via `@/`/tsconfig path aliases — the standard project convention — silently fails at runtime with a confusing low-level error that is far from the root cause.
+- **Blocks published component libraries entirely:** A package consumed via a bare specifier (e.g. `@vyui/core`) cannot ship MT worklets to consumers, because the consumer's MT loader skips all imports into that package. There is no viable workaround for real consumers; a relative side-effect import pointing into `node_modules` is not a publishable solution.
+
+---
+
+## Proposed fix
+
+**Tier 1 — aliases (internal projects):**
+- Replace the `^\.` regex check with resolution via the bundler's own resolver (webpack/rspack `this.resolve`) or by consulting the configured aliases and tsconfig `paths` directly.
+- A minimal variant: also re-emit specifiers matching `@/…` / `~/…` alias patterns — the downstream bundler already knows how to resolve them, so just not filtering them out is enough.
+- Note: calling `this.resolve` requires switching the loader to async (`this.async()`), but that is the correct approach for specifier resolution.
+
+**Tier 2 — dependencies (published packages):**
+- Extend the MT import traversal to follow resolved imports into worklet-bearing packages, or introduce an opt-in loader option (e.g. `includeWorkletPackages: ['@vyui/core']`) combined with a recognisable registration entry-point that the loader can use to pull in the package's MT worklet registrations for a consumer's build.
+
+---
+
+## Environment
+
+- `vue-lynx` 0.4.0
+- `@lynx-js/rspeedy` 0.13.6
+- `@lynx-js/react` 0.116.5 (provides `worklet-runtime` and `@lynx-js/react/transform`)
+- `@lynx-js/types` 3.8.0

--- a/packages/core/src/components/Swiper/SwiperRoot.vue
+++ b/packages/core/src/components/Swiper/SwiperRoot.vue
@@ -23,10 +23,10 @@ export type SwiperRootEmits = {
 </script>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, watch } from 'vue'
-import { runOnBackground, runOnMainThread, useMainThreadRef } from 'vue-lynx'
+import { computed } from 'vue'
 
 import { useStandardVModel } from '@/shared/composables'
+import { useDragGesture } from '@/shared/gesture/useDragGesture'
 
 import { provideSwiperRootContext } from './swiperContext'
 
@@ -44,220 +44,18 @@ const currentIndex = useStandardVModel<number>(props, emits, 0)
 const itemWidth = computed(() => props.itemWidth)
 const itemCount = computed(() => props.itemCount)
 
-// --- MT refs ---------------------------------------------------------------
-const containerRef = useMainThreadRef<any>(null)
-
-const offsetRef = useMainThreadRef<number>(-(currentIndex.value ?? 0) * props.itemWidth)
-const touchStartXRef = useMainThreadRef<number>(0)
-const touchStartOffsetRef = useMainThreadRef<number>(0)
-const isDraggingRef = useMainThreadRef<boolean>(false)
-const internalCommitRef = useMainThreadRef<boolean>(false)
-
-const itemWidthRef = useMainThreadRef<number>(props.itemWidth)
-const itemCountRef = useMainThreadRef<number>(props.itemCount)
-const durationRef = useMainThreadRef<number>(props.duration)
-const thresholdRef = useMainThreadRef<number>(props.threshold)
-const velocityThresholdRef = useMainThreadRef<number>(props.velocityThreshold)
-const disabledRef = useMainThreadRef<boolean>(props.disabled)
-
-const posQueueRef = useMainThreadRef<number[]>([])
-const timeQueueRef = useMainThreadRef<number[]>([])
-
-// Animation generation counter — a worklet checks its starting generation
-// against the current one each frame and bails if a newer animation began.
-// This replaces storing a cancel arrow fn in a ref (which kills the
-// `_workletMap` lookup for `animCancelRef.current()`).
-const animGenRef = useMainThreadRef<number>(0)
-
-// --- BG → MT sync ----------------------------------------------------------
-watch(() => props.itemWidth, (v) => { itemWidthRef.current = v })
-watch(() => props.itemCount, (v) => { itemCountRef.current = v })
-watch(() => props.duration, (v) => { durationRef.current = v })
-watch(() => props.threshold, (v) => { thresholdRef.current = v })
-watch(() => props.velocityThreshold, (v) => { velocityThresholdRef.current = v })
-watch(() => props.disabled, (v) => { disabledRef.current = v })
-
-watch(currentIndex, (next, prev) => {
-  if (next === prev) return
-  runOnMainThread(_jumpAndAnimate as any)(next)
-})
-
-// --- Worklets (all inline; no cross-file calls, no stored worklets) -------
-
-function _setTransform(offset: number) {
-  'main thread'
-  const el = containerRef as unknown as {
-    current?: { setStyleProperty?(k: string, v: string): void }
-  }
-  if (el.current?.setStyleProperty) {
-    el.current.setStyleProperty('transform', `translateX(${offset}px)`)
-  }
-}
-
-function _animateTo(to: number) {
-  'main thread'
-  animGenRef.current = animGenRef.current + 1
-  const gen = animGenRef.current
-  const from = offsetRef.current
-  const ms = durationRef.current
-  if (ms <= 0 || from === to) {
-    offsetRef.current = to
-    _setTransform(to)
-    return
-  }
-  let startTs = 0
-  // Plain nested function — runs inside the outer worklet's closure, no
-  // own `_wkltId`. Mirrors lynx-ui's `useAnimate` pattern (no directive
-  // on inner functions; only the outer scope is the worklet).
-  function step(ts: number) {
-    if (gen !== animGenRef.current) return
-    if (!startTs) startTs = Number(ts)
-    let elapsed = Number(ts) - startTs
-    if (elapsed < 0) elapsed = 0
-    let progress = elapsed / ms
-    if (progress > 1) progress = 1
-    const eased = 1 - (1 - progress) * (1 - progress) * (1 - progress)
-    const value = from + (to - from) * eased
-    offsetRef.current = value
-    const el = containerRef as unknown as {
-      current?: { setStyleProperty?(k: string, v: string): void }
-    }
-    if (el.current?.setStyleProperty) {
-      el.current.setStyleProperty('transform', `translateX(${value}px)`)
-    }
-    if (progress < 1) requestAnimationFrame(step)
-  }
-  requestAnimationFrame(step)
-}
-
-function _jumpAndAnimate(targetIndex: number) {
-  'main thread'
-  if (isDraggingRef.current) return
-  if (internalCommitRef.current) {
-    internalCommitRef.current = false
-    return
-  }
-  const target = -targetIndex * itemWidthRef.current
-  _animateTo(target)
-}
-
-function _pruneQueue(ms: number, minLen: number) {
-  'main thread'
-  const tq = timeQueueRef.current
-  const pq = posQueueRef.current
-  const now = Date.now()
-  while (tq.length > minLen && tq[0] < now - ms) {
-    tq.shift()
-    pq.shift()
-  }
-}
-
-function _onTouchStart(e: { detail: { x: number } }) {
-  'main thread'
-  if (disabledRef.current) return
-  // Cancel any in-flight animation by bumping the generation.
-  animGenRef.current = animGenRef.current + 1
-  isDraggingRef.current = true
-  const x = e.detail.x
-  touchStartXRef.current = x
-  touchStartOffsetRef.current = offsetRef.current
-  timeQueueRef.current = [Date.now()]
-  posQueueRef.current = [x]
-  runOnBackground(_emitSwipeStart as any)()
-}
-
-function _onTouchMove(e: { detail: { x: number } }) {
-  'main thread'
-  if (!isDraggingRef.current) return
-  const x = e.detail.x
-  const delta = x - touchStartXRef.current
-  const width = itemWidthRef.current
-  const count = itemCountRef.current
-  let next = touchStartOffsetRef.current + delta
-  const minOffset = -(count - 1) * width
-  if (next > 0) next = 0
-  if (next < minOffset) next = minOffset
-  offsetRef.current = next
-  _setTransform(next)
-  posQueueRef.current.push(x)
-  timeQueueRef.current.push(Date.now())
-  _pruneQueue(50, 2)
-}
-
-function _onTouchEnd() {
-  'main thread'
-  if (!isDraggingRef.current) return
-  isDraggingRef.current = false
-
-  // Inline velocity (px/s).
-  _pruneQueue(500, 0)
-  const tq = timeQueueRef.current
-  const pq = posQueueRef.current
-  let velocity = 0
-  if (tq.length >= 2) {
-    const dt = (tq[tq.length - 1] - tq[0]) / 1000
-    if (dt > 0) velocity = (pq[pq.length - 1] - pq[0]) / dt
-  }
-
-  const startOffset = touchStartOffsetRef.current
-  const endOffset = offsetRef.current
-  const width = itemWidthRef.current
-  const count = itemCountRef.current
-  const threshold = thresholdRef.current
-  const vThreshold = velocityThresholdRef.current
-
-  // Inline customRound + paging.
-  let target: number
-  const ratio = -endOffset / width
-  const decimal = ratio - Math.floor(ratio)
-  if (decimal >= threshold) target = Math.ceil(ratio)
-  else target = Math.floor(ratio)
-
-  // Velocity flick overrides — advance/retreat one step from start index.
-  if (velocity < 0 ? -velocity >= vThreshold : velocity >= vThreshold) {
-    const startIdx = Math.round(-startOffset / width)
-    target = startIdx + (velocity < 0 ? 1 : -1)
-  }
-
-  if (target < 0) target = 0
-  if (target > count - 1) target = count - 1
-
-  const targetOffset = -target * width
-  internalCommitRef.current = true
-  _animateTo(targetOffset)
-  runOnBackground(_settle as any)(target)
-}
-
-// --- BG callbacks ---------------------------------------------------------
-
-function _emitSwipeStart() {
-  emits('swipeStart')
-}
-
-function _settle(target: number) {
-  if (target !== currentIndex.value) currentIndex.value = target
-  emits('swipeEnd', target)
-}
-
-// --- Public API -----------------------------------------------------------
-
-function setIndex(index: number) {
-  let next = index
-  if (next < 0) next = 0
-  if (next > props.itemCount - 1) next = props.itemCount - 1
-  currentIndex.value = next
-}
-
-// --- Lifecycle ------------------------------------------------------------
-
-onMounted(() => {
-  runOnMainThread(_setTransform as any)(offsetRef.current)
-})
-
-onUnmounted(() => {
-  animGenRef.current = animGenRef.current + 1
-  posQueueRef.current = []
-  timeQueueRef.current = []
+// All drag plumbing (MT refs, velocity, snap animation, MT↔BG hops) lives in
+// the shared controller; this component just wires its config + the track.
+const { containerRef, onTouchStart, onTouchMove, onTouchEnd, setIndex } = useDragGesture({
+  currentIndex,
+  itemWidth: () => props.itemWidth,
+  itemCount: () => props.itemCount,
+  duration: () => props.duration,
+  threshold: () => props.threshold,
+  velocityThreshold: () => props.velocityThreshold,
+  disabled: () => props.disabled,
+  onSwipeStart: () => emits('swipeStart'),
+  onSwipeEnd: index => emits('swipeEnd', index),
 })
 
 defineExpose({ setIndex })
@@ -275,10 +73,10 @@ provideSwiperRootContext({
     <view
       class="vyui-swiper__track"
       :main-thread-ref="containerRef"
-      :main-thread-bindtouchstart="_onTouchStart"
-      :main-thread-bindtouchmove="_onTouchMove"
-      :main-thread-bindtouchend="_onTouchEnd"
-      :main-thread-bindtouchcancel="_onTouchEnd"
+      :main-thread-bindtouchstart="onTouchStart"
+      :main-thread-bindtouchmove="onTouchMove"
+      :main-thread-bindtouchend="onTouchEnd"
+      :main-thread-bindtouchcancel="onTouchEnd"
       :style="{ display: 'flex', flexDirection: 'row' }"
     >
       <slot />

--- a/packages/core/src/shared/gesture/useDragGesture.ts
+++ b/packages/core/src/shared/gesture/useDragGesture.ts
@@ -1,0 +1,287 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0.
+//
+// Shared horizontal drag-gesture controller for paged surfaces (Swiper today;
+// Sheet/drawer next — see #37). Owns the MT refs, the prop→MT-ref sync, the
+// velocity queue, the rAF snap animation, and the MT↔BG hops, so a component
+// only supplies config + settle callbacks.
+//
+// Worklet constraints, learned the hard way in `SwiperRoot.vue`:
+//   - `'main thread'` bodies are INLINE and SELF-CONTAINED. They do NOT call
+//     worklets in another file (cross-file worklet calls don't resolve), so
+//     the math here MIRRORS `./physics.ts` (the unit-tested spec) rather than
+//     importing it. Keep the two in sync.
+//   - Worklets are never stored in a ref and invoked (`ref.current()` kills the
+//     `_workletMap` lookup). The animation uses an integer generation counter
+//     to cancel instead.
+//   - Inner helpers nested inside a worklet carry NO directive — they run in
+//     the outer worklet's closure. Only the top-level handlers are worklets.
+//
+// DEVICE-VERIFY (can't run under vitest — see #6): whether a worklet defined
+// in this `.ts` and bound to `:main-thread-bind*` in a consuming `.vue`
+// template registers correctly. This mirrors Sheet's proven `.vue`→`.vue`
+// cross-file worklet binding (`SheetContentImpl` → `SheetHandle`), with the
+// source module being a `.ts` instead of an SFC.
+
+import type { Ref } from 'vue'
+import { onMounted, onUnmounted, watch } from 'vue'
+import { runOnBackground, runOnMainThread, useMainThreadRef } from 'vue-lynx'
+
+export interface DragGestureConfig {
+  /** Controlled index (v-model). The controller animates to it on change and
+   *  writes the settled index back to it. */
+  currentIndex: Ref<number>
+  /** Width of one item (incl. spacing), px. */
+  itemWidth: () => number
+  /** Total item count. */
+  itemCount: () => number
+  /** Snap animation duration, ms. */
+  duration: () => number
+  /** Fraction of `itemWidth` dragged past which the snap rounds up. */
+  threshold: () => number
+  /** px/s flick above which a release advances by one item. */
+  velocityThreshold: () => number
+  /** When true, touch input is ignored. */
+  disabled: () => boolean
+  /** Fired (on BG) when a drag begins. */
+  onSwipeStart: () => void
+  /** Fired (on BG) with the settled index when a drag ends. */
+  onSwipeEnd: (index: number) => void
+}
+
+export interface DragGesture {
+  /** Bind to the draggable track's `:main-thread-ref`. */
+  containerRef: ReturnType<typeof useMainThreadRef<any>>
+  onTouchStart: (e: { detail: { x: number } }) => void
+  onTouchMove: (e: { detail: { x: number } }) => void
+  onTouchEnd: () => void
+  /** Clamp + commit an index programmatically (BG side). */
+  setIndex: (index: number) => void
+}
+
+export function useDragGesture(config: DragGestureConfig): DragGesture {
+  const { currentIndex } = config
+
+  // --- MT refs -------------------------------------------------------------
+  const containerRef = useMainThreadRef<any>(null)
+
+  const offsetRef = useMainThreadRef<number>(-(currentIndex.value ?? 0) * config.itemWidth())
+  const touchStartXRef = useMainThreadRef<number>(0)
+  const touchStartOffsetRef = useMainThreadRef<number>(0)
+  const isDraggingRef = useMainThreadRef<boolean>(false)
+  const internalCommitRef = useMainThreadRef<boolean>(false)
+
+  const itemWidthRef = useMainThreadRef<number>(config.itemWidth())
+  const itemCountRef = useMainThreadRef<number>(config.itemCount())
+  const durationRef = useMainThreadRef<number>(config.duration())
+  const thresholdRef = useMainThreadRef<number>(config.threshold())
+  const velocityThresholdRef = useMainThreadRef<number>(config.velocityThreshold())
+  const disabledRef = useMainThreadRef<boolean>(config.disabled())
+
+  const posQueueRef = useMainThreadRef<number[]>([])
+  const timeQueueRef = useMainThreadRef<number[]>([])
+
+  // Animation generation counter — a worklet checks its starting generation
+  // against the current one each frame and bails if a newer animation began.
+  const animGenRef = useMainThreadRef<number>(0)
+
+  // --- BG → MT sync --------------------------------------------------------
+  watch(config.itemWidth, (v) => { itemWidthRef.current = v })
+  watch(config.itemCount, (v) => { itemCountRef.current = v })
+  watch(config.duration, (v) => { durationRef.current = v })
+  watch(config.threshold, (v) => { thresholdRef.current = v })
+  watch(config.velocityThreshold, (v) => { velocityThresholdRef.current = v })
+  watch(config.disabled, (v) => { disabledRef.current = v })
+
+  watch(currentIndex, (next, prev) => {
+    if (next === prev) return
+    runOnMainThread(_jumpAndAnimate as any)(next)
+  })
+
+  // --- Worklets (all inline; no cross-file calls, no stored worklets) ------
+
+  function _setTransform(offset: number) {
+    'main thread'
+    const el = containerRef as unknown as {
+      current?: { setStyleProperty?(k: string, v: string): void }
+    }
+    if (el.current?.setStyleProperty) {
+      el.current.setStyleProperty('transform', `translateX(${offset}px)`)
+    }
+  }
+
+  function _animateTo(to: number) {
+    'main thread'
+    animGenRef.current = animGenRef.current + 1
+    const gen = animGenRef.current
+    const from = offsetRef.current
+    const ms = durationRef.current
+    if (ms <= 0 || from === to) {
+      offsetRef.current = to
+      _setTransform(to)
+      return
+    }
+    let startTs = 0
+    // Plain nested function — runs inside the outer worklet's closure, no own
+    // `_wkltId`. `eased` mirrors physics.ts `easeOutCubic`.
+    function step(ts: number) {
+      if (gen !== animGenRef.current) return
+      if (!startTs) startTs = Number(ts)
+      let elapsed = Number(ts) - startTs
+      if (elapsed < 0) elapsed = 0
+      let progress = elapsed / ms
+      if (progress > 1) progress = 1
+      const eased = 1 - (1 - progress) * (1 - progress) * (1 - progress)
+      const value = from + (to - from) * eased
+      offsetRef.current = value
+      const el = containerRef as unknown as {
+        current?: { setStyleProperty?(k: string, v: string): void }
+      }
+      if (el.current?.setStyleProperty) {
+        el.current.setStyleProperty('transform', `translateX(${value}px)`)
+      }
+      if (progress < 1) requestAnimationFrame(step)
+    }
+    requestAnimationFrame(step)
+  }
+
+  function _jumpAndAnimate(targetIndex: number) {
+    'main thread'
+    if (isDraggingRef.current) return
+    if (internalCommitRef.current) {
+      internalCommitRef.current = false
+      return
+    }
+    const target = -targetIndex * itemWidthRef.current
+    _animateTo(target)
+  }
+
+  function _pruneQueue(ms: number, minLen: number) {
+    'main thread'
+    const tq = timeQueueRef.current
+    const pq = posQueueRef.current
+    const now = Date.now()
+    while (tq.length > minLen && tq[0] < now - ms) {
+      tq.shift()
+      pq.shift()
+    }
+  }
+
+  function _onTouchStart(e: { detail: { x: number } }) {
+    'main thread'
+    if (disabledRef.current) return
+    // Cancel any in-flight animation by bumping the generation.
+    animGenRef.current = animGenRef.current + 1
+    isDraggingRef.current = true
+    const x = e.detail.x
+    touchStartXRef.current = x
+    touchStartOffsetRef.current = offsetRef.current
+    timeQueueRef.current = [Date.now()]
+    posQueueRef.current = [x]
+    runOnBackground(_emitSwipeStart as any)()
+  }
+
+  function _onTouchMove(e: { detail: { x: number } }) {
+    'main thread'
+    if (!isDraggingRef.current) return
+    const x = e.detail.x
+    const delta = x - touchStartXRef.current
+    const width = itemWidthRef.current
+    const count = itemCountRef.current
+    let next = touchStartOffsetRef.current + delta
+    const minOffset = -(count - 1) * width
+    if (next > 0) next = 0
+    if (next < minOffset) next = minOffset
+    offsetRef.current = next
+    _setTransform(next)
+    posQueueRef.current.push(x)
+    timeQueueRef.current.push(Date.now())
+    _pruneQueue(50, 2)
+  }
+
+  function _onTouchEnd() {
+    'main thread'
+    if (!isDraggingRef.current) return
+    isDraggingRef.current = false
+
+    // Inline velocity (px/s) — mirrors physics.ts `calcVelocity`.
+    _pruneQueue(500, 0)
+    const tq = timeQueueRef.current
+    const pq = posQueueRef.current
+    let velocity = 0
+    if (tq.length >= 2) {
+      const dt = (tq[tq.length - 1] - tq[0]) / 1000
+      if (dt > 0) velocity = (pq[pq.length - 1] - pq[0]) / dt
+    }
+
+    const startOffset = touchStartOffsetRef.current
+    const endOffset = offsetRef.current
+    const width = itemWidthRef.current
+    const count = itemCountRef.current
+    const threshold = thresholdRef.current
+    const vThreshold = velocityThresholdRef.current
+
+    // Inline customRound + paging — mirrors physics.ts `customRound`/`calcPaging`.
+    let target: number
+    const ratio = -endOffset / width
+    const decimal = ratio - Math.floor(ratio)
+    if (decimal >= threshold) target = Math.ceil(ratio)
+    else target = Math.floor(ratio)
+
+    // Velocity flick overrides — advance/retreat one step from start index.
+    // (Carousel paging policy: flick steps from where the user grabbed, not
+    // from the nearest candidate — see physics.ts `decideSnapTarget`.)
+    if (velocity < 0 ? -velocity >= vThreshold : velocity >= vThreshold) {
+      const startIdx = Math.round(-startOffset / width)
+      target = startIdx + (velocity < 0 ? 1 : -1)
+    }
+
+    if (target < 0) target = 0
+    if (target > count - 1) target = count - 1
+
+    const targetOffset = -target * width
+    internalCommitRef.current = true
+    _animateTo(targetOffset)
+    runOnBackground(_settle as any)(target)
+  }
+
+  // --- BG callbacks --------------------------------------------------------
+
+  function _emitSwipeStart() {
+    config.onSwipeStart()
+  }
+
+  function _settle(target: number) {
+    if (target !== currentIndex.value) currentIndex.value = target
+    config.onSwipeEnd(target)
+  }
+
+  // --- Public API ----------------------------------------------------------
+
+  function setIndex(index: number) {
+    let next = index
+    if (next < 0) next = 0
+    if (next > config.itemCount() - 1) next = config.itemCount() - 1
+    currentIndex.value = next
+  }
+
+  // --- Lifecycle -----------------------------------------------------------
+
+  onMounted(() => {
+    runOnMainThread(_setTransform as any)(offsetRef.current)
+  })
+
+  onUnmounted(() => {
+    animGenRef.current = animGenRef.current + 1
+    posQueueRef.current = []
+    timeQueueRef.current = []
+  })
+
+  return {
+    containerRef,
+    onTouchStart: _onTouchStart,
+    onTouchMove: _onTouchMove,
+    onTouchEnd: _onTouchEnd,
+    setIndex,
+  }
+}

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,66 @@
+# Local dependency patches
+
+pnpm-native patches applied via `pnpm.patchedDependencies` (declared in the root
+`pnpm-workspace.yaml`, since pnpm 11 reads that key from the workspace file).
+
+## `vue-lynx@0.4.0.patch` — follow `@/…` alias imports in the MT worklet loader
+
+**Status:** Tier-1 stopgap. Remove when the upstream fix lands.
+
+**Upstream issue:** `docs/upstream/vue-lynx-mt-worklet-import-issue.md`
+
+### What it does
+
+`vue-lynx`'s main-thread worklet loader (`plugin/dist/loaders/worklet-loader-mt.js`,
+`extractLocalImports(source)`) re-emits a module's imports into the main-thread
+graph but matched **only relative** specifiers:
+
+```js
+const fromRe = /from\s+['"](\.[^'"]+)['"]/g;
+const bareRe = /import\s+['"](\.[^'"]+)['"]/g;
+```
+
+So worklets imported through an `@/…` path alias were never re-emitted into the
+MT graph and never registered (runtime `TypeError: cannot read property 'bind'
+of undefined`). The patch broadens **both** regexes to also follow `@/…` (and
+nothing else — broadening to all bare specifiers would pull npm deps into the MT
+graph):
+
+```js
+const fromRe = /from\s+['"]((?:\.|@\/)[^'"]+)['"]/g;
+const bareRe = /import\s+['"]((?:\.|@\/)[^'"]+)['"]/g;
+```
+
+The re-emitted `import '@/…';` is resolved by the project's existing `@` alias,
+so the module enters the MT graph and its `registerWorkletInternal` calls land.
+
+The patched file also carries a `[vyui local patch — REMOVE WHEN UPSTREAM FIXED]`
+banner comment at the top, so the change is self-documenting in the diff.
+
+### Verifying it works
+
+1. Ensure a worklet composable is imported via the alias, e.g. in
+   `packages/core/src/components/Swiper/SwiperRoot.vue`:
+   `import { useDragGesture } from '@/shared/gesture/useDragGesture'`
+2. `pnpm --filter @vyui/kit-demo build`
+3. Audit the MT bundle for referenced-but-unregistered worklets, from
+   `apps/examples/ui-demo/dist`:
+   ```sh
+   node -e '
+   const s=require("fs").readFileSync("main.web.bundle","utf8");
+   const g=re=>[...s.matchAll(re)].map(m=>m[1]);
+   const reg=new Set(g(/registerWorkletInternal\(\\"main-thread\\",\\"([0-9a-f:]+)\\"/g));
+   const refs=new Set([...g(/_wkltId:\\"([0-9a-f:]+)\\"/g),...g(/_workletMap\[\\"([0-9a-f:]+)\\"\]/g)]);
+   const un=[...refs].filter(id=>!reg.has(id));
+   console.log("registered:",reg.size,"referenced:",refs.size,"UNRESOLVED:",un.length,un.slice(0,20));
+   '
+   ```
+   PASS = `UNRESOLVED: 0`. Without the patch this build reports 7 unresolved
+   (the gesture worklets); with the patch + alias import it is 0.
+
+### Undo (when upstream is fixed)
+
+1. Delete `patches/vue-lynx@0.4.0.patch`.
+2. Remove the `vue-lynx@0.4.0` entry under `patchedDependencies:` in the root
+   `pnpm-workspace.yaml`.
+3. `pnpm install`.

--- a/patches/vue-lynx@0.4.0.patch
+++ b/patches/vue-lynx@0.4.0.patch
@@ -1,0 +1,29 @@
+diff --git a/plugin/dist/loaders/worklet-loader-mt.js b/plugin/dist/loaders/worklet-loader-mt.js
+index 2201679cff292214a49d6db18cc00627f31431a6..049a6456f82a9c0c1b39006528926a1ea8b6454f 100644
+--- a/plugin/dist/loaders/worklet-loader-mt.js
++++ b/plugin/dist/loaders/worklet-loader-mt.js
+@@ -1,7 +1,14 @@
++// [vyui local patch — REMOVE WHEN UPSTREAM FIXED]
++// vue-lynx's MT worklet loader only followed relative imports, so '@/…'
++// alias-imported worklets never registered on MT (TypeError: cannot read
++// property 'bind' of undefined). This widens extractLocalImports to also
++// follow '@/…'. Track: docs/upstream/vue-lynx-mt-worklet-import-issue.md.
++// To undo: delete patches/vue-lynx@0.4.0.patch + its pnpm.patchedDependencies
++// entry in the root package.json, then `pnpm install`.
+ import * as __WEBPACK_EXTERNAL_MODULE__lynx_js_react_transform_7b1e07c1__ from "@lynx-js/react/transform";
+ function extractLocalImports(source) {
+     const specifiers = new Set();
+-    const fromRe = /from\s+['"](\.[^'"]+)['"]/g;
++    const fromRe = /from\s+['"]((?:\.|@\/)[^'"]+)['"]/g;
+     let match;
+     while(null !== (match = fromRe.exec(source))){
+         const lineStart = source.lastIndexOf('\n', match.index) + 1;
+@@ -10,7 +17,7 @@ function extractLocalImports(source) {
+         if (/with\s*\{/.test(line)) continue;
+         specifiers.add(match[1]);
+     }
+-    const bareRe = /import\s+['"](\.[^'"]+)['"]/g;
++    const bareRe = /import\s+['"]((?:\.|@\/)[^'"]+)['"]/g;
+     while(null !== (match = bareRe.exec(source)))specifiers.add(match[1]);
+     if (0 === specifiers.size) return '';
+     return [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  vue-lynx@0.4.0: 69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993
+
 importers:
 
   .:
@@ -74,7 +77,7 @@ importers:
         version: link:../../../packages/kit
       vue-lynx:
         specifier: ^0.4.0
-        version: 0.4.0(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.14))
+        version: 0.4.0(patch_hash=69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.14))
     devDependencies:
       '@iconify-json/icon-park-outline':
         specifier: ^1.2.0
@@ -123,11 +126,11 @@ importers:
         version: link:../../../packages/core
       vue-lynx:
         specifier: ^0.4.0
-        version: 0.4.0(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.14))
+        version: 0.4.0(patch_hash=69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2)
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.6(@rspack/core@1.7.11(@swc/helpers@0.5.21))(typescript@5.9.3)(webpack@5.106.2(postcss@8.5.14))
+        version: 0.13.6(@rspack/core@1.7.11(@swc/helpers@0.5.21))(typescript@5.9.3)(webpack@5.106.2)
       '@lynx-js/types':
         specifier: ^3.8.0
         version: 3.8.0
@@ -151,7 +154,7 @@ importers:
         version: link:../../../packages/kit
       vue-lynx:
         specifier: ^0.4.0
-        version: 0.4.0(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.14))
+        version: 0.4.0(patch_hash=69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.14))
     devDependencies:
       '@iconify-json/icon-park-outline':
         specifier: ^1.2.0
@@ -285,7 +288,7 @@ importers:
         version: 3.3.1
       vue-lynx:
         specifier: ^0.4.0
-        version: 0.4.0(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)(lightningcss@1.32.0))
+        version: 0.4.0(patch_hash=69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)(lightningcss@1.32.0))
       vue-tsc:
         specifier: 3.2.6
         version: 3.2.6(typescript@5.9.3)
@@ -328,7 +331,7 @@ importers:
         version: 3.5.17(typescript@5.9.3)
       vue-lynx:
         specifier: ^0.4.0
-        version: 0.4.0(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.14))
+        version: 0.4.0(patch_hash=69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2)
       vue-tsc:
         specifier: 3.2.6
         version: 3.2.6(typescript@5.9.3)
@@ -355,7 +358,7 @@ importers:
         version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.4)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)
       vue-lynx:
         specifier: ^0.4.0
-        version: 0.4.0(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(lightningcss@1.32.0))
+        version: 0.4.0(patch_hash=69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(lightningcss@1.32.0))
     devDependencies:
       '@types/jsdom':
         specifier: ^28.0.3
@@ -9241,6 +9244,13 @@ snapshots:
     transitivePeerDependencies:
       - webpack
 
+  '@lynx-js/css-extract-webpack-plugin@0.7.1(@lynx-js/template-webpack-plugin@0.10.9(tslib@2.8.1))(webpack@5.106.2)':
+    dependencies:
+      '@lynx-js/template-webpack-plugin': 0.10.9(tslib@2.8.1)
+      mini-css-extract-plugin: 2.10.2(webpack@5.106.2)
+    transitivePeerDependencies:
+      - webpack
+
   '@lynx-js/css-serializer@0.1.5':
     dependencies:
       css-tree: 3.2.1
@@ -9262,6 +9272,32 @@ snapshots:
       '@rsbuild/core': 1.7.3
       '@rsbuild/plugin-css-minimizer': 1.1.1(@rsbuild/core@1.7.3)(webpack@5.106.2(postcss@8.5.14))
       '@rsdoctor/rspack-plugin': 1.2.3(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2(postcss@8.5.14))
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/css'
+      - bufferutil
+      - clean-css
+      - csso
+      - debug
+      - esbuild
+      - lightningcss
+      - supports-color
+      - utf-8-validate
+      - webpack
+
+  '@lynx-js/rspeedy@0.13.6(@rspack/core@1.7.11(@swc/helpers@0.5.21))(typescript@5.9.3)(webpack@5.106.2)':
+    dependencies:
+      '@lynx-js/cache-events-webpack-plugin': 0.0.3
+      '@lynx-js/chunk-loading-webpack-plugin': 0.3.4
+      '@lynx-js/web-rsbuild-server-middleware': 0.19.9
+      '@lynx-js/webpack-dev-transport': 0.2.0
+      '@lynx-js/websocket': 0.0.4
+      '@rsbuild/core': 1.7.3
+      '@rsbuild/plugin-css-minimizer': 1.1.1(@rsbuild/core@1.7.3)(webpack@5.106.2)
+      '@rsdoctor/rspack-plugin': 1.2.3(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -10576,6 +10612,21 @@ snapshots:
       - lightningcss
       - webpack
 
+  '@rsbuild/plugin-css-minimizer@1.1.1(@rsbuild/core@1.7.3)(webpack@5.106.2)':
+    dependencies:
+      css-minimizer-webpack-plugin: 7.0.2(webpack@5.106.2)
+      reduce-configs: 1.1.2
+    optionalDependencies:
+      '@rsbuild/core': 1.7.3
+    transitivePeerDependencies:
+      - '@parcel/css'
+      - '@swc/css'
+      - clean-css
+      - csso
+      - esbuild
+      - lightningcss
+      - webpack
+
   '@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))':
     dependencies:
       rspack-vue-loader: 17.5.0(@rspack/core@1.7.11(@swc/helpers@0.5.21))
@@ -10643,10 +10694,46 @@ snapshots:
       - utf-8-validate
       - webpack
 
+  '@rsdoctor/core@1.2.3(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2)':
+    dependencies:
+      '@rsbuild/plugin-check-syntax': 1.3.0(@rsbuild/core@1.7.3)
+      '@rsdoctor/graph': 1.2.3(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2)
+      '@rsdoctor/sdk': 1.2.3(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2)
+      '@rsdoctor/types': 1.2.3(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2)
+      '@rsdoctor/utils': 1.2.3(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2)
+      axios: 1.16.1
+      browserslist-load-config: 1.0.1
+      enhanced-resolve: 5.12.0
+      filesize: 10.1.6
+      fs-extra: 11.3.5
+      lodash: 4.18.1
+      path-browserify: 1.0.1
+      semver: 7.8.0
+      source-map: 0.7.6
+    transitivePeerDependencies:
+      - '@rsbuild/core'
+      - '@rspack/core'
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+      - webpack
+
   '@rsdoctor/graph@1.2.3(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2(postcss@8.5.14))':
     dependencies:
       '@rsdoctor/types': 1.2.3(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2(postcss@8.5.14))
       '@rsdoctor/utils': 1.2.3(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2(postcss@8.5.14))
+      lodash.unionby: 4.8.0
+      source-map: 0.7.6
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - supports-color
+      - webpack
+
+  '@rsdoctor/graph@1.2.3(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2)':
+    dependencies:
+      '@rsdoctor/types': 1.2.3(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2)
+      '@rsdoctor/utils': 1.2.3(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2)
       lodash.unionby: 4.8.0
       source-map: 0.7.6
     transitivePeerDependencies:
@@ -10661,6 +10748,24 @@ snapshots:
       '@rsdoctor/sdk': 1.2.3(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2(postcss@8.5.14))
       '@rsdoctor/types': 1.2.3(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2(postcss@8.5.14))
       '@rsdoctor/utils': 1.2.3(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2(postcss@8.5.14))
+      lodash: 4.18.1
+    optionalDependencies:
+      '@rspack/core': 1.7.11(@swc/helpers@0.5.21)
+    transitivePeerDependencies:
+      - '@rsbuild/core'
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+      - webpack
+
+  '@rsdoctor/rspack-plugin@1.2.3(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2)':
+    dependencies:
+      '@rsdoctor/core': 1.2.3(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2)
+      '@rsdoctor/graph': 1.2.3(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2)
+      '@rsdoctor/sdk': 1.2.3(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2)
+      '@rsdoctor/types': 1.2.3(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2)
+      '@rsdoctor/utils': 1.2.3(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2)
       lodash: 4.18.1
     optionalDependencies:
       '@rspack/core': 1.7.11(@swc/helpers@0.5.21)
@@ -10696,6 +10801,30 @@ snapshots:
       - utf-8-validate
       - webpack
 
+  '@rsdoctor/sdk@1.2.3(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2)':
+    dependencies:
+      '@rsdoctor/client': 1.2.3
+      '@rsdoctor/graph': 1.2.3(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2)
+      '@rsdoctor/types': 1.2.3(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2)
+      '@rsdoctor/utils': 1.2.3(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2)
+      '@types/fs-extra': 11.0.4
+      body-parser: 1.20.3
+      cors: 2.8.5
+      dayjs: 1.11.13
+      fs-extra: 11.3.5
+      json-cycle: 1.5.0
+      open: 8.4.2
+      sirv: 2.0.4
+      socket.io: 4.8.1
+      source-map: 0.7.6
+      tapable: 2.2.2
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - webpack
+
   '@rsdoctor/types@1.2.3(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2(postcss@8.5.14))':
     dependencies:
       '@types/connect': 3.4.38
@@ -10706,10 +10835,44 @@ snapshots:
       '@rspack/core': 1.7.11(@swc/helpers@0.5.21)
       webpack: 5.106.2(postcss@8.5.14)
 
+  '@rsdoctor/types@1.2.3(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2)':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/estree': 1.0.5
+      '@types/tapable': 2.2.7
+      source-map: 0.7.6
+    optionalDependencies:
+      '@rspack/core': 1.7.11(@swc/helpers@0.5.21)
+      webpack: 5.106.2
+
   '@rsdoctor/utils@1.2.3(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2(postcss@8.5.14))':
     dependencies:
       '@babel/code-frame': 7.26.2
       '@rsdoctor/types': 1.2.3(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2(postcss@8.5.14))
+      '@types/estree': 1.0.5
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      acorn-walk: 8.3.4
+      connect: 3.7.0
+      deep-eql: 4.1.4
+      envinfo: 7.14.0
+      filesize: 10.1.6
+      fs-extra: 11.3.5
+      get-port: 5.1.1
+      json-stream-stringify: 3.0.1
+      lines-and-columns: 2.0.4
+      picocolors: 1.1.1
+      rslog: 1.3.2
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - supports-color
+      - webpack
+
+  '@rsdoctor/utils@1.2.3(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2)':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@rsdoctor/types': 1.2.3(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.106.2)
       '@types/estree': 1.0.5
       acorn: 8.16.0
       acorn-import-attributes: 1.9.5(acorn@8.16.0)
@@ -12415,6 +12578,16 @@ snapshots:
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       webpack: 5.106.2(postcss@8.5.14)
+
+  css-minimizer-webpack-plugin@7.0.2(webpack@5.106.2):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      cssnano: 7.1.9(postcss@8.5.14)
+      jest-worker: 29.7.0
+      postcss: 8.5.14
+      schema-utils: 4.3.3
+      serialize-javascript: 6.0.2
+      webpack: 5.106.2
 
   css-select@5.2.2:
     dependencies:
@@ -14556,6 +14729,12 @@ snapshots:
       tapable: 2.3.3
       webpack: 5.106.2(postcss@8.5.14)
 
+  mini-css-extract-plugin@2.10.2(webpack@5.106.2):
+    dependencies:
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      webpack: 5.106.2
+
   minimark@0.2.0: {}
 
   minimatch@10.2.5:
@@ -16681,6 +16860,14 @@ snapshots:
     optionalDependencies:
       postcss: 8.5.14
 
+  terser-webpack-plugin@5.6.0(webpack@5.106.2):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.47.1
+      webpack: 5.106.2
+
   terser@5.47.1:
     dependencies:
       '@jridgewell/source-map': 0.3.11
@@ -17289,7 +17476,7 @@ snapshots:
 
   vue-devtools-stub@0.1.0: {}
 
-  vue-lynx@0.4.0(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)(lightningcss@1.32.0)):
+  vue-lynx@0.4.0(patch_hash=69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)(lightningcss@1.32.0)):
     dependencies:
       '@lynx-js/css-extract-webpack-plugin': 0.7.1(@lynx-js/template-webpack-plugin@0.10.9(tslib@2.8.1))(webpack@5.106.2(esbuild@0.28.0)(lightningcss@1.32.0))
       '@lynx-js/react': 0.116.5(@lynx-js/types@3.8.0)(@types/react@18.3.28)
@@ -17306,7 +17493,7 @@ snapshots:
       - tslib
       - webpack
 
-  vue-lynx@0.4.0(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.14)):
+  vue-lynx@0.4.0(patch_hash=69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.14)):
     dependencies:
       '@lynx-js/css-extract-webpack-plugin': 0.7.1(@lynx-js/template-webpack-plugin@0.10.9(tslib@2.8.1))(webpack@5.106.2(postcss@8.5.14))
       '@lynx-js/react': 0.116.5(@lynx-js/types@3.8.0)(@types/react@18.3.28)
@@ -17323,7 +17510,24 @@ snapshots:
       - tslib
       - webpack
 
-  vue-lynx@0.4.0(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(lightningcss@1.32.0)):
+  vue-lynx@0.4.0(patch_hash=69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2):
+    dependencies:
+      '@lynx-js/css-extract-webpack-plugin': 0.7.1(@lynx-js/template-webpack-plugin@0.10.9(tslib@2.8.1))(webpack@5.106.2)
+      '@lynx-js/react': 0.116.5(@lynx-js/types@3.8.0)(@types/react@18.3.28)
+      '@lynx-js/runtime-wrapper-webpack-plugin': 0.1.3
+      '@lynx-js/template-webpack-plugin': 0.10.9(tslib@2.8.1)
+      '@lynx-js/webpack-dev-transport': 0.2.0
+      '@rsbuild/core': 1.7.3
+      '@rsbuild/plugin-vue': 1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(vue@3.5.17(typescript@5.9.3))
+      '@vue/runtime-core': 3.5.34
+    transitivePeerDependencies:
+      - '@lynx-js/lynx-core'
+      - '@lynx-js/types'
+      - '@types/react'
+      - tslib
+      - webpack
+
+  vue-lynx@0.4.0(patch_hash=69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(lightningcss@1.32.0)):
     dependencies:
       '@lynx-js/css-extract-webpack-plugin': 0.7.1(@lynx-js/template-webpack-plugin@0.10.9(tslib@2.8.1))(webpack@5.106.2(lightningcss@1.32.0))
       '@lynx-js/react': 0.116.5(@lynx-js/types@3.8.0)(@types/react@18.3.28)
@@ -17416,6 +17620,46 @@ snapshots:
   webpack-sources@3.4.1: {}
 
   webpack-virtual-modules@0.6.2: {}
+
+  webpack@5.106.2:
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.2
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.21.3
+      es-module-lexer: 2.1.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      loader-runner: 4.3.2
+      mime-db: 1.54.0
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      terser-webpack-plugin: 5.6.0(webpack@5.106.2)
+      watchpack: 2.5.1
+      webpack-sources: 3.4.1
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
 
   webpack@5.106.2(esbuild@0.28.0)(lightningcss@1.32.0):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,3 +16,5 @@ allowBuilds:
   esbuild: true
   sharp: true
   vue-demi: false
+patchedDependencies:
+  vue-lynx@0.4.0: patches/vue-lynx@0.4.0.patch


### PR DESCRIPTION
Stacked on #38. Re-lands the shared `useDragGesture` composable now that the real blocker is understood and fixed locally.

- Root cause (see #37): vue-lynx's MT worklet loader only follows **relative** imports, so the `@/`-aliased composable's worklets never registered on MT → `bind of undefined`. Not a vue-lynx/composable limitation — an import-path packaging gap.
- `shared/gesture/useDragGesture.ts` re-added; `SwiperRoot` consumes it via the clean `@/` import (238→18 line component).
- `patches/vue-lynx@0.4.0.patch` — pnpm patch widening `worklet-loader-mt`'s `extractLocalImports` to also follow `@/` aliases. Self-documented with a `REMOVE WHEN UPSTREAM FIXED` banner + undo steps in `patches/README.md`.
- `docs/upstream/` — drafted vue-lynx issue (root cause + tiered fix) for the proper upstream fix.

Verified:
- core `vue-tsc` clean; `@vyui/kit-demo` rspeedy build passes
- MT-bundle audit: unresolved worklets **7 → 0**
- **device tap-test passed** — Swiper drag/snap/flick works in LynxExplorer ✅

Excludes unrelated `apps/docs/*` WIP (different work). Relates to #37, #38.