### PR TITLE
fix(kit): land foreground colors on text slots (Lynx CSS-inheritance)

### DIFF
--- a/.changeset/lynx-text-color-inheritance.md
+++ b/.changeset/lynx-text-color-inheritance.md
@@ -1,0 +1,6 @@
+---
+"@vyui/kit": patch
+---
+Fix stranded foreground colors on Lynx (`enableCSSInheritance: false`). Color set on a wrapping `<view>` slot never reached the nested text/icon, so it rendered in the default color — invisible on dark/colored surfaces (e.g. a neutral-solid button or solid card).
+
+Foreground `text-*` now lands on the text-bearing slots (label / title / description / icon / input value) across `input`, `textarea`, `numberField`, `select`, `combobox`, `toggle`, `toggleGroup`, `chip`, `islandButton`, `card`, `accordion`, `dropdownMenu`, `tabs`, `stepper`. State-driven colors on child elements use the `group-data-[state=…]` form, and the Tailwind preset safelist is widened to cover those variants so they aren't purged.

--- a/packages/kit/src/components/Accordion.vue
+++ b/packages/kit/src/components/Accordion.vue
@@ -149,7 +149,7 @@ const resolveValue = (item: AccordionItem, index: number) =>
         <slot :name="(item.slot || 'content')" :item="item" :index="index" :open="open">
           <view :class="ui.body({ class: props.ui?.body })">
             <slot name="body" :item="item" :index="index" :open="open">
-              <text v-if="item.content">{{ item.content }}</text>
+              <text v-if="item.content" :class="ui.bodyText({ class: props.ui?.bodyText })">{{ item.content }}</text>
             </slot>
           </view>
         </slot>

