### PR TITLE
feat: AspectRatio + Avatar core primitives

### DIFF
--- a/.changeset/aspect-ratio.md
+++ b/.changeset/aspect-ratio.md
@@ -1,0 +1,7 @@
+---
+"@vyui/core": minor
+---
+
+Add AspectRatio — headless `@vyui/core` primitive (`AspectRatioRoot`, exported as both `AspectRatio` and `AspectRatioRoot`) that constrains its default slot to a given `ratio` (number, default `1`).
+
+Ported from reka-ui but adapted for the Lynx render layer: instead of reka-ui's DOM padding-bottom-percentage hack, it renders a single `<view>` using the native CSS `aspect-ratio` property (supported by Lynx's Starlight layout engine), so there is no absolutely-positioned wrapper.

--- a/.changeset/aspect-ratio.md
+++ b/.changeset/aspect-ratio.md
@@ -4,4 +4,4 @@
 
 Add AspectRatio — headless `@vyui/core` primitive (`AspectRatioRoot`, exported as both `AspectRatio` and `AspectRatioRoot`) that constrains its default slot to a given `ratio` (number, default `1`).
 
-Ported from reka-ui but adapted for the Lynx render layer: instead of reka-ui's DOM padding-bottom-percentage hack, it renders a single `<view>` using the native CSS `aspect-ratio` property (supported by Lynx's Starlight layout engine), so there is no absolutely-positioned wrapper.
+Built for the Lynx render layer: it renders a single `<view>` using the native CSS `aspect-ratio` property (supported by Lynx's Starlight layout engine), with no absolutely-positioned padding wrapper.

--- a/.changeset/avatar-core-primitives.md
+++ b/.changeset/avatar-core-primitives.md
@@ -1,0 +1,8 @@
+---
+"@vyui/core": minor
+"@vyui/kit": minor
+---
+
+Add Avatar — headless `@vyui/core` primitives (`AvatarRoot` / `AvatarImage` / `AvatarFallback`) ported from reka-ui. `AvatarRoot` provides image load-status context; `AvatarImage` renders a Lynx `<image>` and downgrades to the error state on `binderror` (`@error`); `AvatarFallback` shows when no image is loaded, with reka's `delayMs` flash-avoidance delay.
+
+Refactor `@vyui/kit`'s `VyAvatar` to compose the new core primitives for behaviour (load-status + fallback) while keeping its public `AvatarProps` API, initials derivation, chip overlay, theming, and `AvatarGroup` size/color inheritance unchanged.

--- a/apps/docs/app/pages/changelog.vue
+++ b/apps/docs/app/pages/changelog.vue
@@ -1,133 +1,158 @@
 <script setup lang="ts">
-const { data: entries } = await useAsyncData('changelog', () =>
-  queryCollection('changelog').order('date', 'DESC').all(),
-)
+const { data: entries } = await useAsyncData("changelog", () =>
+    queryCollection("changelog").order("date", "DESC").all(),
+);
 
-const dateFormatter = new Intl.DateTimeFormat('en-US', {
-  day: 'numeric',
-  month: 'short',
-  year: 'numeric',
-})
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+});
 
 function formatDate(date: string) {
-  // Parse as UTC so the displayed day doesn't drift across timezones.
-  return dateFormatter.format(new Date(`${date}T00:00:00Z`))
+    // Parse as UTC so the displayed day doesn't drift across timezones.
+    return dateFormatter.format(new Date(`${date}T00:00:00Z`));
 }
 
 useSeoMeta({
-  title: 'Changelog',
-  description: 'Release notes for Vy UI — @vyui/core and @vyui/kit, side by side as the project evolves.',
-})
+    title: "Changelog",
+    description: "Release notes for Vy UI — @vyui/core and @vyui/kit.",
+});
 </script>
 
 <template>
-  <UContainer>
-    <div class="py-12 sm:py-16">
-      <div class="mx-auto mb-12 max-w-2xl text-center">
-        <h1 class="text-highlighted text-4xl font-semibold tracking-tight sm:text-5xl">
-          Changelog
-        </h1>
-        <p class="text-muted mt-3 text-base sm:text-lg">
-          What's shipping across <code class="text-highlighted">@vyui/core</code> and
-          <code class="text-highlighted">@vyui/kit</code> — one rolling timeline, newest first.
-        </p>
-      </div>
-
-      <UAlert
-        v-if="!entries?.length"
-        icon="i-lucide-flask-conical"
-        color="warning"
-        variant="subtle"
-        title="No entries yet"
-        description="Vy UI is pre-alpha. This page fills in as core and kit evolve."
-      />
-
-      <template v-else>
-        <!-- Rail headers (desktop only) -->
-        <div class="text-muted mb-6 hidden grid-cols-[1fr_auto_1fr] items-center gap-x-12 text-sm font-medium md:grid">
-          <div class="flex items-center justify-end gap-2">
-            <UIcon
-              name="i-lucide-box"
-              class="text-primary size-4"
-            />
-            <code class="text-highlighted">@vyui/core</code>
-          </div>
-          <div class="size-3" />
-          <div class="flex items-center gap-2">
-            <UIcon
-              name="i-lucide-layers"
-              class="text-info size-4"
-            />
-            <code class="text-highlighted">@vyui/kit</code>
-          </div>
-        </div>
-
-        <div class="relative">
-          <!-- Center spine -->
-          <div class="bg-border absolute inset-y-0 left-[7px] w-px md:left-1/2 md:-translate-x-1/2" />
-
-          <ul class="space-y-10">
-            <li
-              v-for="entry in entries"
-              :key="entry.path"
-              class="relative md:grid md:grid-cols-2 md:gap-x-12"
-            >
-              <!-- Node on the spine -->
-              <span
-                class="ring-bg absolute top-2 left-[7px] z-10 size-3.5 -translate-x-1/2 rounded-full ring-4 md:left-1/2"
-                :class="entry.package === 'core' ? 'bg-primary' : 'bg-info'"
-              />
-
-              <div
-                :class="[
-                  'pl-8 md:pl-0',
-                  entry.package === 'core'
-                    ? 'md:col-start-1 md:pr-2 md:text-right'
-                    : 'md:col-start-2 md:pl-2',
-                ]"
-              >
-                <UCard
-                  variant="subtle"
-                  :ui="{ body: 'sm:p-5' }"
+    <UContainer>
+        <div class="py-12 sm:py-16">
+            <div class="mx-auto mb-12 max-w-2xl text-center">
+                <h1
+                    class="text-highlighted text-4xl font-semibold tracking-tight sm:text-5xl"
                 >
-                  <div
-                    class="flex items-center gap-2"
-                    :class="entry.package === 'core' && 'md:flex-row-reverse'"
-                  >
-                    <UBadge
-                      :color="entry.package === 'core' ? 'primary' : 'info'"
-                      variant="subtle"
-                      size="sm"
-                    >
-                      @vyui/{{ entry.package }}
-                    </UBadge>
-                    <UBadge
-                      color="neutral"
-                      variant="outline"
-                      size="sm"
-                      class="font-mono"
-                    >
-                      {{ entry.version }}
-                    </UBadge>
-                  </div>
+                    Changelog
+                </h1>
+                <p class="text-muted mt-3 text-base sm:text-lg">
+                    What's shipping across
+                    <code class="text-highlighted">@vyui/core</code> and
+                    <code class="text-highlighted">@vyui/kit</code> — one
+                    rolling timeline, newest first.
+                </p>
+            </div>
 
-                  <time class="text-dimmed mt-3 block font-mono text-xs">
-                    {{ formatDate(entry.date) }}
-                  </time>
+            <UAlert
+                v-if="!entries?.length"
+                icon="i-lucide-flask-conical"
+                color="warning"
+                variant="subtle"
+                title="No entries yet"
+                description="Vy UI is pre-alpha. This page fills in as core and kit evolve."
+            />
 
-                  <h2 class="text-highlighted mt-1 text-lg font-semibold">
-                    {{ entry.title }}
-                  </h2>
+            <template v-else>
+                <!-- Rail headers (desktop only) -->
+                <div
+                    class="text-muted mb-6 hidden grid-cols-[1fr_auto_1fr] items-center gap-x-12 text-sm font-medium md:grid"
+                >
+                    <div class="flex items-center justify-end gap-2">
+                        <UIcon
+                            name="i-lucide-box"
+                            class="text-primary size-4"
+                        />
+                        <code class="text-highlighted">@vyui/core</code>
+                    </div>
+                    <div class="size-3" />
+                    <div class="flex items-center gap-2">
+                        <UIcon
+                            name="i-lucide-layers"
+                            class="text-info size-4"
+                        />
+                        <code class="text-highlighted">@vyui/kit</code>
+                    </div>
+                </div>
 
-                  <div class="text-muted mt-2 text-sm [&_a]:text-primary [&_code]:text-highlighted">
-                    <ContentRenderer :value="entry" />
-                  </div>
-                </UCard>
-              </div>
-            </li>
-          </ul>
+                <div class="relative">
+                    <!-- Center spine -->
+                    <div
+                        class="bg-border absolute inset-y-0 left-[7px] w-px md:left-1/2 md:-translate-x-1/2"
+                    />
+
+                    <ul class="space-y-10">
+                        <li
+                            v-for="entry in entries"
+                            :key="entry.path"
+                            class="relative md:grid md:grid-cols-2 md:gap-x-12"
+                        >
+                            <!-- Node on the spine -->
+                            <span
+                                class="ring-bg absolute top-2 left-[7px] z-10 size-3.5 -translate-x-1/2 rounded-full ring-4 md:left-1/2"
+                                :class="
+                                    entry.package === 'core'
+                                        ? 'bg-primary'
+                                        : 'bg-info'
+                                "
+                            />
+
+                            <div
+                                :class="[
+                                    'pl-8 md:pl-0',
+                                    entry.package === 'core'
+                                        ? 'md:col-start-1 md:pr-2 md:text-right'
+                                        : 'md:col-start-2 md:pl-2',
+                                ]"
+                            >
+                                <UCard
+                                    variant="subtle"
+                                    :ui="{ body: 'sm:p-5' }"
+                                >
+                                    <div
+                                        class="flex items-center gap-2"
+                                        :class="
+                                            entry.package === 'core' &&
+                                            'md:flex-row-reverse'
+                                        "
+                                    >
+                                        <UBadge
+                                            :color="
+                                                entry.package === 'core'
+                                                    ? 'primary'
+                                                    : 'info'
+                                            "
+                                            variant="subtle"
+                                            size="sm"
+                                        >
+                                            @vyui/{{ entry.package }}
+                                        </UBadge>
+                                        <UBadge
+                                            color="neutral"
+                                            variant="outline"
+                                            size="sm"
+                                            class="font-mono"
+                                        >
+                                            {{ entry.version }}
+                                        </UBadge>
+                                    </div>
+
+                                    <time
+                                        class="text-dimmed mt-3 block font-mono text-xs"
+                                    >
+                                        {{ formatDate(entry.date) }}
+                                    </time>
+
+                                    <h2
+                                        class="text-highlighted mt-1 text-lg font-semibold"
+                                    >
+                                        {{ entry.title }}
+                                    </h2>
+
+                                    <div
+                                        class="text-muted mt-2 text-sm [&_a]:text-primary [&_code]:text-highlighted"
+                                    >
+                                        <ContentRenderer :value="entry" />
+                                    </div>
+                                </UCard>
+                            </div>
+                        </li>
+                    </ul>
+                </div>
+            </template>
         </div>
-      </template>
-    </div>
-  </UContainer>
+    </UContainer>
 </template>

--- a/apps/examples/kit-demo/src/App.vue
+++ b/apps/examples/kit-demo/src/App.vue
@@ -5,6 +5,7 @@ import { VyTabs } from '@vyui/kit'
 import ThemeSection from './sections/ThemeSection.vue'
 import FormSection from './sections/FormSection.vue'
 import DisplaySection from './sections/DisplaySection.vue'
