### PR TITLE
docs: match @vyui/kit changelog icon to docs

### DIFF
--- a/apps/docs/app/pages/changelog.vue
+++ b/apps/docs/app/pages/changelog.vue
@@ -55,7 +55,7 @@ useSeoMeta({
           <div class="size-3" />
           <div class="flex items-center gap-2">
             <UIcon
-              name="i-lucide-palette"
+              name="i-lucide-layers"
               class="text-info size-4"
             />
             <code class="text-highlighted">@vyui/kit</code>


### PR DESCRIPTION
Aligns the changelog rail icon for `@vyui/kit` with the rest of the docs.

- Changelog rail used `i-lucide-palette`; docs use `i-lucide-layers` for `@vyui/kit` — switched the rail to match.