### PR TITLE
chore(deps): group GitHub Actions bumps into one dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,9 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    # Bundle all GitHub Actions bumps into a single PR per run so the weekly
+    # review is one PR instead of one-per-action.
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Bundles all GitHub Actions version bumps into a single weekly dependabot PR instead of one-per-action.

- Adds a `github-actions` group (`patterns: ["*"]`) to `.github/dependabot.yml`
- Cuts the weekly dependency review from N PRs down to 1