+import IslandSection from './sections/IslandSection.vue'
 import OverlaySection from './sections/OverlaySection.vue'
 
 type PaletteName = 'green' | 'rose' | 'blue' | 'violet' | 'amber' | 'teal' | 'pink' | 'orange'
@@ -22,6 +23,7 @@ const allTabItems = [
   { value: 'theme',   label: 'Theme', icon: 'icon-park-outline:paint',            slot: 'theme' },
   { value: 'form',    label: 'Form',  icon: 'icon-park-outline:edit',             slot: 'form' },
   { value: 'display', label: 'View',  icon: 'icon-park-outline:layers',           slot: 'display' },
+  { value: 'island',  label: 'Island', icon: 'icon-park-outline:pill',            slot: 'island' },
   { value: 'overlay', label: 'Modal', icon: 'icon-park-outline:application-menu', slot: 'overlay' },
 ]
 const tabItems = computed(() => allTabItems)
@@ -73,6 +75,10 @@ const tabItems = computed(() => allTabItems)
 
           <template #display>
             <DisplaySection />
+          </template>
+
+          <template #island>
+            <IslandSection />
           </template>
 
           <template #overlay>

--- a/apps/examples/kit-demo/src/sections/DisplaySection.vue
+++ b/apps/examples/kit-demo/src/sections/DisplaySection.vue
@@ -4,15 +4,13 @@ import { ToastProvider } from '@vyui/core'
 import {
   VyAccordion,
   VyAlert,
+  VyAspectRatio,
   VyAvatar,
   VyAvatarGroup,
   VyBadge,
   VyButton,
   VyCard,
   VyChip,
-  VyIsland,
-  VyIslandButton,
-  VyIslandGroup,
   VyProgress,
   VySeparator,
   VySkeleton,
@@ -47,47 +45,9 @@ const innerTabItems = [
   { value: 'reviews',  label: 'Reviews',  icon: 'icon-park-outline:comments',   slot: 'reviews' },
 ]
 
-// Linear-style bottom dock. With the new declarative API, the three island
-// state axes (`value` for active tab, `mode` for row mode, `open` for the
-// expanded panel) are v-model'd from a single set of refs — buttons opt
-// into each axis via props (`value=…`, `mode=…`, `expand`, `reset`).
-const dockTab = ref<string | number | null>('inbox')
-const dockMode = ref<string>('default')
-const dockOpen = ref(false)
-const floatingDockVisible = ref(true)
-
-// Mock inbox content — revealed on tap of the Inbox tab in the dock. Each
-// issue is an accordion row that opens to show the detail body that the
-// retired tooltip used to host. Active / inactive grouped via the `status`
-// flag rendered as an inline badge in the label.
-const inboxOpen = ref<string | number>('iss-431')
-const inboxIssues = [
-  {
-    value: 'iss-431',
-    label: 'iss-431 · API /users returns 500 on limit=0',
-    content: 'Repro: GET /users?limit=0 → 500. Stack trace points to the pagination middleware not guarding against zero. Triaged to backend, ETA today. Owner: api-team. Severity: high. Affects: production EU + US.',
-  },
-  {
-    value: 'iss-428',
-    label: 'iss-428 · Mobile nav misaligned on iOS 17',
-    content: 'Safe-area inset is mis-applied when the keyboard is dismissed. Reproducible on iPhone 14 Pro / iOS 17.4. Workaround: rotate twice. Owner: mobile-team. Severity: medium.',
-  },
-  {
-    value: 'iss-419',
-    label: 'iss-419 · Email digest sending twice',
-    content: 'Two cron entries enqueueing the same job at 09:00 UTC. Removed the duplicate from infra/cron.yaml; backfill not needed (Mailgun dedupe absorbed it). Verified clean run on the 09:00 + 12:00 ticks.',
-  },
-  {
-    value: 'iss-389',
-    label: 'iss-389 · Old caching layer key collisions',
-    content: 'Closed: superseded by the new Redis namespacing rolled out in PR #1204. Verified across all four services; cache hit rate up 3%.',
-  },
-  {
-    value: 'iss-355',
-    label: 'iss-355 · Deprecated auth flow still in mobile',
-    content: 'Closed: shipped v5.2 of the mobile client; deprecated path now returns 410. Server-side route scheduled for removal in v5.4.',
-  },
-]
+// Deliberately unresolvable src to exercise the Avatar image `binderror` →
+// fallback path (initials / icon). See Avatar.vue's CoreAvatarImage handling.
+const brokenImage = 'https://invalid.vyui.local/missing-avatar.png'
 </script>
 
 <template>
@@ -100,6 +60,13 @@ const inboxIssues = [
         <VyAvatar alt="Kealan Clarke" />
         <VyAvatar icon="icon-park-outline:user" />
         <VyAvatar size="xl" alt="Big Avatar" />
+      </view>
+      <text class="text-slate-900 text-sm font-medium pt-1">Broken image → fallback</text>
+      <view class="flex flex-row flex-wrap items-center gap-3">
+        <!-- `src` fails to load → falls back to alt-derived initials -->
+        <VyAvatar :src="brokenImage" alt="Ada Lovelace" />
+        <!-- `src` fails to load, no text → falls back to the icon -->
+        <VyAvatar :src="brokenImage" icon="icon-park-outline:user" />
       </view>
       <text class="text-slate-900 text-sm font-medium pt-1">Group</text>
       <VyAvatarGroup :max="3" size="md">
@@ -293,111 +260,39 @@ const inboxIssues = [
       </view>
     </ToastProvider>
 
-    <!-- Island — the real floating dock is rendered after the closing
-         </view> of this card (see below). This card holds the description
-         + secondary placement variants (top pair, single icon). -->
-    <view class="bg-white border border-slate-200 rounded-lg p-4 flex flex-col gap-4">
-      <view class="flex flex-col gap-1">
-        <text class="text-slate-900 text-base font-semibold">Island</text>
-        <text class="text-slate-500 text-xs">
-          Linear-style pill container — anchored to the viewport edge by
-          default. The main dock for this section is floating at the bottom
-          of the screen; toggle it below. Side-by-side and single-button
-          patterns are inlined here for layout reference.
-        </text>
-        <text class="text-slate-400 text-[11px] pt-1">value: <text class="font-mono">{{ dockTab }}</text> · mode: <text class="font-mono">{{ dockMode }}</text> · open: <text class="font-mono">{{ dockOpen }}</text></text>
-      </view>
-
-      <!-- Inbox view — revealed when the Inbox tab is active in the dock.
-           Each issue is an accordion row; tap to expand its detail body
-           (replaces the old tooltip-on-hover affordance with a touch one).
-           `type="single"` keeps at most one open at a time. -->
-      <view v-if="dockTab === 'inbox'" class="flex flex-col gap-2">
-        <text class="text-slate-500 text-xs">{{ inboxIssues.length }} issues · tap any row to expand</text>
-        <VyAccordion v-model="inboxOpen" :items="inboxIssues" type="single" />
-      </view>
-
-      <VySeparator />
-
-      <!-- Top pair — two inline islands side-by-side -->
-      <view class="flex flex-col items-stretch gap-2">
-        <text class="text-slate-500 text-xs">Two top islands side-by-side (left breadcrumb, right actions)</text>
-        <view class="flex flex-row items-start justify-between gap-2">
-          <VyIsland position="inline" size="sm">
-            <VyIslandButton icon="icon-park-outline:left" @tap="() => {}" />
-            <VyIslandButton label="Inbox" @tap="() => {}" />
-          </VyIsland>
-          <VyIsland position="inline" size="sm">
-            <VyIslandButton icon="icon-park-outline:share" @tap="() => {}" />
-            <VyIslandButton icon="icon-park-outline:more" @tap="() => {}" />
-          </VyIsland>
-        </view>
-      </view>
-
-      <VySeparator />
-
-      <!-- Single-button island -->
-      <view class="flex flex-col items-center gap-2">
-        <text class="text-slate-500 text-xs">Single icon, no labels</text>
-        <VyIsland position="inline" size="lg">
-          <VyIslandButton icon="icon-park-outline:message" @tap="() => {}" />
-        </VyIsland>
-      </view>
-
-      <VySeparator />
-
-      <!-- Show / hide the floating dock anchored at the bottom -->
-      <view class="flex flex-row items-center justify-between gap-2">
-        <view class="flex flex-col gap-0.5">
-          <text class="text-slate-900 text-sm font-medium">Floating bottom dock</text>
-          <text class="text-slate-500 text-xs">Fixed to the bottom of the viewport. Trailing pill = close.</text>
-        </view>
-        <VyButton
-          :label="floatingDockVisible ? 'Hide' : 'Show'"
-          :color="floatingDockVisible ? 'neutral' : 'primary'"
-          :variant="floatingDockVisible ? 'subtle' : 'solid'"
-          size="sm"
-          @tap="floatingDockVisible = !floatingDockVisible"
+    <!-- AspectRatio — pure layout primitive; the box sizes to parent width
+         and derives height from `ratio` (Lynx supports `aspect-ratio` natively). -->
+    <view class="bg-white border border-slate-200 rounded-lg p-4 flex flex-col gap-3">
+      <text class="text-slate-900 text-base font-semibold">AspectRatio</text>
+      <view class="flex flex-col gap-2">
+        <text class="text-slate-500 text-xs">16 / 9</text>
+        <!-- Render the AspectRatio *as* the <image> so the ratio sits on the
+             image element itself: a nested image sized via h-full/flex collapses
+             to 0 on native, and a Lynx <image> with a 0 computed size never loads
+             (see @lynx-js/types image `prefetch-*` notes). `aspectFit` keeps the
+             square logo uncropped inside the wide box. -->
+        <VyAspectRatio
+          as="image"
+          :ratio="16 / 9"
+          :src="vyuiIcon"
+          mode="aspectFit"
+          class="rounded-lg bg-slate-100"
         />
       </view>
+      <view class="flex flex-row gap-3">
+        <view class="flex flex-col gap-2 flex-1">
+          <text class="text-slate-500 text-xs">1 / 1</text>
+          <VyAspectRatio :ratio="1" class="bg-sky-500 rounded-lg flex items-center justify-center">
+            <text class="text-white text-sm font-semibold">1:1</text>
+          </VyAspectRatio>
+        </view>
+        <view class="flex flex-col gap-2 flex-1">
+          <text class="text-slate-500 text-xs">4 / 3</text>
+          <VyAspectRatio :ratio="4 / 3" class="bg-violet-500 rounded-lg flex items-center justify-center">
+            <text class="text-white text-sm font-semibold">4:3</text>
+          </VyAspectRatio>
+        </view>
+      </view>
     </view>
-
-    <!-- Anchored Linear-style dock — rendered at the section root so the
-         fixed position is relative to the viewport, not a clipped parent.
-         Wrapped in <VyIslandGroup> so a separate close pill sits to the
-         right of the main dock. Group owns the bottom-of-viewport
-         positioning; member islands stay `position="inline"`.
-         Shares state with the inline preview above. -->
-    <VyIslandGroup v-if="floatingDockVisible" position="bottom" size="lg">
-      <VyIsland
-        v-model:open="dockOpen"
-        v-model:mode="dockMode"
-        v-model:value="dockTab"
-        position="inline"
-        size="lg"
-      >
-        <VyIslandButton value="inbox" icon="icon-park-outline:inbox-in" />
-        <VyIslandButton mode="fullisland" icon="icon-park-outline:search" />
-        <VyIslandButton value="bell" icon="icon-park-outline:remind" />
-        <VyIslandButton expand icon="icon-park-outline:expand-text-input" />
-
-        <template #fullisland>
-          <VyIslandButton reset icon="icon-park-outline:search" label="Search…" />
-          <VyIslandButton reset icon="icon-park-outline:close" />
-        </template>
-
-        <template #expanded="{ close }">
-          <VyIslandButton icon="icon-park-outline:setting" label="Settings" @tap="close" />
-          <VyIslandButton icon="icon-park-outline:help" label="Help" @tap="close" />
-          <VyIslandButton icon="icon-park-outline:logout" label="Sign out" @tap="floatingDockVisible = false" />
-        </template>
-      </VyIsland>
-
-      <!-- Trailing companion island. Free-form contents — close here, but
-           could be a status pill, a chip count, a mini-player, etc. -->
-      <VyIsland position="inline" size="lg">
-        <VyIslandButton icon="icon-park-outline:close" @tap="floatingDockVisible = false" />
-      </VyIsland>
-    </VyIslandGroup>
   </view>
 </template>

--- a/apps/examples/kit-demo/src/sections/IslandSection.vue
+++ b/apps/examples/kit-demo/src/sections/IslandSection.vue
@@ -83,11 +83,11 @@ const inboxIssues = [
       <view class="flex flex-col items-stretch gap-2">
         <text class="text-slate-500 text-xs">Two top islands side-by-side (left breadcrumb, right actions)</text>
         <view class="flex flex-row items-start justify-between gap-2">
-          <VyIsland position="inline" size="sm">
+          <VyIsland layer="inline" size="sm">
             <VyIslandButton icon="icon-park-outline:left" @tap="() => {}" />
             <VyIslandButton label="Inbox" @tap="() => {}" />
           </VyIsland>
-          <VyIsland position="inline" size="sm">
+          <VyIsland layer="inline" size="sm">
             <VyIslandButton icon="icon-park-outline:share" @tap="() => {}" />
             <VyIslandButton icon="icon-park-outline:more" @tap="() => {}" />
           </VyIsland>
@@ -99,7 +99,7 @@ const inboxIssues = [
       <!-- Single-button island -->
       <view class="flex flex-col items-center gap-2">
         <text class="text-slate-500 text-xs">Single icon, no labels</text>
-        <VyIsland position="inline" size="lg">
+        <VyIsland layer="inline" size="lg">
           <VyIslandButton icon="icon-park-outline:message" @tap="() => {}" />
         </VyIsland>
       </view>
@@ -126,14 +126,14 @@ const inboxIssues = [
          fixed position is relative to the viewport, not a clipped parent.
          Wrapped in <VyIslandGroup> so a separate close pill sits to the
          right of the main dock. Group owns the bottom-of-viewport
-         positioning; member islands stay `position="inline"`.
+         positioning; member islands stay `layer="inline"`.
          Shares state with the inline preview above. -->
     <VyIslandGroup v-if="floatingDockVisible" position="bottom" size="lg">
       <VyIsland
         v-model:open="dockOpen"
         v-model:mode="dockMode"
         v-model:value="dockTab"
-        position="inline"
+        layer="inline"
         size="lg"
       >
         <VyIslandButton value="inbox" icon="icon-park-outline:inbox-in" />
@@ -155,7 +155,7 @@ const inboxIssues = [
 
       <!-- Trailing companion island. Free-form contents — close here, but
            could be a status pill, a chip count, a mini-player, etc. -->
-      <VyIsland position="inline" size="lg">
+      <VyIsland layer="inline" size="lg">
         <VyIslandButton icon="icon-park-outline:close" @tap="floatingDockVisible = false" />
       </VyIsland>
     </VyIslandGroup>

--- a/apps/examples/kit-demo/src/sections/IslandSection.vue
+++ b/apps/examples/kit-demo/src/sections/IslandSection.vue
@@ -1,0 +1,163 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import {
+  VyAccordion,
+  VyButton,
+  VyIsland,
+  VyIslandButton,
+  VyIslandGroup,
+  VySeparator,
+} from '@vyui/kit'
+
+// Linear-style bottom dock. With the declarative API, the three island state
+// axes (`value` for active tab, `mode` for row mode, `open` for the expanded
+// panel) are v-model'd from a single set of refs — buttons opt into each axis
+// via props (`value=…`, `mode=…`, `expand`, `reset`).
+const dockTab = ref<string | number | null>('inbox')
+const dockMode = ref<string>('default')
+const dockOpen = ref(false)
+const floatingDockVisible = ref(true)
+
+// Mock inbox content — revealed on tap of the Inbox tab in the dock. Each
+// issue is an accordion row that opens to show its detail body. `type="single"`
+// keeps at most one open at a time.
+const inboxOpen = ref<string | number>('iss-431')
+const inboxIssues = [
+  {
+    value: 'iss-431',
+    label: 'iss-431 · API /users returns 500 on limit=0',
+    content: 'Repro: GET /users?limit=0 → 500. Stack trace points to the pagination middleware not guarding against zero. Triaged to backend, ETA today. Owner: api-team. Severity: high. Affects: production EU + US.',
+  },
+  {
+    value: 'iss-428',
+    label: 'iss-428 · Mobile nav misaligned on iOS 17',
+    content: 'Safe-area inset is mis-applied when the keyboard is dismissed. Reproducible on iPhone 14 Pro / iOS 17.4. Workaround: rotate twice. Owner: mobile-team. Severity: medium.',
+  },
+  {
+    value: 'iss-419',
+    label: 'iss-419 · Email digest sending twice',
+    content: 'Two cron entries enqueueing the same job at 09:00 UTC. Removed the duplicate from infra/cron.yaml; backfill not needed (Mailgun dedupe absorbed it). Verified clean run on the 09:00 + 12:00 ticks.',
+  },
+  {
+    value: 'iss-389',
+    label: 'iss-389 · Old caching layer key collisions',
+    content: 'Closed: superseded by the new Redis namespacing rolled out in PR #1204. Verified across all four services; cache hit rate up 3%.',
+  },
+  {
+    value: 'iss-355',
+    label: 'iss-355 · Deprecated auth flow still in mobile',
+    content: 'Closed: shipped v5.2 of the mobile client; deprecated path now returns 410. Server-side route scheduled for removal in v5.4.',
+  },
+]
+</script>
+
+<template>
+  <view class="flex flex-col gap-4 pt-2">
+    <!-- Island — the real floating dock is rendered after the closing
+         </view> of this card (see below). This card holds the description
+         + secondary placement variants (top pair, single icon). -->
+    <view class="bg-white border border-slate-200 rounded-lg p-4 flex flex-col gap-4">
+      <view class="flex flex-col gap-1">
+        <text class="text-slate-900 text-base font-semibold">Island</text>
+        <text class="text-slate-500 text-xs">
+          Linear-style pill container — anchored to the viewport edge by
+          default. The main dock for this section is floating at the bottom
+          of the screen; toggle it below. Side-by-side and single-button
+          patterns are inlined here for layout reference.
+        </text>
+        <text class="text-slate-400 text-[11px] pt-1">value: <text class="font-mono">{{ dockTab }}</text> · mode: <text class="font-mono">{{ dockMode }}</text> · open: <text class="font-mono">{{ dockOpen }}</text></text>
+      </view>
+
+      <!-- Inbox view — revealed when the Inbox tab is active in the dock.
+           Each issue is an accordion row; tap to expand its detail body
+           (replaces the old tooltip-on-hover affordance with a touch one).
+           `type="single"` keeps at most one open at a time. -->
+      <view v-if="dockTab === 'inbox'" class="flex flex-col gap-2">
+        <text class="text-slate-500 text-xs">{{ inboxIssues.length }} issues · tap any row to expand</text>
+        <VyAccordion v-model="inboxOpen" :items="inboxIssues" type="single" />
+      </view>
+
+      <VySeparator />
+
+      <!-- Top pair — two inline islands side-by-side -->
+      <view class="flex flex-col items-stretch gap-2">
+        <text class="text-slate-500 text-xs">Two top islands side-by-side (left breadcrumb, right actions)</text>
+        <view class="flex flex-row items-start justify-between gap-2">
+          <VyIsland position="inline" size="sm">
+            <VyIslandButton icon="icon-park-outline:left" @tap="() => {}" />
+            <VyIslandButton label="Inbox" @tap="() => {}" />
+          </VyIsland>
+          <VyIsland position="inline" size="sm">
+            <VyIslandButton icon="icon-park-outline:share" @tap="() => {}" />
+            <VyIslandButton icon="icon-park-outline:more" @tap="() => {}" />
+          </VyIsland>
+        </view>
+      </view>
+
+      <VySeparator />
+
+      <!-- Single-button island -->
+      <view class="flex flex-col items-center gap-2">
+        <text class="text-slate-500 text-xs">Single icon, no labels</text>
+        <VyIsland position="inline" size="lg">
+          <VyIslandButton icon="icon-park-outline:message" @tap="() => {}" />
+        </VyIsland>
+      </view>
+
+      <VySeparator />
+
+      <!-- Show / hide the floating dock anchored at the bottom -->
+      <view class="flex flex-row items-center justify-between gap-2">
+        <view class="flex flex-col gap-0.5">
+          <text class="text-slate-900 text-sm font-medium">Floating bottom dock</text>
+          <text class="text-slate-500 text-xs">Fixed to the bottom of the viewport. Trailing pill = close.</text>
+        </view>
+        <VyButton
+          :label="floatingDockVisible ? 'Hide' : 'Show'"
+          :color="floatingDockVisible ? 'neutral' : 'primary'"
+          :variant="floatingDockVisible ? 'subtle' : 'solid'"
+          size="sm"
+          @tap="floatingDockVisible = !floatingDockVisible"
+        />
+      </view>
+    </view>
+
+    <!-- Anchored Linear-style dock — rendered at the section root so the
+         fixed position is relative to the viewport, not a clipped parent.
+         Wrapped in <VyIslandGroup> so a separate close pill sits to the
+         right of the main dock. Group owns the bottom-of-viewport
+         positioning; member islands stay `position="inline"`.
+         Shares state with the inline preview above. -->
+    <VyIslandGroup v-if="floatingDockVisible" position="bottom" size="lg">
+      <VyIsland
+        v-model:open="dockOpen"
+        v-model:mode="dockMode"
+        v-model:value="dockTab"
+        position="inline"
+        size="lg"
+      >
+        <VyIslandButton value="inbox" icon="icon-park-outline:inbox-in" />
+        <VyIslandButton mode="fullisland" icon="icon-park-outline:search" />
+        <VyIslandButton value="bell" icon="icon-park-outline:remind" />
+        <VyIslandButton expand icon="icon-park-outline:expand-text-input" />
+
+        <template #fullisland>
+          <VyIslandButton reset icon="icon-park-outline:search" label="Search…" />
+          <VyIslandButton reset icon="icon-park-outline:close" />
+        </template>
+
+        <template #expanded="{ close }">
+          <VyIslandButton icon="icon-park-outline:setting" label="Settings" @tap="close" />
+          <VyIslandButton icon="icon-park-outline:help" label="Help" @tap="close" />
+          <VyIslandButton icon="icon-park-outline:logout" label="Sign out" @tap="floatingDockVisible = false" />
+        </template>
+      </VyIsland>
+
+      <!-- Trailing companion island. Free-form contents — close here, but
+           could be a status pill, a chip count, a mini-player, etc. -->
+      <VyIsland position="inline" size="lg">
+        <VyIslandButton icon="icon-park-outline:close" @tap="floatingDockVisible = false" />
+      </VyIsland>
+    </VyIslandGroup>
+  </view>
+</template>

--- a/apps/examples/kit-demo/src/sections/OverlaySection.vue
+++ b/apps/examples/kit-demo/src/sections/OverlaySection.vue
@@ -6,14 +6,23 @@ import {
   VyDrawer,
   VyDropdownMenu,
   VyModal,
-  VyPlaceholder,
   VyPopover,
   VySelect,
+  VySwiper,
 } from '@vyui/kit'
 
 const modalOpen = ref(false)
 const drawerOpen = ref(false)
 const dropdownOpen = ref(false)
+
+// Swiper hosted inside the modal — confirms `useDragGesture` works within the
+// overlay layer (gestures aren't swallowed by the backdrop / portal).
+const modalSwiperIndex = ref(0)
+const modalSlides = [
+  { label: 'Slide 1', tint: 'bg-sky-500' },
+  { label: 'Slide 2', tint: 'bg-violet-500' },
+  { label: 'Slide 3', tint: 'bg-emerald-500' },
+]
 
 // Notifications — each entry gets its own popover open state so tapping one
 // reveals its "bit of info" without affecting the others. Replaces the
@@ -76,11 +85,25 @@ const fruitItems = [
   <view class="flex flex-col gap-4 pt-2">
     <view class="bg-white border border-slate-200 rounded-lg p-4 flex flex-col gap-2">
       <text class="text-slate-900 text-base font-semibold">Modal</text>
-      <text class="text-slate-500 text-xs">Dialog with overlay backdrop.</text>
-      <VyModal v-model:open="modalOpen" title="Modal title" description="Anchored over OverlayRoot.">
+      <text class="text-slate-500 text-xs">Dialog with overlay backdrop — hosts an interactive Swiper.</text>
+      <VyModal v-model:open="modalOpen" title="Modal title" description="Drag the carousel below — gestures work inside the dialog.">
         <VyButton color="neutral" variant="subtle" label="Open modal" />
         <template #content>
-          <VyPlaceholder class="h-48 m-4" />
+          <view class="flex flex-col gap-3 p-4">
+            <VySwiper
+              v-model="modalSwiperIndex"
+              :items="modalSlides"
+              :item-width="260"
+              show-indicators
+            >
+              <template #item="{ item }">
+                <view :class="['h-32 rounded-lg flex items-center justify-center', item.tint]" :style="{ width: '244px' }">
+                  <text class="text-white text-lg font-bold">{{ item.label }}</text>
+                </view>
+              </template>
+            </VySwiper>
+            <text class="text-slate-500 text-xs">Active: {{ modalSwiperIndex + 1 }} / {{ modalSlides.length }}</text>
+          </view>
         </template>
       </VyModal>
     </view>

--- a/apps/examples/linear-demo/src/sections/BottomDock.vue
+++ b/apps/examples/linear-demo/src/sections/BottomDock.vue
@@ -23,28 +23,20 @@ const isTakeover = computed(() => isSearchMode.value || dockOpen.value)
 </script>
 
 <template>
-  <!-- See TopBar.vue for the inline-style rationale — Lynx ignores tailwind
-       `fixed` on IslandGroup so we pin via inline `style` instead. The `gap-2`
-       :ui override tightens spacing between the main dock and trailing AI
-       pill (default `lg` group gap reads as too airy here). -->
+  <!-- `position="bottom"` floats the group fixed over the viewport (the
+       component owns the Lynx-safe inline positioning). The `gap-2` :ui
+       override tightens spacing between the main dock and trailing AI pill
+       (default `lg` group gap reads as too airy here). -->
   <VyIslandGroup
-    position="inline"
+    position="bottom"
     size="lg"
     :ui="{ root: 'gap-2' }"
-    :style="{
-      position: 'fixed',
-      bottom: '16px',
-      left: '0',
-      right: '0',
-      zIndex: 50,
-      justifyContent: 'center',
-    }"
   >
     <VyIsland
       v-model:mode="dockMode"
       v-model:value="tab"
       v-model:open="dockOpen"
-      position="inline"
+      layer="inline"
       size="lg"
       expand-style="attached"
       :style="isSearchMode
@@ -103,7 +95,7 @@ const isTakeover = computed(() => isSearchMode.value || dockOpen.value)
          focused surface. -->
     <VyIsland
       v-if="!isTakeover"
-      position="inline"
+      layer="inline"
       size="lg"
       :ui="{ row: 'px-0 py-2' }"
     >

--- a/apps/examples/linear-demo/src/sections/TopBar.vue
+++ b/apps/examples/linear-demo/src/sections/TopBar.vue
@@ -12,7 +12,7 @@ import AccountMenu from '../components/AccountMenu.vue'
        there's only one — pinning the island itself lets us offset it from
        the top-right corner exactly. Adjust `top` / `right` here to nudge. -->
   <VyIsland
-    position="inline"
+    layer="inline"
     size="sm"
     :style="{
       position: 'fixed',

--- a/packages/core/src/components/AspectRatio/AspectRatio.story.vue
+++ b/packages/core/src/components/AspectRatio/AspectRatio.story.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { AspectRatio } from '.'
+</script>
+
+<template>
+  <Story
+    title="AspectRatio/Demo"
+    :layout="{ type: 'single', iframe: true }"
+  >
+    <Variant title="16/9">
+      <div class="w-[300px]">
+        <AspectRatio
+          :ratio="16 / 9"
+          class="bg-[#d7cff9] rounded-md overflow-hidden"
+        >
+          <image
+            src="https://images.unsplash.com/photo-1535025183041-0991a977e25b?w=300&dpr=2&q=80"
+            class="w-full h-full"
+            mode="aspectFill"
+          />
+        </AspectRatio>
+      </div>
+    </Variant>
+
+    <Variant title="1/1 (default)">
+      <div class="w-[200px]">
+        <AspectRatio class="bg-[#d7cff9] rounded-md">
+          <text>1:1</text>
+        </AspectRatio>
+      </div>
+    </Variant>
+  </Story>
+</template>

--- a/packages/core/src/components/AspectRatio/AspectRatioRoot.test.ts
+++ b/packages/core/src/components/AspectRatio/AspectRatioRoot.test.ts
@@ -1,4 +1,3 @@
-// Adapted from reka-ui (MIT) — https://github.com/unovue/reka-ui
 import { describe, expect, it } from 'vitest'
 import { render } from '@vyui/testing-utils'
 import * as Exports from '.'
@@ -13,21 +12,21 @@ describe('AspectRatio', () => {
 
   it('defaults to a 1:1 ratio via the native aspect-ratio CSS property', () => {
     const { container } = render(AspectRatio)
-    const el = container.querySelector('[data-reka-aspect-ratio]')!
-    expect(el.getAttribute('data-reka-aspect-ratio')).toBe('1')
+    const el = container.querySelector('[data-vyui-aspect-ratio]')!
+    expect(el.getAttribute('data-vyui-aspect-ratio')).toBe('1')
     expect(el.getAttribute('style') ?? '').toContain('aspect-ratio: 1')
   })
 
   it('reflects a custom ratio on the element', () => {
     const { container } = render(AspectRatio, { ratio: 16 / 9 })
-    const el = container.querySelector('[data-reka-aspect-ratio]')!
-    expect(el.getAttribute('data-reka-aspect-ratio')).toBe(String(16 / 9))
+    const el = container.querySelector('[data-vyui-aspect-ratio]')!
+    expect(el.getAttribute('data-vyui-aspect-ratio')).toBe(String(16 / 9))
     expect(el.getAttribute('style') ?? '').toContain(`aspect-ratio: ${16 / 9}`)
   })
 
   it('does not emit a padding-bottom wrapper (Lynx uses native aspect-ratio)', () => {
     const { container } = render(AspectRatio, { ratio: 16 / 9 })
-    expect(container.querySelector('[data-reka-aspect-ratio-wrapper]')).toBeNull()
+    expect(container.querySelector('[data-vyui-aspect-ratio-wrapper]')).toBeNull()
     expect(container.innerHTML).not.toContain('padding-bottom')
   })
 

--- a/packages/core/src/components/AspectRatio/AspectRatioRoot.test.ts
+++ b/packages/core/src/components/AspectRatio/AspectRatioRoot.test.ts
@@ -1,0 +1,38 @@
+// Adapted from reka-ui (MIT) — https://github.com/unovue/reka-ui
+import { describe, expect, it } from 'vitest'
+import { render } from '@vyui/testing-utils'
+import * as Exports from '.'
+import AspectRatio from './story/_AspectRatio.vue'
+
+describe('AspectRatio', () => {
+  it('exports AspectRatioRoot and the AspectRatio alias', () => {
+    expect(Exports.AspectRatioRoot).toBeDefined()
+    expect(Exports.AspectRatio).toBeDefined()
+    expect(Exports.AspectRatio).toBe(Exports.AspectRatioRoot)
+  })
+
+  it('defaults to a 1:1 ratio via the native aspect-ratio CSS property', () => {
+    const { container } = render(AspectRatio)
+    const el = container.querySelector('[data-reka-aspect-ratio]')!
+    expect(el.getAttribute('data-reka-aspect-ratio')).toBe('1')
+    expect(el.getAttribute('style') ?? '').toContain('aspect-ratio: 1')
+  })
+
+  it('reflects a custom ratio on the element', () => {
+    const { container } = render(AspectRatio, { ratio: 16 / 9 })
+    const el = container.querySelector('[data-reka-aspect-ratio]')!
+    expect(el.getAttribute('data-reka-aspect-ratio')).toBe(String(16 / 9))
+    expect(el.getAttribute('style') ?? '').toContain(`aspect-ratio: ${16 / 9}`)
+  })
+
+  it('does not emit a padding-bottom wrapper (Lynx uses native aspect-ratio)', () => {
+    const { container } = render(AspectRatio, { ratio: 16 / 9 })
+    expect(container.querySelector('[data-reka-aspect-ratio-wrapper]')).toBeNull()
+    expect(container.innerHTML).not.toContain('padding-bottom')
+  })
+
+  it('renders default slot content', () => {
+    const { container } = render(AspectRatio)
+    expect(container.innerHTML).toContain('slot-content')
+  })
+})

--- a/packages/core/src/components/AspectRatio/AspectRatioRoot.test.ts
+++ b/packages/core/src/components/AspectRatio/AspectRatioRoot.test.ts
@@ -17,6 +17,12 @@ describe('AspectRatio', () => {
     expect(el.getAttribute('style') ?? '').toContain('aspect-ratio: 1')
   })
 
+  it('defaults to width: 100% so the ratio has a definite dimension to size from', () => {
+    const { container } = render(AspectRatio)
+    const el = container.querySelector('[data-vyui-aspect-ratio]')!
+    expect(el.getAttribute('style') ?? '').toContain('width: 100%')
+  })
+
   it('reflects a custom ratio on the element', () => {
     const { container } = render(AspectRatio, { ratio: 16 / 9 })
     const el = container.querySelector('[data-vyui-aspect-ratio]')!

--- a/packages/core/src/components/AspectRatio/AspectRatioRoot.vue
+++ b/packages/core/src/components/AspectRatio/AspectRatioRoot.vue
@@ -1,23 +1,18 @@
 <script lang="ts">
-// Ported from reka-ui (MIT) — https://github.com/unovue/reka-ui
+// Constrains content to a fixed width-to-height ratio.
 //
-// LYNX MECHANISM — uses the native CSS `aspect-ratio` property, NOT reka-ui's
-// DOM padding-bottom-percentage hack.
-//
-// reka-ui's web AspectRatio wraps content in an absolutely-positioned box inside
-// a `padding-bottom: (1/ratio)*100%` parent. That hack exists only because older
-// browsers lacked `aspect-ratio`. Lynx's layout engine (Starlight, flexbox by
-// default) supports the `aspect-ratio` CSS property directly — it is listed as a
-// settable property in `@lynx-js/types` (`csstype.d.ts` Property union: `aspectRatio`).
-//
-// So we render a single `<view>` with `aspect-ratio: <ratio>` and no wrapper:
-//   - no `position: absolute`/`inset: 0` content (Lynx percentage padding resolves
-//     differently and absolute positioning would fight the default flex layout),
+// Lynx's layout engine (Starlight, flexbox by default) supports the `aspect-ratio`
+// CSS property directly — it is a settable property in `@lynx-js/types`
+// (`csstype.d.ts` Property union: `aspectRatio`). So we render a single `<view>`
+// with `aspect-ratio: <ratio>` and no wrapper:
+//   - no `position: absolute`/`inset: 0` content (percentage padding resolves
+//     against parent width and absolute positioning would fight the default flex
+//     layout),
 //   - cleaner DOM (one element instead of two),
 //   - the element sizes itself to the parent width and derives height from `ratio`.
 //
 // The default slot still receives `aspect` (the computed 1/ratio*100 percentage)
-// to keep the public API identical to reka-ui for ported call-sites.
+// for call-sites that want the raw percentage.
 import type { PrimitiveProps } from '@/components/Primitive'
 import { useForwardExpose } from '@/shared'
 
@@ -56,7 +51,7 @@ const aspect = computed(() => (1 / props.ratio) * 100)
     :ref="forwardRef"
     :as-child="asChild"
     :as="as"
-    :data-reka-aspect-ratio="ratio"
+    :data-vyui-aspect-ratio="ratio"
     :style="{ aspectRatio: `${ratio}` }"
   >
     <slot :aspect="aspect" />

--- a/packages/core/src/components/AspectRatio/AspectRatioRoot.vue
+++ b/packages/core/src/components/AspectRatio/AspectRatioRoot.vue
@@ -11,6 +11,13 @@
 //   - cleaner DOM (one element instead of two),
 //   - the element sizes itself to the parent width and derives height from `ratio`.
 //
+// `aspect-ratio` only derives the missing dimension when ONE dimension is
+// definite. Browsers infer a stretched element's width as definite; Lynx's
+// layout engine does not, so a width-less box can't solve its height and falls
+// back to content height. We therefore default `width: 100%` (fills the
+// container, the common case) — override `width` if you instead want to size by
+// a fixed height and derive width.
+//
 // The default slot still receives `aspect` (the computed 1/ratio*100 percentage)
 // for call-sites that want the raw percentage.
 import type { PrimitiveProps } from '@/components/Primitive'
@@ -52,7 +59,7 @@ const aspect = computed(() => (1 / props.ratio) * 100)
     :as-child="asChild"
     :as="as"
     :data-vyui-aspect-ratio="ratio"
-    :style="{ aspectRatio: `${ratio}` }"
+    :style="{ width: '100%', aspectRatio: `${ratio}` }"
   >
     <slot :aspect="aspect" />
   </Primitive>

--- a/packages/core/src/components/AspectRatio/AspectRatioRoot.vue
+++ b/packages/core/src/components/AspectRatio/AspectRatioRoot.vue
@@ -1,0 +1,64 @@
+<script lang="ts">
+// Ported from reka-ui (MIT) — https://github.com/unovue/reka-ui
+//
+// LYNX MECHANISM — uses the native CSS `aspect-ratio` property, NOT reka-ui's
+// DOM padding-bottom-percentage hack.
+//
+// reka-ui's web AspectRatio wraps content in an absolutely-positioned box inside
+// a `padding-bottom: (1/ratio)*100%` parent. That hack exists only because older
+// browsers lacked `aspect-ratio`. Lynx's layout engine (Starlight, flexbox by
+// default) supports the `aspect-ratio` CSS property directly — it is listed as a
+// settable property in `@lynx-js/types` (`csstype.d.ts` Property union: `aspectRatio`).
+//
+// So we render a single `<view>` with `aspect-ratio: <ratio>` and no wrapper:
+//   - no `position: absolute`/`inset: 0` content (Lynx percentage padding resolves
+//     differently and absolute positioning would fight the default flex layout),
+//   - cleaner DOM (one element instead of two),
+//   - the element sizes itself to the parent width and derives height from `ratio`.
+//
+// The default slot still receives `aspect` (the computed 1/ratio*100 percentage)
+// to keep the public API identical to reka-ui for ported call-sites.
+import type { PrimitiveProps } from '@/components/Primitive'
+import { useForwardExpose } from '@/shared'
+
+export interface AspectRatioRootProps extends PrimitiveProps {
+  /**
+   * The desired ratio. Eg: 16/9
+   * @defaultValue 1
+   */
+  ratio?: number
+}
+</script>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { Primitive } from '@/components/Primitive'
+
+const props = withDefaults(defineProps<AspectRatioRootProps>(), {
+  ratio: 1,
+  as: 'view',
+})
+
+defineSlots<{
+  default?: (props: {
+    /** Current aspect ratio (in %) */
+    aspect: typeof aspect.value
+  }) => any
+}>()
+
+const { forwardRef } = useForwardExpose()
+
+const aspect = computed(() => (1 / props.ratio) * 100)
+</script>
+
+<template>
+  <Primitive
+    :ref="forwardRef"
+    :as-child="asChild"
+    :as="as"
+    :data-reka-aspect-ratio="ratio"
+    :style="{ aspectRatio: `${ratio}` }"
+  >
+    <slot :aspect="aspect" />
+  </Primitive>
+</template>

--- a/packages/core/src/components/AspectRatio/index.ts
+++ b/packages/core/src/components/AspectRatio/index.ts
@@ -1,0 +1,6 @@
+export {
+  default as AspectRatio,
+  default as AspectRatioRoot,
+  type AspectRatioRootProps,
+  type AspectRatioRootProps as AspectRatioProps,
+} from './AspectRatioRoot.vue'

--- a/packages/core/src/components/AspectRatio/story/_AspectRatio.vue
+++ b/packages/core/src/components/AspectRatio/story/_AspectRatio.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import type { AspectRatioRootProps } from '..'
+import { AspectRatio } from '..'
+
+const props = defineProps<AspectRatioRootProps>()
+</script>
+
+<template>
+  <AspectRatio v-bind="props">
+    <text>slot-content</text>
+  </AspectRatio>
+</template>

--- a/packages/core/src/components/Avatar/Avatar.story.vue
+++ b/packages/core/src/components/Avatar/Avatar.story.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { AvatarFallback, AvatarImage, AvatarRoot } from '.'
+</script>
+
+<template>
+  <Story
+    title="Avatar/Demo"
+    :layout="{ type: 'single', iframe: true }"
+  >
+    <Variant title="With image">
+      <AvatarRoot class="inline-flex items-center justify-center w-12 h-12 rounded-full overflow-hidden bg-black/20">
+        <AvatarImage src="https://github.com/vuejs.png" />
+        <AvatarFallback class="text-white text-sm">
+          <text>VU</text>
+        </AvatarFallback>
+      </AvatarRoot>
+    </Variant>
+
+    <Variant title="Fallback (no src)">
+      <AvatarRoot class="inline-flex items-center justify-center w-12 h-12 rounded-full overflow-hidden bg-black/20">
+        <AvatarImage />
+        <AvatarFallback class="text-white text-sm">
+          <text>AB</text>
+        </AvatarFallback>
+      </AvatarRoot>
+    </Variant>
+
+    <Variant title="Fallback (broken src) with delay">
+      <AvatarRoot class="inline-flex items-center justify-center w-12 h-12 rounded-full overflow-hidden bg-black/20">
+        <AvatarImage src="https://example.com/does-not-exist.png" />
+        <AvatarFallback :delay-ms="600" class="text-white text-sm">
+          <text>CD</text>
+        </AvatarFallback>
+      </AvatarRoot>
+    </Variant>
+  </Story>
+</template>

--- a/packages/core/src/components/Avatar/Avatar.test.ts
+++ b/packages/core/src/components/Avatar/Avatar.test.ts
@@ -1,0 +1,64 @@
+import { createEvent } from '@testing-library/dom'
+import { describe, expect, it } from 'vitest'
+import { fireEvent, render, waitForUpdate } from '@vyui/testing-utils'
+import _Avatar from './story/_Avatar.vue'
+
+function image(container: Element) {
+  return container.querySelector('[data-testid="image"]') as Element | null
+}
+function fallback(container: Element) {
+  return container.querySelector('[data-testid="fallback"]') as Element | null
+}
+
+/**
+ * Dispatch the native Lynx `binderror` event (bound in Vue as `@error`).
+ * Lynx routes events as `bindEvent:<name>`, so a bare `error` Event won't reach
+ * the handler (and would trip jsdom's special-cased window error path). Mirror
+ * the keyed `fireEvent.*` path used for `tap` / `input` with `eventName: error`.
+ */
+function fireImageError(el: Element) {
+  const eventInit = { eventType: 'bindEvent', eventName: 'error' }
+  const event = createEvent('bindEvent:error', el, eventInit)
+  Object.assign(event, eventInit)
+  fireEvent(el, event)
+}
+
+describe('Avatar — image / fallback', () => {
+  it('renders the image and hides the fallback when src loads', () => {
+    const { container } = render(_Avatar, { src: 'https://example.com/a.png', fallback: 'AB' })
+    expect(image(container)).not.toBeNull()
+    expect(fallback(container)).toBeNull()
+  })
+
+  it('shows the fallback when there is no src', () => {
+    const { container } = render(_Avatar, { fallback: 'AB' })
+    expect(image(container)).toBeNull()
+    expect(fallback(container)).not.toBeNull()
+  })
+
+  it('falls back to the fallback content when the image errors', async () => {
+    const { container } = render(_Avatar, { src: 'https://example.com/bad.png', fallback: 'AB' })
+    const img = image(container)
+    expect(img).not.toBeNull()
+    fireImageError(img!)
+    await waitForUpdate()
+    expect(image(container)).toBeNull()
+    expect(fallback(container)).not.toBeNull()
+  })
+})
+
+describe('Avatar — delayMs', () => {
+  it('shows the fallback immediately when delayMs is 0', () => {
+    const { container } = render(_Avatar, { fallback: 'AB', delayMs: 0 })
+    expect(fallback(container)).not.toBeNull()
+  })
+
+  it('delays rendering the fallback when delayMs > 0', async () => {
+    const { container } = render(_Avatar, { fallback: 'AB', delayMs: 50 })
+    // Not yet visible right after mount.
+    expect(fallback(container)).toBeNull()
+    await new Promise(resolve => setTimeout(resolve, 80))
+    await waitForUpdate()
+    expect(fallback(container)).not.toBeNull()
+  })
+})

--- a/packages/core/src/components/Avatar/AvatarFallback.vue
+++ b/packages/core/src/components/Avatar/AvatarFallback.vue
@@ -1,0 +1,56 @@
+<script lang="ts">
+import type { PrimitiveProps } from '@/components/Primitive'
+
+export interface AvatarFallbackProps extends PrimitiveProps {
+  /**
+   * Delay, in milliseconds, before the fallback is shown. Useful to avoid a
+   * flash of fallback content while a fast image loads. Defaults to `0` (show
+   * immediately when there is no loaded image).
+   */
+  delayMs?: number
+}
+</script>
+
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref } from 'vue'
+import { Primitive } from '@/components/Primitive'
+import { useForwardExpose } from '@/shared'
+import { injectAvatarRootContext } from './AvatarRoot.vue'
+
+const props = withDefaults(defineProps<AvatarFallbackProps>(), {
+  as: 'view',
+  delayMs: 0,
+})
+
+defineSlots<{
+  default?: (props: {}) => any
+}>()
+
+const { imageLoadingStatus } = injectAvatarRootContext()
+useForwardExpose()
+
+// Gate rendering behind `delayMs`: only after the timer elapses can the
+// fallback paint. With `delayMs === 0` this resolves synchronously on mount.
+const canRender = ref(props.delayMs === 0)
+let timer: ReturnType<typeof setTimeout> | undefined
+
+onMounted(() => {
+  if (props.delayMs > 0)
+    timer = setTimeout(() => { canRender.value = true }, props.delayMs)
+})
+
+onUnmounted(() => {
+  if (timer)
+    clearTimeout(timer)
+})
+</script>
+
+<template>
+  <Primitive
+    v-if="canRender && imageLoadingStatus !== 'loaded'"
+    :as="as"
+    :as-child="asChild"
+  >
+    <slot />
+  </Primitive>
+</template>

--- a/packages/core/src/components/Avatar/AvatarImage.vue
+++ b/packages/core/src/components/Avatar/AvatarImage.vue
@@ -1,0 +1,52 @@
+<script lang="ts">
+import type { ImageLoadingStatus } from './AvatarRoot.vue'
+
+export interface AvatarImageProps {
+  /** Image source URL. Renders a Lynx `<image>`. */
+  src?: string
+}
+
+export type AvatarImageEmits = {
+  /** Fires whenever the load status transitions (`loading` → `loaded` | `error`). */
+  loadingStatusChange: [status: ImageLoadingStatus]
+}
+</script>
+
+<script setup lang="ts">
+import { watch } from 'vue'
+import { useForwardExpose } from '@/shared'
+import { injectAvatarRootContext } from './AvatarRoot.vue'
+
+const props = defineProps<AvatarImageProps>()
+const emit = defineEmits<AvatarImageEmits>()
+
+const { imageLoadingStatus } = injectAvatarRootContext()
+useForwardExpose()
+
+function setStatus(status: ImageLoadingStatus) {
+  if (imageLoadingStatus.value === status)
+    return
+  imageLoadingStatus.value = status
+  emit('loadingStatusChange', status)
+}
+
+// Lynx `<image>` has no dependable `load` event, so we optimistically treat a
+// present `src` as `loaded` and only fall back to `error` when the native
+// `binderror` (`@error`) fires. An absent `src` is `error` so the fallback
+// shows. Re-evaluated whenever `src` changes so a fresh URL gets a new attempt.
+watch(() => props.src, (src) => {
+  setStatus(src ? 'loaded' : 'error')
+}, { immediate: true })
+
+function onError() {
+  setStatus('error')
+}
+</script>
+
+<template>
+  <image
+    v-if="src && imageLoadingStatus !== 'error'"
+    :src="src"
+    @error="onError"
+  />
+</template>

--- a/packages/core/src/components/Avatar/AvatarRoot.vue
+++ b/packages/core/src/components/Avatar/AvatarRoot.vue
@@ -1,0 +1,47 @@
+<script lang="ts">
+import type { Ref } from 'vue'
+import type { PrimitiveProps } from '@/components/Primitive'
+import { createContext } from '@/shared'
+
+/** Load lifecycle of the avatar image, mirroring reka-ui's `ImageLoadingStatus`. */
+export type ImageLoadingStatus = 'idle' | 'loading' | 'loaded' | 'error'
+
+export interface AvatarRootProps extends PrimitiveProps {}
+
+export interface AvatarRootContext {
+  /** Current image load status. `AvatarImage` writes it; `AvatarFallback` reads it. */
+  imageLoadingStatus: Ref<ImageLoadingStatus>
+}
+
+export const [injectAvatarRootContext, provideAvatarRootContext]
+  = createContext<AvatarRootContext>('AvatarRoot')
+</script>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { Primitive } from '@/components/Primitive'
+import { useForwardExpose } from '@/shared'
+
+withDefaults(defineProps<AvatarRootProps>(), {
+  as: 'view',
+})
+
+defineSlots<{
+  default?: (props: {}) => any
+}>()
+
+useForwardExpose()
+
+// `idle` until an `AvatarImage` mounts and begins loading. On Lynx there is no
+// reliable `load` event, so `AvatarImage` optimistically flips this to `loaded`
+// and only downgrades to `error` when the native `binderror` (`@error`) fires.
+const imageLoadingStatus = ref<ImageLoadingStatus>('idle')
+
+provideAvatarRootContext({ imageLoadingStatus })
+</script>
+
+<template>
+  <Primitive :as="as" :as-child="asChild">
+    <slot />
+  </Primitive>
+</template>

--- a/packages/core/src/components/Avatar/index.ts
+++ b/packages/core/src/components/Avatar/index.ts
@@ -1,0 +1,16 @@
+export {
+  injectAvatarRootContext,
+  type AvatarRootContext,
+  default as AvatarRoot,
+  type AvatarRootProps,
+  type ImageLoadingStatus,
+} from './AvatarRoot.vue'
+export {
+  default as AvatarImage,
+  type AvatarImageEmits,
+  type AvatarImageProps,
+} from './AvatarImage.vue'
+export {
+  default as AvatarFallback,
+  type AvatarFallbackProps,
+} from './AvatarFallback.vue'

--- a/packages/core/src/components/Avatar/story/_Avatar.vue
+++ b/packages/core/src/components/Avatar/story/_Avatar.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import {
+  AvatarFallback,
+  AvatarImage,
+  AvatarRoot,
+} from '..'
+
+defineProps<{
+  src?: string
+  fallback?: string
+  delayMs?: number
+}>()
+</script>
+
+<template>
+  <AvatarRoot data-testid="root">
+    <AvatarImage
+      :src="src"
+      data-testid="image"
+    />
+    <AvatarFallback
+      :delay-ms="delayMs"
+      data-testid="fallback"
+    >
+      <text>{{ fallback }}</text>
+    </AvatarFallback>
+  </AvatarRoot>
+</template>

--- a/packages/core/src/components/Swiper/SwiperRoot.vue
+++ b/packages/core/src/components/Swiper/SwiperRoot.vue
@@ -69,7 +69,7 @@ provideSwiperRootContext({
 </script>
 
 <template>
-  <view class="vyui-swiper" data-vyui-swiper-root :style="{ overflow: 'hidden' }">
+  <view class="vyui-swiper" data-vyui-swiper-root :style="{ overflow: 'hidden', position: 'relative' }">
     <view
       class="vyui-swiper__track"
       :main-thread-ref="containerRef"
@@ -81,5 +81,8 @@ provideSwiperRootContext({
     >
       <slot />
     </view>
+    <!-- Overlay content (e.g. indicators) lives outside the track so the
+         track's drag transform doesn't drag it along — it stays fixed. -->
+    <slot name="overlay" />
   </view>
 </template>

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -32,6 +32,12 @@ export const components = {
     'AlertDialogDescription',
   ] as const,
 
+  avatar: [
+    'AvatarRoot',
+    'AvatarImage',
+    'AvatarFallback',
+  ] as const,
+
   checkbox: [
     'CheckboxGroupRoot',
     'CheckboxRoot',

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -32,6 +32,10 @@ export const components = {
     'AlertDialogDescription',
   ] as const,
 
+  aspectRatio: [
+    'AspectRatioRoot',
+  ] as const,
+
   checkbox: [
     'CheckboxGroupRoot',
     'CheckboxRoot',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,6 +27,7 @@ export * from './components/IslandContainer'
 
 // Disclosure + universal Phase 1 components
 export * from './components/Accordion'
+export * from './components/Avatar'
 export * from './components/Checkbox'
 export * from './components/Collapsible'
 export * from './components/Label'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,6 +27,7 @@ export * from './components/IslandContainer'
 
 // Disclosure + universal Phase 1 components
 export * from './components/Accordion'
+export * from './components/AspectRatio'
 export * from './components/Checkbox'
 export * from './components/Collapsible'
 export * from './components/Label'

--- a/packages/kit/src/components/Avatar.vue
+++ b/packages/kit/src/components/Avatar.vue
@@ -55,9 +55,14 @@ export const AVATAR_GROUP_KEY: InjectionKey<AvatarGroupContext> = Symbol('vyui:a
 </script>
 
 <script setup lang="ts">
-import { computed, inject, ref, watch } from 'vue'
+import { computed, inject } from 'vue'
 import { useAppConfig } from '../composables/useAppConfig'
-import { Icon as VyIcon } from '@vyui/core'
+import {
+  AvatarFallback as CoreAvatarFallback,
+  AvatarImage as CoreAvatarImage,
+  AvatarRoot as CoreAvatarRoot,
+  Icon as VyIcon,
+} from '@vyui/core'
 import VyChip from './Chip.vue'
 
 const props = withDefaults(defineProps<AvatarProps>(), {})
@@ -95,36 +100,34 @@ const ui = computed(() => buildAvatar(appConfig)({
   size: resolvedSize.value,
   color: resolvedColor.value,
 }))
-
-// Lynx `<image>` fires `binderror` (bound as `@error`) when the source fails
-// to load. Track it so we fall back to initials/icon instead of a broken
-// image. Reset whenever `src` changes so a new URL gets a fresh attempt.
-const imageLoadError = ref(false)
-watch(() => props.src, () => { imageLoadError.value = false })
-const showImage = computed(() => !!props.src && !imageLoadError.value)
 </script>
 
 <template>
-  <view :class="[ui.root({ class: [props.class, props.ui?.root] }), chip ? 'relative' : '']">
+  <!--
+    Headless behaviour (image load-status + fallback) comes from @vyui/core's
+    Avatar primitives. The Lynx `<image>` `binderror` (`@error`) handling lives
+    in `CoreAvatarImage`; this wrapper only layers theming + chip overlay.
+  -->
+  <CoreAvatarRoot :class="[ui.root({ class: [props.class, props.ui?.root] }), chip ? 'relative' : '']">
     <slot>
-      <image
-        v-if="showImage"
+      <CoreAvatarImage
         :src="src"
         :class="ui.image({ class: props.ui?.image })"
-        @error="imageLoadError = true"
       />
-      <slot v-else name="fallback">
-        <text
-          v-if="fallbackText"
-          :class="ui.text({ class: props.ui?.text })"
-        >{{ fallbackText }}</text>
-        <VyIcon
-          v-else-if="icon"
-          :name="icon"
-          :class="ui.icon({ class: props.ui?.icon })"
-        />
-      </slot>
+      <CoreAvatarFallback>
+        <slot name="fallback">
+          <text
+            v-if="fallbackText"
+            :class="ui.text({ class: props.ui?.text })"
+          >{{ fallbackText }}</text>
+          <VyIcon
+            v-else-if="icon"
+            :name="icon"
+            :class="ui.icon({ class: props.ui?.icon })"
+          />
+        </slot>
+      </CoreAvatarFallback>
     </slot>
     <VyChip v-if="resolvedChipProps" v-bind="resolvedChipProps" />
-  </view>
+  </CoreAvatarRoot>
 </template>

--- a/packages/kit/src/components/Island.vue
+++ b/packages/kit/src/components/Island.vue
@@ -62,11 +62,23 @@ export interface IslandProps {
   /** Initial value when uncontrolled. */
   defaultValue?: string | number | null
   /**
-   * Placement variant. `inline` opts out of fixed positioning for embedded
-   * layouts (e.g. two top islands side-by-side).
+   * Which viewport edge to float against — only relevant when the island is
+   * floating (`layer !== 'inline'`). Works on Lynx via an inline `style`, so a
+   * lone `<VyIsland>` hovers with no wrapper. Also sets the panel growth
+   * direction (panel grows away from the edge).
    * @defaultValue `'bottom'`
    */
   position?: IslandVariants['position']
+  /**
+   * How the island participates in layout / stacking — the primary axis.
+   *  - `overlay` — floats over page content (z-50).
+   *  - `base` — floats at the viewport edge but on a low layer, so
+   *    higher-tier surfaces (drawers, modals) render over it.
+   *  - `inline` — sits in normal flow; a parent layout (or `<VyIslandGroup>`)
+   *    owns placement. `position` is ignored.
+   * @defaultValue `'overlay'`
+   */
+  layer?: 'overlay' | 'base' | 'inline'
   /**
    * How the expanded panel relates visually to the row:
    *  - `floating` — panel and row are independent surfaces with a gap
@@ -130,6 +142,7 @@ const props = withDefaults(defineProps<IslandProps>(), {
   defaultOpen: false,
   defaultMode: 'default',
   defaultValue: null,
+  layer: 'overlay',
   as: 'view',
 })
 const emit = defineEmits<IslandEmits>()
@@ -219,6 +232,21 @@ const isOpen = computed(() => hasExpanded.value && resolvedOpen.value)
 // `position="top"` flips it to grow downward.
 const panelAbove = computed(() => props.position !== 'top')
 
+// Lynx ignores tailwind `fixed`, so floating islands are pinned via an inline
+// `style` (which Lynx respects) — a lone island floats with no wrapper. The
+// strip spans full-width; inline `alignItems` centers the pill within it.
+// `layer="inline"` returns no style so a parent layout owns placement; `base`
+// drops the island to a low z so modals/drawers cover it. Any caller-passed
+// `style` merges over this via attr fallthrough.
+const positionStyle = computed(() => {
+  if (props.layer === 'inline') return undefined
+  const zIndex = props.layer === 'base' ? 10 : 50
+  if (props.position === 'top') {
+    return { position: 'fixed', top: '16px', left: '0', right: '0', zIndex, alignItems: 'center' } as const
+  }
+  return { position: 'fixed', bottom: '16px', left: '0', right: '0', zIndex, alignItems: 'center' } as const
+})
+
 const slotProps = computed(() => ({
   open: isOpen.value,
   mode: resolvedMode.value,
@@ -246,6 +274,7 @@ const { ui } = useStyledComponent('island', theme, () => ({
     :data-state="isOpen ? 'open' : 'closed'"
     :data-mode="resolvedMode"
     :class="ui.root({ class: [props.class, props.ui?.root] })"
+    :style="positionStyle"
   >
     <view
       v-if="isOpen && panelAbove"

--- a/packages/kit/src/components/Island.vue
+++ b/packages/kit/src/components/Island.vue
@@ -122,7 +122,7 @@ export interface IslandSlots {
 </script>
 
 <script setup lang="ts">
-import { computed, ref, toRef, useSlots } from 'vue'
+import { Comment, computed, Fragment, ref, Text, toRef, useSlots, type VNode } from 'vue'
 import { useStyledComponent } from '../composables/useStyledComponent'
 import { provideIslandContext, type IslandSize } from './islandContext'
 
@@ -191,6 +191,27 @@ const activeRowSlot = computed(() => {
   return name
 })
 
+// Count the *renderable* children of a slot — skips comment nodes (e.g. a
+// `v-if` that's false) and whitespace-only text so a single real button still
+// counts as one. Recurses into fragments (a `v-for` or grouped children).
+function countRenderable(nodes: VNode[] | undefined): number {
+  let n = 0
+  for (const node of nodes ?? []) {
+    if (node.type === Comment) continue
+    if (node.type === Text && (typeof node.children !== 'string' || !node.children.trim())) continue
+    if (node.type === Fragment) { n += countRenderable(node.children as VNode[]); continue }
+    n++
+  }
+  return n
+}
+
+// `solo` → the active row renders a single child. Drives the tight symmetric
+// padding (theme `solo` variant) so a lone icon button reads as one circle.
+const isSolo = computed(() => {
+  const fn = slots[activeRowSlot.value]
+  return fn ? countRenderable(fn(slotProps.value)) === 1 : false
+})
+
 const hasExpanded = computed(() => !!slots.expanded)
 const isOpen = computed(() => hasExpanded.value && resolvedOpen.value)
 
@@ -215,6 +236,7 @@ const { ui } = useStyledComponent('island', theme, () => ({
   size: resolvedSize.value,
   expandStyle: props.expandStyle,
   open: isOpen.value,
+  solo: isSolo.value,
 }))
 </script>
 

--- a/packages/kit/src/components/IslandButton.vue
+++ b/packages/kit/src/components/IslandButton.vue
@@ -112,6 +112,14 @@ const effectiveSize = computed<IslandSize | undefined>(
   () => props.size ?? island?.size.value,
 )
 
+// Icon pixel size per island size. The core `<VyIcon>` bakes width/height as
+// an inline style (overriding any `size-*` utility class), so the glyph size
+// has to be passed as the numeric `size` prop — not via the theme's
+// `leadingIcon` class. Values mirror the `size-*` classes in `islandButton.ts`
+// (sm→16, md→20, lg→24, xl→28) for a ~40–45% icon-to-button ratio.
+const ICON_PX = { sm: 16, md: 20, lg: 24, xl: 28 } as const
+const iconPx = computed(() => ICON_PX[(effectiveSize.value ?? 'md') as IslandSize])
+
 // Auto-active when this button's `value` matches the parent island's value.
 // Explicit `active` prop forces it on regardless.
 const effectiveActive = computed(() => {
@@ -149,6 +157,7 @@ function onTap() {
       <VyIcon
         v-if="icon"
         :name="icon"
+        :size="iconPx"
         :class="ui.leadingIcon({ class: props.ui?.leadingIcon })"
       />
     </slot>

--- a/packages/kit/src/components/IslandGroup.vue
+++ b/packages/kit/src/components/IslandGroup.vue
@@ -11,15 +11,15 @@ type IslandGroupVariants = VariantProps<IslandGroupTV>
  * close pill on the right; two top islands stacked left/right).
  *
  * Owns the viewport-anchored positioning so member islands can stay
- * `position="inline"` and focus on their own contents. The companion
+ * `layer="inline"` and focus on their own contents. The companion
  * island's contents are free-form — pass any `<VyIslandButton>`s,
  * indicators, mini-pills, etc.
  *
  * Usage:
  * ```vue
  * <VyIslandGroup position="bottom" size="lg">
- *   <VyIsland position="inline" size="lg">…main dock…</VyIsland>
- *   <VyIsland position="inline" size="lg">
+ *   <VyIsland layer="inline" size="lg">…main dock…</VyIsland>
+ *   <VyIsland layer="inline" size="lg">
  *     <VyIslandButton icon="…" @tap="…" />
  *   </VyIsland>
  * </VyIslandGroup>
@@ -31,18 +31,23 @@ type IslandGroupVariants = VariantProps<IslandGroupTV>
  */
 export interface IslandGroupProps {
   /**
-   * Placement variant.
-   *  - `bottom` / `top` — floats fixed over the viewport (centered by
-   *    default; tweak with `align`). Works on Lynx via an inline `style`,
-   *    so no caller-side positioning workaround is needed.
-   *  - `inline` — opts out of fixed positioning and lets a parent layout
-   *    own placement.
-   *
-   * Override offsets / z-index by passing your own `style`; it merges over
-   * the built-in positioning.
-   * @defaultValue `'inline'`
+   * Which viewport edge to float against — only relevant when the group is
+   * floating (`layer !== 'inline'`). Centered along the cross axis by default
+   * (tweak with `align`). Works on Lynx via an inline `style`, so no
+   * caller-side positioning workaround is needed.
+   * @defaultValue `'bottom'`
    */
   position?: IslandGroupVariants['position']
+  /**
+   * How the group participates in layout / stacking — the primary axis.
+   *  - `overlay` — floats over page content (z-50).
+   *  - `base` — floats at the viewport edge but on a low layer, so
+   *    higher-tier surfaces (drawers, modals) render over it.
+   *  - `inline` — sits in normal flow; a parent layout owns placement.
+   *    `position` is ignored.
+   * @defaultValue `'overlay'`
+   */
+  layer?: 'overlay' | 'base' | 'inline'
   /**
    * Stack direction. `'row'` lays members horizontally; `'col'` vertically.
    * @defaultValue `'row'`
@@ -73,7 +78,9 @@ export interface IslandGroupSlots {
 import { computed } from 'vue'
 import { useStyledComponent } from '../composables/useStyledComponent'
 
-const props = withDefaults(defineProps<IslandGroupProps>(), {})
+const props = withDefaults(defineProps<IslandGroupProps>(), {
+  layer: 'overlay',
+})
 defineSlots<IslandGroupSlots>()
 
 const { ui } = useStyledComponent('islandGroup', theme, () => ({
@@ -83,20 +90,31 @@ const { ui } = useStyledComponent('islandGroup', theme, () => ({
   size: props.size,
 }))
 
-// Lynx ignores tailwind `fixed`, so the `top`/`bottom` theme variants alone
-// leave the group baked into document flow. We pin via an inline `style`
-// (which Lynx respects) so `position="bottom"` floats over the viewport with
-// no caller-side workaround. `inline` opts out and lets a parent layout own
-// positioning. Any caller-passed `style` still merges over this via attr
-// fallthrough, so offsets/z-index stay overridable.
+// `align` → main-axis justification, applied inline (Lynx doesn't pick up the
+// tailwind `justify-*` class, so without this the fixed full-width group hugs
+// the left edge instead of centering).
+const ALIGN_JUSTIFY = {
+  start: 'flex-start',
+  center: 'center',
+  end: 'flex-end',
+  between: 'space-between',
+} as const satisfies Record<NonNullable<IslandGroupProps['align']>, string>
+
+// Lynx ignores tailwind `fixed`, so a floating group is pinned via an inline
+// `style` (which Lynx respects): the strip spans full-width (left:0/right:0),
+// `justifyContent` auto-centers the islands within it, and `alignItems` pins
+// them to the anchored edge. `layer="inline"` returns no style and lets a
+// parent layout own positioning; `base` drops the group to a low z so
+// modals/drawers cover it. Any caller-passed `style` still merges over this
+// via attr fallthrough, so offsets/z-index stay overridable.
 const positionStyle = computed(() => {
-  if (props.position === 'bottom') {
-    return { position: 'fixed', bottom: '16px', left: '0', right: '0', zIndex: 50 } as const
-  }
+  if (props.layer === 'inline') return undefined
+  const justifyContent = ALIGN_JUSTIFY[(props.align ?? 'center') as keyof typeof ALIGN_JUSTIFY]
+  const zIndex = props.layer === 'base' ? 10 : 50
   if (props.position === 'top') {
-    return { position: 'fixed', top: '16px', left: '0', right: '0', zIndex: 50 } as const
+    return { position: 'fixed', top: '16px', left: '0', right: '0', zIndex, justifyContent, alignItems: 'flex-start' } as const
   }
-  return undefined
+  return { position: 'fixed', bottom: '16px', left: '0', right: '0', zIndex, justifyContent, alignItems: 'flex-end' } as const
 })
 </script>
 

--- a/packages/kit/src/components/IslandGroup.vue
+++ b/packages/kit/src/components/IslandGroup.vue
@@ -31,7 +31,15 @@ type IslandGroupVariants = VariantProps<IslandGroupTV>
  */
 export interface IslandGroupProps {
   /**
-   * Placement variant. `inline` lets a parent layout own positioning.
+   * Placement variant.
+   *  - `bottom` / `top` — floats fixed over the viewport (centered by
+   *    default; tweak with `align`). Works on Lynx via an inline `style`,
+   *    so no caller-side positioning workaround is needed.
+   *  - `inline` — opts out of fixed positioning and lets a parent layout
+   *    own placement.
+   *
+   * Override offsets / z-index by passing your own `style`; it merges over
+   * the built-in positioning.
    * @defaultValue `'inline'`
    */
   position?: IslandGroupVariants['position']
@@ -62,6 +70,7 @@ export interface IslandGroupSlots {
 </script>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import { useStyledComponent } from '../composables/useStyledComponent'
 
 const props = withDefaults(defineProps<IslandGroupProps>(), {})
@@ -73,10 +82,29 @@ const { ui } = useStyledComponent('islandGroup', theme, () => ({
   align: props.align,
   size: props.size,
 }))
+
+// Lynx ignores tailwind `fixed`, so the `top`/`bottom` theme variants alone
+// leave the group baked into document flow. We pin via an inline `style`
+// (which Lynx respects) so `position="bottom"` floats over the viewport with
+// no caller-side workaround. `inline` opts out and lets a parent layout own
+// positioning. Any caller-passed `style` still merges over this via attr
+// fallthrough, so offsets/z-index stay overridable.
+const positionStyle = computed(() => {
+  if (props.position === 'bottom') {
+    return { position: 'fixed', bottom: '16px', left: '0', right: '0', zIndex: 50 } as const
+  }
+  if (props.position === 'top') {
+    return { position: 'fixed', top: '16px', left: '0', right: '0', zIndex: 50 } as const
+  }
+  return undefined
+})
 </script>
 
 <template>
-  <view :class="ui.root({ class: [props.class, props.ui?.root] })">
+  <view
+    :class="ui.root({ class: [props.class, props.ui?.root] })"
+    :style="positionStyle"
+  >
     <slot />
   </view>
 </template>

--- a/packages/kit/src/components/Swiper.vue
+++ b/packages/kit/src/components/Swiper.vue
@@ -40,7 +40,7 @@ export interface SwiperProps {
   autoplay?: boolean | number
   direction?: SwiperVariants['direction']
   size?: SwiperVariants['size']
-  /** Show the dot indicator strip. */
+  /** Show the fixed dot indicator strip. Opt-in. */
   showIndicators?: boolean
   class?: any
   ui?: Partial<Record<keyof ReturnType<typeof buildSwiper>['slots'], any>>
@@ -64,7 +64,7 @@ import { useAppConfig } from '../composables/useAppConfig'
 const props = withDefaults(defineProps<SwiperProps>(), {
   itemWidth: 300,
   direction: 'horizontal',
-  showIndicators: true,
+  showIndicators: false,
 })
 const emit = defineEmits<SwiperEmits>()
 defineSlots<SwiperSlots>()
@@ -105,18 +105,17 @@ const itemCount = computed(() => {
     </template>
     <slot v-else />
 
-    <view
-      v-if="showIndicators && items && items.length > 1"
-      :class="ui.indicators({ class: props.ui?.indicators })"
-    >
-      <view
-        v-for="(_, i) in items"
-        :key="i"
-        :class="[
-          ui.indicator({ class: props.ui?.indicator }),
-          modelValue === i && ui.indicatorActive({ class: props.ui?.indicatorActive }),
-        ]"
-      />
-    </view>
+    <template v-if="showIndicators && itemCount > 1" #overlay>
+      <view :class="ui.indicators({ class: props.ui?.indicators })">
+        <view
+          v-for="i in itemCount"
+          :key="i"
+          :class="[
+            ui.indicator({ class: props.ui?.indicator }),
+            modelValue === i - 1 && ui.indicatorActive({ class: props.ui?.indicatorActive }),
+          ]"
+        />
+      </view>
+    </template>
   </SwiperRoot>
 </template>

--- a/packages/kit/src/index.ts
+++ b/packages/kit/src/index.ts
@@ -19,6 +19,9 @@ export { createTv, tv } from './utils/tv'
 export { default as Accordion, default as VyAccordion } from './components/Accordion.vue'
 export { default as ActionSheet, default as VyActionSheet } from './components/ActionSheet.vue'
 export { default as Alert, default as VyAlert } from './components/Alert.vue'
+// AspectRatio is pure layout with nothing to theme, so re-export the core
+// primitive directly under a Vy* alias for discoverability (as with Icon).
+export { AspectRatio, AspectRatio as VyAspectRatio, type AspectRatioProps } from '@vyui/core'
 export { default as Avatar, default as VyAvatar } from './components/Avatar.vue'
 export { default as AvatarGroup, default as VyAvatarGroup } from './components/AvatarGroup.vue'
 export { default as Badge, default as VyBadge } from './components/Badge.vue'

--- a/packages/kit/src/theme/island.ts
+++ b/packages/kit/src/theme/island.ts
@@ -17,9 +17,11 @@
  *     transparent inner sections, gap goes to zero, children stretch
  *     edge-to-edge). Reads as the dock itself growing upward.
  *
- * Asymmetric `px > py` on the row keeps a SINGLE-button island a clear
- * horizontal pill (instead of collapsing to a circle that `rounded-full`
- * would otherwise paint on a square wrapper).
+ * Asymmetric `px > py` on the row gives multi-item rows a clear horizontal
+ * pill shape. A SOLO row (one child) flips this: padding goes symmetric +
+ * tight so the surface hugs the single button — an icon-only button reads as
+ * one clean circle instead of a wide pill with a small circle floating inside
+ * it. See the `solo` variant + compoundVariants below.
  *
  * `size` flows from the wrapper to child `<VyIslandButton>`s via context.
  * `position` covers fixed `top` / `bottom` placement + `inline` for
@@ -88,8 +90,25 @@ export default {
       true: {},
       false: {},
     },
+    // `solo` fires when the row hosts a single child. Tightens row padding to
+    // symmetric (see compoundVariants) AND zeroes the gap: vue-lynx renders
+    // empty `<text>` anchor nodes flanking the slotted button, and a non-zero
+    // `gap` inserts spacing on either side of them — adding horizontal-only
+    // width that warps the would-be circle into a wide pill. Counted in
+    // `Island.vue`.
+    solo: {
+      true: { row: 'gap-0' },
+      false: {},
+    },
   },
   compoundVariants: [
+    // Solo row: collapse the asymmetric px→py to a symmetric ring so the
+    // surface hugs the lone button (icon-only → clean circle). Only the `px`
+    // is overridden; the `py` from the size variant already sets the ring.
+    { solo: true, size: 'sm', class: { row: 'px-1' } },
+    { solo: true, size: 'md', class: { row: 'px-1.5' } },
+    { solo: true, size: 'lg', class: { row: 'px-2' } },
+    { solo: true, size: 'xl', class: { row: 'px-2.5' } },
     // Attached + open: collapse the two surfaces into one. Chrome migrates
     // to root, row + panel become transparent, gap goes to 0, and children
     // stretch edge-to-edge so the visual width is uniform.
@@ -108,5 +127,6 @@ export default {
     size: 'md' as const,
     expandStyle: 'floating' as const,
     open: false as const,
+    solo: false as const,
   },
 }

--- a/packages/kit/src/theme/island.ts
+++ b/packages/kit/src/theme/island.ts
@@ -24,8 +24,9 @@
  * it. See the `solo` variant + compoundVariants below.
  *
  * `size` flows from the wrapper to child `<VyIslandButton>`s via context.
- * `position` covers fixed `top` / `bottom` placement + `inline` for
- * embedded use. Panel grows away from the anchored edge.
+ * `position` (`top`/`bottom`) picks the viewport edge; `layer`
+ * (`overlay`/`base`/`inline`) controls stacking vs in-flow. Panel grows away
+ * from the anchored edge.
  */
 
 const PILL_SURFACE
@@ -47,10 +48,14 @@ export default {
     panel: `flex flex-col ${PILL_SURFACE} rounded-3xl`,
   },
   variants: {
+    // Which viewport edge to float against — only takes effect when
+    // `layer !== 'inline'`. The actual fixed placement is applied as an inline
+    // `style` in Island.vue (Lynx ignores tailwind `fixed`); these variants
+    // just own cross-axis centering. `inline`-flow vs floating is the `layer`
+    // axis, not this one.
     position: {
-      top: { root: 'fixed top-4 left-1/2 -translate-x-1/2 z-50 items-center' },
-      bottom: { root: 'fixed bottom-4 left-1/2 -translate-x-1/2 z-50 items-center' },
-      inline: { root: 'items-center' },
+      top: { root: 'items-center' },
+      bottom: { root: 'items-center' },
     },
     size: {
       sm: {

--- a/packages/kit/src/theme/islandButton.ts
+++ b/packages/kit/src/theme/islandButton.ts
@@ -9,10 +9,10 @@
  *   xl → 64px (oversized hero dock)
  *
  * Icons and buttons grow together so the icon-to-button ratio stays around
- * 50–57% — that's the sweet spot where the glyph reads centered without
- * dead space around it. Earlier revisions either kept icons too small (airy
- * vertical padding) or made buttons too tall (same problem); both have been
- * dialed back.
+ * 40–45% — enough presence without crowding the pill. NB: the actual rendered
+ * size comes from the numeric `size` prop `IslandButton.vue` passes to
+ * `<VyIcon>` (`ICON_PX`); the `size-*` classes here mirror those values but
+ * are overridden by the icon's inline width/height, so keep the two in sync.
  *
  * Footprint sizing lives entirely in `compoundVariants` so the icon-only
  * and label-pill branches don't fight over `px-*`. Size flows in from the
@@ -29,10 +29,10 @@ export default {
   },
   variants: {
     size: {
-      sm: { base: 'text-xs', leadingIcon: 'size-5' },
-      md: { base: 'text-sm', leadingIcon: 'size-6' },
-      lg: { base: 'text-base', leadingIcon: 'size-8' },
-      xl: { base: 'text-lg', leadingIcon: 'size-9' },
+      sm: { base: 'text-xs', leadingIcon: 'size-4' },
+      md: { base: 'text-sm', leadingIcon: 'size-5' },
+      lg: { base: 'text-base', leadingIcon: 'size-6' },
+      xl: { base: 'text-lg', leadingIcon: 'size-7' },
     },
     active: {
       true: { base: 'bg-black/10 text-slate-900' },

--- a/packages/kit/src/theme/islandGroup.ts
+++ b/packages/kit/src/theme/islandGroup.ts
@@ -3,20 +3,23 @@
  * main bottom dock + a trailing close pill, or two top islands side-by-side.
  *
  * Owns the fixed positioning (top/bottom of viewport) so each member
- * island can use `position="inline"` and stay focused on its own contents.
+ * island can use `layer="inline"` and stay focused on its own contents.
  *
  * `direction` toggles row vs column stacking. `align` controls which way
  * the group is pinned horizontally (or vertically, in column mode).
  */
 export default {
   slots: {
-    root: 'flex items-end',
+    root: 'flex',
   },
   variants: {
+    // Which viewport edge to float against — only takes effect when
+    // `layer !== 'inline'`. Fixed placement + centering are applied as an
+    // inline `style` in IslandGroup.vue (Lynx ignores tailwind `fixed`/
+    // `justify-*`); these variants just own cross-axis alignment.
     position: {
-      top: 'fixed top-4 inset-x-0 z-50 items-start',
-      bottom: 'fixed bottom-4 inset-x-0 z-50',
-      inline: '',
+      top: 'items-start',
+      bottom: 'items-end',
     },
     direction: {
       row: 'flex-row',
@@ -36,7 +39,7 @@ export default {
     },
   },
   defaultVariants: {
-    position: 'inline' as const,
+    position: 'bottom' as const,
     direction: 'row' as const,
     align: 'center' as const,
     size: 'md' as const,

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,17 @@ packages:
   - 'packages/*'
   - 'apps/examples/*'
   - 'apps/docs'
+# Keep Tailwind v4's PostCSS plugin out of the hoisted virtual store. It is
+# pulled in transitively by @nuxt/ui (docs app, legitimately on Tailwind v4),
+# and pnpm otherwise hoists it into node_modules/.pnpm/node_modules where
+# vue-lynx's `require.resolve('@tailwindcss/postcss')` finds it and warns that
+# v4 is incompatible with rsbuild-plugin-tailwindcss / @lynx-js/tailwind-preset.
+# The Lynx demo apps are all on Tailwind v3, so the warning is a false positive.
+# @nuxt/ui still resolves the plugin via its own dependency link, so excluding
+# it from hoisting does not affect the docs build.
+hoistPattern:
+  - '*'
+  - '!@tailwindcss/postcss'
 # Per-dependency allowlist for install/build (lifecycle) scripts. Everything is
 # blocked by default (pnpm 10+) so a poisoned dependency cannot auto-execute a
 # postinstall to harvest secrets. Only the native packages that genuinely need a


### PR DESCRIPTION
Adds two universal primitives flagged in the components-tracking issue, following the established core (headless, reka-ui parity) / kit (styled, nuxt-ui) split.

**AspectRatio** (`@vyui/core`, core-only)
- New `AspectRatioRoot` primitive; reka-compatible `ratio` prop and default-slot `aspect` percentage.
- Uses Lynx's native CSS `aspect-ratio` (settable in `@lynx-js/types`) — no padding-hack wrapper, since percentage padding resolves differently under Lynx's flexbox layout.
- No kit styled wrapper (nothing to theme); re-exported from kit as `AspectRatio`/`VyAspectRatio` for discoverability.

**Avatar** (headless in `@vyui/core`, styled wrapper refactored in `@vyui/kit`)
- New headless `AvatarRoot` / `AvatarImage` / `AvatarFallback` (reka parity, `delayMs` flash-avoidance, Lynx `binderror` handling).
- kit `Avatar.vue` now composes the core primitives; public `AvatarProps` / `AvatarSlots` and `AVATAR_GROUP_KEY` unchanged, so `AvatarGroup.vue` is untouched.

Verified: `@vyui/core` typecheck + 818 tests pass (10 new); `@vyui/core` build + `@vyui/kit` typecheck pass.

Note: kit Avatar fallback content is now nested one `<view>` deeper (inside `AvatarFallback`'s Primitive); still centered.

Closes the AspectRatio and Avatar items in the components-tracking issue.