--- a/packages/kit/src/components/Chip.vue
+++ b/packages/kit/src/components/Chip.vue
@@ -68,7 +68,7 @@ const ui = computed(() => buildChip(appConfig)({
   <template v-if="standalone">
     <view v-if="show" :class="ui.base({ class: [props.class, props.ui?.base] })">
       <slot name="content">
-        <text v-if="hasContent">{{ props.text }}</text>
+        <text v-if="hasContent" :class="ui.text({ class: props.ui?.text })">{{ props.text }}</text>
       </slot>
     </view>
   </template>
@@ -76,7 +76,7 @@ const ui = computed(() => buildChip(appConfig)({
     <slot />
     <view v-if="show" :class="ui.base({ class: props.ui?.base })">
       <slot name="content">
-        <text v-if="hasContent">{{ props.text }}</text>
+        <text v-if="hasContent" :class="ui.text({ class: props.ui?.text })">{{ props.text }}</text>
       </slot>
     </view>
   </view>

--- a/packages/kit/src/components/Stepper.vue
+++ b/packages/kit/src/components/Stepper.vue
@@ -116,7 +116,10 @@ const ui = computed(() => buildStepper(appConfig)({
                   :name="item.icon"
                   :class="ui.icon({ class: props.ui?.icon })"
                 />
-                <text v-else>{{ index + 1 }}</text>
+                <!-- `ui.icon` carries the active/completed foreground color;
+                     it must sit on this <text> since color can't inherit from
+                     the trigger <view> (`enableCSSInheritance: false`). -->
+                <text v-else :class="ui.icon({ class: props.ui?.icon })">{{ index + 1 }}</text>
               </slot>
             </StepperIndicator>
           </StepperTrigger>

--- a/packages/kit/src/components/internal/DropdownMenuItems.vue
+++ b/packages/kit/src/components/internal/DropdownMenuItems.vue
@@ -87,7 +87,10 @@ function getItemSlot(item: DropdownMenuItem | undefined, suffix?: 'leading' | 'l
       v-else-if="row.kind === 'label'"
       :class="ui.label({ class: uiOverrides?.label })"
     >
-      <text :class="ui.itemLabel({ class: uiOverrides?.itemLabel })">{{ getLabel(row.item) }}</text>
+      <!-- `enableCSSInheritance: false`: the `label` slot's `text-neutral-900`
+           sits on the wrapping <view>, so the heading color must land on this
+           <text> directly. -->
+      <text :class="ui.itemLabel({ class: ['text-neutral-900', uiOverrides?.itemLabel] })">{{ getLabel(row.item) }}</text>
     </DropdownMenuLabel>
 
     <DropdownMenuCheckboxItem
@@ -108,7 +111,7 @@ function getItemSlot(item: DropdownMenuItem | undefined, suffix?: 'leading' | 'l
           :class="ui.itemLeadingIcon({ color: row.item?.color, class: uiOverrides?.itemLeadingIcon })"
         />
         <view :class="ui.itemWrapper({ class: uiOverrides?.itemWrapper })">
-          <text :class="ui.itemLabel({ class: uiOverrides?.itemLabel })">{{ getLabel(row.item) }}</text>
+          <text :class="ui.itemLabel({ color: row.item?.color, class: uiOverrides?.itemLabel })">{{ getLabel(row.item) }}</text>
           <text v-if="getDescription(row.item)" :class="ui.itemDescription({ class: uiOverrides?.itemDescription })">{{ getDescription(row.item) }}</text>
         </view>
       </template>
@@ -181,7 +184,7 @@ function getItemSlot(item: DropdownMenuItem | undefined, suffix?: 'leading' | 'l
             :index="row.index"
             :ui="ui"
           />
-          <text v-else :class="ui.itemLabel({ class: uiOverrides?.itemLabel })">{{ getLabel(row.item) }}</text>
+          <text v-else :class="ui.itemLabel({ color: row.item?.color, class: uiOverrides?.itemLabel })">{{ getLabel(row.item) }}</text>
 
           <component
             v-if="getItemSlot(row.item, 'description')"

--- a/packages/kit/src/tailwind.js
+++ b/packages/kit/src/tailwind.js
@@ -100,16 +100,28 @@ export function createVyuiPreset({ colors = COLORS, neutral = NEUTRAL, shades = 
         pattern: new RegExp(
           `(bg|text|ring|border)-(${allColors.join('|')})-(${shades.join('|')})`,
         ),
+        // State/attribute variants the kit themes pair with dynamic color
+        // utilities. CSS inheritance is off on Lynx, so state-driven foreground
+        // colors live on child text/icon slots and read the parent's state via
+        // the `group-data-[…]` forms — both the self (`data-[…]`) and group
+        // (`group-data-[…]`) forms must be safelisted or the scanner purges them.
         variants: [
           'hover',
           'active',
           'focus',
           'disabled',
+          'data-[highlighted]',
+          'data-[state=active]',
           'data-[state=on]',
           'data-[state=open]',
           'data-[state=checked]',
+          'group-data-[highlighted]',
           'group-data-[state=active]',
           'group-data-[state=completed]',
+          'group-data-[state=inactive]',
+          'group-data-[state=on]',
+          'group-data-[state=open]',
+          'group-data-[state=checked]',
         ],
       },
       'text-white',

--- a/packages/kit/src/theme/accordion.ts
+++ b/packages/kit/src/theme/accordion.ts
@@ -14,7 +14,12 @@ export default {
     trigger:
       'group flex-1 flex flex-row items-center gap-1.5 font-medium text-sm py-3.5 min-w-0',
     content: 'overflow-hidden',
-    body: 'text-sm pb-3.5 text-neutral-700',
+    // `body` is a wrapping <view>; `enableCSSInheritance: false` means its
+    // `text-*` can't reach the nested content <text>, so the foreground color
+    // moves onto `bodyText` (applied to the string-content <text> in
+    // Accordion.vue). `body` keeps layout/sizing only.
+    body: 'text-sm pb-3.5',
+    bodyText: 'text-sm text-neutral-700',
     leadingIcon: 'shrink-0 size-5 text-neutral-500',
     trailingIcon:
       'shrink-0 size-5 ms-auto text-neutral-500 group-data-[state=open]:rotate-180 transition-transform duration-200',

--- a/packages/kit/src/theme/card.ts
+++ b/packages/kit/src/theme/card.ts
@@ -14,7 +14,17 @@ export default {
   variants: {
     variant: {
       solid: {
-        root: 'bg-neutral-900 text-white',
+        // `enableCSSInheritance: false`: a `text-*` on the `root` <view> never
+        // reaches slot content. Card owns no text element (header/body/footer
+        // are containers for user-supplied content), so the foreground rides on
+        // those content slots. Lynx still won't cascade into deeply-nested
+        // <text>, so plain-text children of a solid card should set their own
+        // color (or pass `ui.{header,body,footer}`); the `bg-*` fill stays on
+        // `root`.
+        root: 'bg-neutral-900',
+        header: 'text-white',
+        body: 'text-white',
+        footer: 'text-white',
       },
       outline: {
         root: 'bg-white border border-neutral-200',

--- a/packages/kit/src/theme/chip.ts
+++ b/packages/kit/src/theme/chip.ts
@@ -26,7 +26,13 @@ export default (colors: Color[]) => ({
     // `tabular-nums` keeps single-digit content visually centered (Lynx
     // proportional fonts shift digit baselines just enough to look off in a
     // 16px circle).
-    base: 'rounded-full flex flex-row items-center justify-center text-white font-medium whitespace-nowrap leading-none tabular-nums border-2 border-white',
+    base: 'rounded-full flex flex-row items-center justify-center font-medium whitespace-nowrap leading-none tabular-nums border-2 border-white',
+    // Foreground color for the content <text>. CSS inheritance is OFF in the
+    // Lynx build (`enableCSSInheritance: false`), so `text-white` on the `base`
+    // dot <view> never reaches the content <text> — it sits here directly. The
+    // per-size `text-*` font size is co-located on this slot for the same
+    // reason (font-size doesn't cascade either). Same convention as `button.ts`.
+    text: 'text-white',
   },
   variants: {
     color: Object.fromEntries(colors.map(c => [c, ''])) as Record<Color, ''>,
@@ -82,13 +88,16 @@ export default (colors: Color[]) => ({
     // `min-w` matches `h` so single digits render as a perfect circle.
     // Horizontal padding is intentionally tiny (px-0.5 / px-1) so two-digit
     // counts widen the pill slightly without the single-digit case going oval.
-    { hasContent: true, size: 'xs' as const, class: 'h-[18px] min-w-[18px] px-1 text-[11px]' },
-    { hasContent: true, size: 'sm' as const, class: 'h-5 min-w-5 px-1 text-xs' },
-    { hasContent: true, size: 'md' as const, class: 'h-[22px] min-w-[22px] px-1.5 text-xs' },
-    { hasContent: true, size: 'lg' as const, class: 'h-6 min-w-6 px-1.5 text-sm' },
-    { hasContent: true, size: 'xl' as const, class: 'h-7 min-w-7 px-2 text-sm' },
-    { hasContent: true, size: '2xl' as const, class: 'h-8 min-w-8 px-2 text-base' },
-    { hasContent: true, size: '3xl' as const, class: 'h-9 min-w-9 px-2.5 text-lg' },
+    // Font size lives on the `text` slot (the content <text>), not `base` —
+    // Lynx won't cascade `text-*` from the dot <view> (`enableCSSInheritance:
+    // false`). The dot's box sizing (`h-*`/`min-w-*`/`px-*`) stays on `base`.
+    { hasContent: true, size: 'xs' as const, class: { base: 'h-[18px] min-w-[18px] px-1', text: 'text-[11px]' } },
+    { hasContent: true, size: 'sm' as const, class: { base: 'h-5 min-w-5 px-1', text: 'text-xs' } },
+    { hasContent: true, size: 'md' as const, class: { base: 'h-[22px] min-w-[22px] px-1.5', text: 'text-xs' } },
+    { hasContent: true, size: 'lg' as const, class: { base: 'h-6 min-w-6 px-1.5', text: 'text-sm' } },
+    { hasContent: true, size: 'xl' as const, class: { base: 'h-7 min-w-7 px-2', text: 'text-sm' } },
+    { hasContent: true, size: '2xl' as const, class: { base: 'h-8 min-w-8 px-2', text: 'text-base' } },
+    { hasContent: true, size: '3xl' as const, class: { base: 'h-9 min-w-9 px-2.5', text: 'text-lg' } },
 
     // inset=false: nudge half the dot's size out of the parent at each corner
     { position: 'top-right' as const, inset: false, class: '-translate-y-1/2 translate-x-1/2 transform' },

--- a/packages/kit/src/theme/combobox.ts
+++ b/packages/kit/src/theme/combobox.ts
@@ -13,7 +13,11 @@ import type { Color } from './colors'
 export default (colors: Color[]) => ({
   slots: {
     root: 'relative flex flex-row items-center w-full',
-    base: 'relative w-full rounded-md flex flex-row items-center text-neutral-900 placeholder:text-neutral-400 disabled:cursor-not-allowed disabled:opacity-75 transition-colors',
+    // `base` is the trigger <view> — surface only. The trigger value <text> and
+    // search <input> carry their own text colors (set in Combobox.vue): CSS
+    // inheritance is OFF in the Lynx build (`enableCSSInheritance: false`), so a
+    // `text-*` on the trigger <view> never reaches those children.
+    base: 'relative w-full rounded-md flex flex-row items-center disabled:cursor-not-allowed disabled:opacity-75 transition-colors',
     input: 'flex-1 min-w-0 bg-transparent outline-none placeholder:text-neutral-400 disabled:cursor-not-allowed disabled:opacity-75',
     arrow: 'fill-neutral-200',
     content: 'max-h-60 w-full bg-white rounded-md border border-neutral-200 overflow-hidden pointer-events-auto',
@@ -22,12 +26,16 @@ export default (colors: Color[]) => ({
     empty: 'py-2 text-center text-sm text-neutral-500',
     label: 'font-semibold text-neutral-900',
     separator: '-mx-1 my-1 h-px bg-neutral-200',
-    item: 'group relative w-full flex flex-row items-center select-none rounded-md data-[disabled]:cursor-not-allowed data-[disabled]:opacity-75 text-neutral-700 data-[state=checked]:text-neutral-900 transition-colors',
+    // `item` is the row <view> — surface/layout only. Item label color lives on
+    // `itemLabel` (the row's <text>): CSS inheritance is OFF in the Lynx build
+    // (`enableCSSInheritance: false`), so a `text-*` on the row <view> never
+    // reaches the label <text>.
+    item: 'group relative w-full flex flex-row items-center select-none rounded-md data-[disabled]:cursor-not-allowed data-[disabled]:opacity-75 transition-colors',
     itemLeadingIcon: 'shrink-0 transition-colors',
     itemLeadingAvatar: 'shrink-0',
     itemTrailing: 'ms-auto flex flex-row gap-1.5 items-center',
     itemTrailingIcon: 'shrink-0',
-    itemLabel: 'truncate',
+    itemLabel: 'truncate text-neutral-700 group-data-[state=checked]:text-neutral-900',
     leading: 'flex flex-row items-center shrink-0',
     leadingIcon: 'shrink-0',
     leadingAvatar: 'shrink-0',

--- a/packages/kit/src/theme/dropdownMenu.ts
+++ b/packages/kit/src/theme/dropdownMenu.ts
@@ -29,13 +29,20 @@ export default (colors: Color[]) => ({
   },
   variants: {
     color: Object.fromEntries(colors.map(c => [c, ''])) as Record<Color, ''>,
+    // `enableCSSInheritance: false`: foreground text color set on the `item`
+    // <view> (CoreDropdownMenuItem) does NOT reach the nested `itemLabel`
+    // <text>. The label color rides on `itemLabel` (the `item` carries the
+    // `group` class, so its `data-[…]` state drives `group-data-[…]:` here);
+    // only the `bg-*` surface stays on `item`.
     active: {
       true: {
-        item: 'text-neutral-900 bg-neutral-100',
+        item: 'bg-neutral-100',
+        itemLabel: 'text-neutral-900',
         itemLeadingIcon: 'text-neutral-700',
       },
       false: {
-        item: 'text-neutral-700 data-[highlighted]:text-neutral-900 data-[state=open]:text-neutral-900 data-[highlighted]:bg-neutral-100 data-[state=open]:bg-neutral-100',
+        item: 'data-[highlighted]:bg-neutral-100 data-[state=open]:bg-neutral-100',
+        itemLabel: 'text-neutral-700 group-data-[highlighted]:text-neutral-900 group-data-[state=open]:text-neutral-900',
         itemLeadingIcon: 'text-neutral-500 group-data-[highlighted]:text-neutral-700 group-data-[state=open]:text-neutral-700',
       },
     },
@@ -72,11 +79,16 @@ export default (colors: Color[]) => ({
     },
   },
   compoundVariants: [
+    // Foreground (`text-*`) rides on `itemLabel`/`itemLeadingIcon`, surface
+    // (`bg-*`) on `item` — see the `active` variant note (`enableCSSInheritance`
+    // is off). State selectors become `group-data-[…]:` on the label since the
+    // `item` <view> owns the `group` + `data-[…]` state.
     ...colors.map(color => ({
       color,
       active: false as const,
       class: {
-        item: `text-${color}-500 data-[highlighted]:text-${color}-600 data-[highlighted]:bg-${color}-50 data-[state=open]:bg-${color}-50`,
+        item: `data-[highlighted]:bg-${color}-50 data-[state=open]:bg-${color}-50`,
+        itemLabel: `text-${color}-500 group-data-[highlighted]:text-${color}-600`,
         itemLeadingIcon: `text-${color}-500 group-data-[highlighted]:text-${color}-600 group-data-[state=open]:text-${color}-600`,
       },
     })),
@@ -84,7 +96,8 @@ export default (colors: Color[]) => ({
       color,
       active: true as const,
       class: {
-        item: `text-${color}-600 bg-${color}-50`,
+        item: `bg-${color}-50`,
+        itemLabel: `text-${color}-600`,
         itemLeadingIcon: `text-${color}-600`,
       },
     })),

--- a/packages/kit/src/theme/input.ts
+++ b/packages/kit/src/theme/input.ts
@@ -23,7 +23,10 @@ export default (colors: Color[]) => ({
     // Border + bg + radius live on root; base stays transparent so the icon
     // wrappers (siblings) sit *inside* the rounded chrome.
     root: 'flex flex-row items-center w-full rounded-md transition-colors',
-    base: 'flex-1 min-w-0 bg-transparent placeholder:text-neutral-400 focus:outline-none disabled:cursor-not-allowed disabled:opacity-75',
+    // Typed-text color sits on `base` (the <input>), not `root`: CSS
+    // inheritance is OFF in the Lynx build (`enableCSSInheritance: false`), so a
+    // `text-*` on the root <view> never reaches the input element.
+    base: 'flex-1 min-w-0 bg-transparent text-neutral-900 placeholder:text-neutral-400 focus:outline-none disabled:cursor-not-allowed disabled:opacity-75',
     leading: 'flex flex-row items-center shrink-0',
     leadingIcon: 'shrink-0',
     leadingAvatar: 'shrink-0',
@@ -57,12 +60,14 @@ export default (colors: Color[]) => ({
         trailingIcon: 'size-7'
       }
     },
+    // Surface only (bg/border) on `root`; typed-text color lives on `base`
+    // (the <input>) — see the `slots.base` note re `enableCSSInheritance: false`.
     variant: {
-      outline: { root: 'text-neutral-900 bg-white border' },
-      soft: { root: 'text-neutral-900 bg-neutral-100/50 active:bg-neutral-100 disabled:bg-neutral-100/50' },
-      subtle: { root: 'text-neutral-900 bg-neutral-100 border' },
-      ghost: { root: 'text-neutral-900 bg-transparent active:bg-neutral-100 disabled:bg-transparent' },
-      none: { root: 'text-neutral-900 bg-transparent' }
+      outline: { root: 'bg-white border' },
+      soft: { root: 'bg-neutral-100/50 active:bg-neutral-100 disabled:bg-neutral-100/50' },
+      subtle: { root: 'bg-neutral-100 border' },
+      ghost: { root: 'bg-transparent active:bg-neutral-100 disabled:bg-transparent' },
+      none: { root: 'bg-transparent' }
     },
     color: Object.fromEntries(colors.map(c => [c, ''])) as Record<Color, ''>,
     leading: { true: '' },

--- a/packages/kit/src/theme/islandButton.ts
+++ b/packages/kit/src/theme/islandButton.ts
@@ -18,14 +18,19 @@
  * and label-pill branches don't fight over `px-*`. Size flows in from the
  * parent `<VyIsland>` via context; pass an explicit `size` to override.
  */
+// Foreground color (`text-slate-*`) sits on the `leadingIcon` / `label` slots,
+// NOT the root `base` <view>: CSS inheritance is OFF in the Lynx build
+// (`enableCSSInheritance: false`), so a `text-*` on the root never reaches the
+// icon/label children. Surface (bg/opacity) stays on `base`. Same convention
+// as `button.ts`.
 export default {
   slots: {
     base:
       'flex flex-row items-center justify-center '
-      + 'rounded-full text-slate-700 font-medium '
+      + 'rounded-full font-medium '
       + 'active:bg-black/10 disabled:opacity-40',
-    leadingIcon: 'shrink-0',
-    label: 'truncate',
+    leadingIcon: 'shrink-0 text-slate-700',
+    label: 'truncate text-slate-700',
   },
   variants: {
     size: {
@@ -35,7 +40,8 @@ export default {
       xl: { base: 'text-lg', leadingIcon: 'size-7' },
     },
     active: {
-      true: { base: 'bg-black/10 text-slate-900' },
+      // `text-slate-900` on the text-bearing slots (won't cascade from `base`).
+      true: { base: 'bg-black/10', leadingIcon: 'text-slate-900', label: 'text-slate-900' },
       false: {},
     },
     iconOnly: {

--- a/packages/kit/src/theme/numberField.ts
+++ b/packages/kit/src/theme/numberField.ts
@@ -51,12 +51,16 @@ export default (colors: Color[]) => ({
         decrementIcon: 'size-6',
       },
     },
+    // Surface only (bg/border) on `root`; typed-text color lives on `base`
+    // (the <input>) — CSS inheritance is OFF in the Lynx build
+    // (`enableCSSInheritance: false`), so a `text-*` on the root <view> never
+    // reaches the input element.
     variant: {
-      outline: { root: 'text-neutral-900 bg-white border' },
-      soft: { root: 'text-neutral-900 bg-neutral-100/50 disabled:bg-neutral-100/50 border-transparent' },
-      subtle: { root: 'text-neutral-900 bg-neutral-100 border' },
-      ghost: { root: 'text-neutral-900 bg-transparent disabled:bg-transparent border-transparent' },
-      none: { root: 'text-neutral-900 bg-transparent border-transparent' },
+      outline: { root: 'bg-white border' },
+      soft: { root: 'bg-neutral-100/50 disabled:bg-neutral-100/50 border-transparent' },
+      subtle: { root: 'bg-neutral-100 border' },
+      ghost: { root: 'bg-transparent disabled:bg-transparent border-transparent' },
+      none: { root: 'bg-transparent border-transparent' },
     },
     color: Object.fromEntries(colors.map(c => [c, ''])) as Record<Color, ''>,
   },

--- a/packages/kit/src/theme/select.ts
+++ b/packages/kit/src/theme/select.ts
@@ -17,8 +17,13 @@ import type { Color } from './colors'
 export default (colors: Color[]) => ({
   slots: {
     root: 'relative flex flex-row items-center',
-    base: 'w-full rounded-md flex flex-row items-center text-neutral-900 placeholder:text-neutral-400 disabled:cursor-not-allowed disabled:opacity-75 transition-colors',
-    value: 'flex-1 min-w-0 truncate text-start',
+    // `base` is the trigger <view> — surface only. The selected-value text
+    // color lives on the `value` <text> slot and the placeholder color on the
+    // `placeholder` <text> slot: CSS inheritance is OFF in the Lynx build
+    // (`enableCSSInheritance: false`), so a `text-*` on the trigger <view>
+    // never reaches those <text> children.
+    base: 'w-full rounded-md flex flex-row items-center disabled:cursor-not-allowed disabled:opacity-75 transition-colors',
+    value: 'flex-1 min-w-0 truncate text-start text-neutral-900',
     placeholder: 'flex-1 min-w-0 truncate text-start text-neutral-400',
     arrow: 'fill-neutral-200',
     content: 'max-h-60 w-full bg-white rounded-md border border-neutral-200 overflow-hidden pointer-events-auto',
@@ -27,12 +32,16 @@ export default (colors: Color[]) => ({
     empty: 'py-2 text-center text-sm text-neutral-500',
     label: 'font-semibold text-neutral-900',
     separator: '-mx-1 my-1 h-px bg-neutral-200',
-    item: 'group relative w-full flex flex-row items-center select-none rounded-md data-[disabled]:cursor-not-allowed data-[disabled]:opacity-75 text-neutral-700 data-[state=checked]:text-neutral-900 transition-colors',
+    // `item` is the row <view> — surface/layout only. Item label color lives on
+    // `itemLabel` (the SelectItemText <text>): CSS inheritance is OFF in the
+    // Lynx build (`enableCSSInheritance: false`), so a `text-*` on the row
+    // <view> never reaches the label <text>.
+    item: 'group relative w-full flex flex-row items-center select-none rounded-md data-[disabled]:cursor-not-allowed data-[disabled]:opacity-75 transition-colors',
     itemLeadingIcon: 'shrink-0 transition-colors',
     itemLeadingAvatar: 'shrink-0',
     itemTrailing: 'ms-auto flex flex-row gap-1.5 items-center',
     itemTrailingIcon: 'shrink-0',
-    itemLabel: 'truncate',
+    itemLabel: 'truncate text-neutral-700 group-data-[state=checked]:text-neutral-900',
     leading: 'flex flex-row items-center shrink-0',
     leadingIcon: 'shrink-0',
     leadingAvatar: 'shrink-0',

--- a/packages/kit/src/theme/stepper.ts
+++ b/packages/kit/src/theme/stepper.ts
@@ -12,9 +12,14 @@ export default (colors: Color[]) => ({
     header: 'flex',
     item: 'group text-center relative w-full',
     container: 'relative',
-    trigger: 'rounded-full font-medium text-center align-middle flex flex-row items-center justify-center font-semibold group-data-[state=completed]:text-white group-data-[state=active]:text-white text-neutral-500 bg-neutral-100',
+    // `enableCSSInheritance: false`: the foreground (`text-*`) must sit on the
+    // indicator content (`icon` slot / the step-number <text>), not the
+    // `trigger` <view> — color there never reaches the nested icon/number. The
+    // `item` carries the `group`, so state stays `group-data-[state=…]:`. The
+    // `bg-*` fill stays on `trigger`.
+    trigger: 'rounded-full font-medium text-center align-middle flex flex-row items-center justify-center font-semibold bg-neutral-100',
     indicator: 'flex flex-row items-center justify-center size-full',
-    icon: 'shrink-0',
+    icon: 'shrink-0 group-data-[state=completed]:text-white group-data-[state=active]:text-white text-neutral-500',
     separator: 'absolute rounded-full group-data-[disabled]:opacity-75 bg-neutral-200',
     wrapper: '',
     title: 'font-medium text-neutral-900',

--- a/packages/kit/src/theme/tabs.ts
+++ b/packages/kit/src/theme/tabs.ts
@@ -13,15 +13,24 @@
  */
 import type { Color } from './colors'
 
-// `pill`: solid indicator behind the active trigger, light text on top.
-const pillTrigger = (_c: string) =>
-  `data-[state=active]:text-white data-[state=inactive]:text-neutral-500 active:data-[state=inactive]:text-neutral-900`
+// `enableCSSInheritance: false`: the active/inactive text color must sit on the
+// `label` <text>, not the `trigger` <view> (color set there never reaches the
+// nested label). The `trigger` carries the `group` class + `data-[state=…]`, so
+// the label uses `group-data-[state=…]:`. Indicator keeps its `bg-*` surface.
+
+// `pill`: solid indicator behind the active trigger, light text on top. The
+// `active:` press-feedback that the original carried on the trigger is dropped
+// here: it relied on the trigger's own `active:` pseudo, which doesn't translate
+// to the child label as a reliable `group-active:` on Lynx. State colors use
+// `group-data-[state=…]:` (the trigger owns the `group` + `data-state`).
+const pillLabel = (_c: string) =>
+  `group-data-[state=active]:text-white group-data-[state=inactive]:text-neutral-500`
 
 const pillIndicator = (c: string) => `bg-${c}-500`
 
 // `link`: underline indicator + colored active label.
-const linkTrigger = (c: string) =>
-  `data-[state=active]:text-${c}-500 data-[state=inactive]:text-neutral-500 active:data-[state=inactive]:text-neutral-900`
+const linkLabel = (c: string) =>
+  `group-data-[state=active]:text-${c}-500 group-data-[state=inactive]:text-neutral-500`
 
 const linkIndicator = (c: string) => `bg-${c}-500`
 
@@ -137,12 +146,12 @@ export default (colors: Color[]) => ({
       {
         color,
         variant: 'pill' as const,
-        class: { indicator: pillIndicator(color), trigger: pillTrigger(color) },
+        class: { indicator: pillIndicator(color), label: pillLabel(color), leadingIcon: pillLabel(color) },
       },
       {
         color,
         variant: 'link' as const,
-        class: { indicator: linkIndicator(color), trigger: linkTrigger(color) },
+        class: { indicator: linkIndicator(color), label: linkLabel(color), leadingIcon: linkLabel(color) },
       },
     ]),
   ],

--- a/packages/kit/src/theme/textarea.ts
+++ b/packages/kit/src/theme/textarea.ts
@@ -15,7 +15,10 @@ import type { Color } from './colors'
 export default (colors: Color[]) => ({
   slots: {
     root: 'flex flex-row items-start w-full rounded-md transition-colors',
-    base: 'flex-1 min-w-0 bg-transparent placeholder:text-neutral-400 focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 align-top',
+    // Typed-text color sits on `base` (the <textarea>), not `root`: CSS
+    // inheritance is OFF in the Lynx build (`enableCSSInheritance: false`), so a
+    // `text-*` on the root <view> never reaches the textarea element.
+    base: 'flex-1 min-w-0 bg-transparent text-neutral-900 placeholder:text-neutral-400 focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 align-top',
     leading: 'flex flex-row items-center shrink-0',
     leadingIcon: 'shrink-0',
     leadingAvatar: 'shrink-0',
@@ -49,12 +52,14 @@ export default (colors: Color[]) => ({
         trailingIcon: 'size-7'
       }
     },
+    // Surface only (bg/border) on `root`; typed-text color lives on `base`
+    // (the <textarea>) — see the `slots.base` note re `enableCSSInheritance: false`.
     variant: {
-      outline: { root: 'text-neutral-900 bg-white border' },
-      soft: { root: 'text-neutral-900 bg-neutral-100/50 active:bg-neutral-100 disabled:bg-neutral-100/50' },
-      subtle: { root: 'text-neutral-900 bg-neutral-100 border' },
-      ghost: { root: 'text-neutral-900 bg-transparent active:bg-neutral-100 disabled:bg-transparent' },
-      none: { root: 'text-neutral-900 bg-transparent' }
+      outline: { root: 'bg-white border' },
+      soft: { root: 'bg-neutral-100/50 active:bg-neutral-100 disabled:bg-neutral-100/50' },
+      subtle: { root: 'bg-neutral-100 border' },
+      ghost: { root: 'bg-transparent active:bg-neutral-100 disabled:bg-transparent' },
+      none: { root: 'bg-transparent' }
     },
     color: Object.fromEntries(colors.map(c => [c, ''])) as Record<Color, ''>,
     leading: { true: '' },

--- a/packages/kit/src/theme/toggle.ts
+++ b/packages/kit/src/theme/toggle.ts
@@ -5,20 +5,26 @@
  *
  * Off state uses a neutral hover/active treatment regardless of color so the
  * pressed state can convey the color × variant emphasis on its own.
+ *
+ * Surface (`base`: bg/border on the root <view>) is kept separate from the
+ * foreground color (`fg`: text-*). CSS inheritance is OFF in the Lynx build
+ * (`enableCSSInheritance: false`), so a `text-*` on the root <view> never
+ * reaches the `icon` <VyIcon> child — `fg` is spread onto the `icon` slot.
+ * Same convention as `button.ts`.
  */
 import type { Color } from './colors'
 
 const solid = (c: string) =>
-  `text-white bg-${c}-500 active:bg-${c}-600 active:bg-${c}-600`
+  ({ base: `bg-${c}-500 active:bg-${c}-600 active:bg-${c}-600`, fg: 'text-white' })
 
 const outline = (c: string) =>
-  `text-${c}-500 border border-${c}-300 active:bg-${c}-50 active:bg-${c}-100`
+  ({ base: `border border-${c}-300 active:bg-${c}-50 active:bg-${c}-100`, fg: `text-${c}-500` })
 
 const soft = (c: string) =>
-  `text-${c}-500 bg-${c}-50 active:bg-${c}-100 active:bg-${c}-200`
+  ({ base: `bg-${c}-50 active:bg-${c}-100 active:bg-${c}-200`, fg: `text-${c}-500` })
 
 const ghost = (c: string) =>
-  `text-${c}-500 active:bg-${c}-50 active:bg-${c}-100`
+  ({ base: `active:bg-${c}-50 active:bg-${c}-100`, fg: `text-${c}-500` })
 
 const VARIANT_BUILDERS = { solid, outline, soft, ghost } as const
 
@@ -42,18 +48,25 @@ export default (colors: Color[]) => ({
     },
     pressed: {
       true: '',
-      false: { base: 'text-neutral-700 active:bg-neutral-100 active:bg-neutral-200' },
+      // `text-*` must sit on the `icon` slot too — the root <view> won't
+      // cascade it to the icon (`enableCSSInheritance: false`).
+      false: { base: 'active:bg-neutral-100 active:bg-neutral-200', icon: 'text-neutral-700' },
     },
   },
   compoundVariants: [
-    // pressed × color × variant -> concrete tailwind classes for the active look
+    // pressed × color × variant -> concrete tailwind classes for the active look.
+    // Surface lands on `base`; foreground color (`fg`) on `icon` since the root
+    // <view> won't cascade it (`enableCSSInheritance: false`).
     ...colors.flatMap(color =>
-      VARIANTS.map(variant => ({
-        pressed: true as const,
-        color,
-        variant,
-        class: { base: VARIANT_BUILDERS[variant](color) },
-      })),
+      VARIANTS.map((variant) => {
+        const { base, fg } = VARIANT_BUILDERS[variant](color)
+        return {
+          pressed: true as const,
+          color,
+          variant,
+          class: { base, icon: fg },
+        }
+      }),
     ),
   ],
   defaultVariants: {

--- a/packages/kit/src/theme/toggleGroup.ts
+++ b/packages/kit/src/theme/toggleGroup.ts
@@ -10,18 +10,35 @@
  */
 import type { Color } from './colors'
 
-// Each builder returns the *inactive* + *on-state* classes for an item.
+// Each builder returns the *inactive* + *on-state* surface classes (`base`,
+// applied to the item <view>) separately from the foreground color (`fg`:
+// text-*, incl. the on-state shift). CSS inheritance is OFF in the Lynx build
+// (`enableCSSInheritance: false`), so a `text-*` on the item <view> never
+// reaches the `leadingIcon` / `label` children — `fg` is spread onto those
+// slots directly. The item <view> carries `group` + `data-state`, so the
+// on-state color shift uses `group-data-[state=on]:text-*` on the children
+// (the children don't get `data-state` themselves). Same convention as
+// `dropdownMenu.ts` / `stepper.ts`.
 const outline = (c: string) =>
-  `text-neutral-700 border border-neutral-300 bg-white active:bg-${c}-50 active:bg-${c}-100`
-    + ` data-[state=on]:text-${c}-600 data-[state=on]:border-${c}-500 data-[state=on]:bg-${c}-50`
+  ({
+    base: `border border-neutral-300 bg-white active:bg-${c}-50 active:bg-${c}-100`
+      + ` data-[state=on]:border-${c}-500 data-[state=on]:bg-${c}-50`,
+    fg: `text-neutral-700 group-data-[state=on]:text-${c}-600`,
+  })
 
 const soft = (c: string) =>
-  `text-neutral-700 bg-neutral-100 active:bg-${c}-50 active:bg-${c}-100`
-    + ` data-[state=on]:text-${c}-600 data-[state=on]:bg-${c}-100`
+  ({
+    base: `bg-neutral-100 active:bg-${c}-50 active:bg-${c}-100`
+      + ` data-[state=on]:bg-${c}-100`,
+    fg: `text-neutral-700 group-data-[state=on]:text-${c}-600`,
+  })
 
 const subtle = (c: string) =>
-  `text-neutral-700 border border-neutral-200 bg-white active:bg-${c}-50 active:bg-${c}-100`
-    + ` data-[state=on]:text-${c}-600 data-[state=on]:border-${c}-300 data-[state=on]:bg-${c}-100`
+  ({
+    base: `border border-neutral-200 bg-white active:bg-${c}-50 active:bg-${c}-100`
+      + ` data-[state=on]:border-${c}-300 data-[state=on]:bg-${c}-100`,
+    fg: `text-neutral-700 group-data-[state=on]:text-${c}-600`,
+  })
 
 const VARIANT_BUILDERS = { outline, soft, subtle } as const
 
@@ -33,7 +50,9 @@ export default (colors: Color[]) => ({
   slots: {
     // `root` direction is set per orientation variant (flex-row/flex-col).
     root: 'flex',
-    item: 'flex flex-row items-center justify-center font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+    // `group` so children can read the item's `data-state` via
+    // `group-data-[state=on]:*` (Lynx won't cascade `text-*`).
+    item: 'group flex flex-row items-center justify-center font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50',
     leadingIcon: 'shrink-0',
     label: 'truncate',
   },
@@ -58,12 +77,18 @@ export default (colors: Color[]) => ({
     },
   },
   compoundVariants: [
+    // Surface lands on `item`; foreground color (`fg`) on `leadingIcon` +
+    // `label` since the item <view> won't cascade it (`enableCSSInheritance:
+    // false`).
     ...colors.flatMap(color =>
-      VARIANTS.map(variant => ({
-        color,
-        variant,
-        class: { item: VARIANT_BUILDERS[variant](color) },
-      })),
+      VARIANTS.map((variant) => {
+        const { base, fg } = VARIANT_BUILDERS[variant](color)
+        return {
+          color,
+          variant,
+          class: { item: base, leadingIcon: fg, label: fg },
+        }
+      }),
     ),
   ],
   defaultVariants: {


### PR DESCRIPTION
The Lynx build runs with `enableCSSInheritance: false`, so a `text-*` color set on a wrapping `<view>` slot never reaches the nested text/icon — it rendered in Lynx's default color, invisible on dark/colored surfaces (the trigger here was neutral-solid buttons, but it was a latent bug across the kit). This continues the fix already landed for Button/Badge/Alert in #49.

- Relocate foreground `text-*` onto the text-bearing slots (label / title / description / icon / input value) instead of the wrapping container.
- Form inputs: `input`, `textarea`, `numberField`, `select`, `combobox` — typed value + item labels now carry their own color.
- Interactive: `toggle`, `toggleGroup`, `chip`, `islandButton` — color moved to label/icon slots.
- Surfaces/overlays: `card` (solid), `accordion` (new `bodyText` slot), `dropdownMenu`, `tabs`, `stepper`.
- State-driven child colors switched to the `group-data-[state=…]` form (the state attr lives on the parent `group`), incl. fixing `select`/`combobox` item-checked color that was using the non-group form.
- Widen the Tailwind preset safelist to cover `group-data-[state=on|open|inactive|checked]` + `(group-)data-[highlighted]` so those dynamic colors aren't purged.

Surfaces (`bg-*`/`border-*`/`divide-*`), shades and neutral structural borders are unchanged — this only relocates foreground color so it actually renders.

Out of scope (proposed follow-ups for full nuxt/ui parity): semantic surface tokens (`bg-default/elevated/muted`, `text-muted/dimmed/inverted`, `border-default`) and dark mode — both need design decisions on token names/CSS vars/palettes rather than a mechanical sweep.

Verified: `@vyui/kit` typecheck + build pass. No `.vue` slot left referencing a removed slot; `group` ownership confirmed on each state-driven parent.