### PR TITLE
feat(docs): changelog read-more + roadmap web/a11y links

### DIFF
--- a/apps/docs/app/components/ChangelogBody.vue
+++ b/apps/docs/app/components/ChangelogBody.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import type { Collections } from "@nuxt/content";
+
+const props = defineProps<{
+    entry: Collections["changelog"];
+    align?: "left" | "right";
+}>();
+
+// Collapsed height cap (px). Entries taller than this get a Read more toggle.
+const COLLAPSED_MAX = 160;
+
+const content = ref<HTMLElement | null>(null);
+const expanded = ref(false);
+const overflowing = ref(false);
+
+function measure() {
+    const el = content.value;
+    if (!el) return;
+    overflowing.value = el.scrollHeight > COLLAPSED_MAX + 24;
+}
+
+onMounted(() => {
+    measure();
+    if (typeof ResizeObserver !== "undefined" && content.value) {
+        const ro = new ResizeObserver(() => measure());
+        ro.observe(content.value);
+        onBeforeUnmount(() => ro.disconnect());
+    }
+});
+
+// Fade the last stretch to transparent while collapsed, independent of the
+// card background colour.
+const collapsed = computed(() => overflowing.value && !expanded.value);
+const maskStyle = computed(() =>
+    collapsed.value
+        ? "linear-gradient(to bottom, black calc(100% - 3rem), transparent)"
+        : undefined,
+);
+</script>
+
+<template>
+    <div>
+        <div
+            ref="content"
+            class="text-muted text-sm [&_a]:text-primary [&_code]:text-highlighted overflow-hidden transition-[max-height] duration-300 ease-out"
+            :style="{
+                maxHeight: collapsed ? `${COLLAPSED_MAX}px` : 'none',
+                maskImage: maskStyle,
+                WebkitMaskImage: maskStyle,
+            }"
+        >
+            <ContentRenderer :value="props.entry" />
+        </div>
+
+        <button
+            v-if="overflowing"
+            type="button"
+            class="text-primary mt-2 flex items-center gap-1 text-sm font-medium hover:underline"
+            :class="props.align === 'right' && 'md:ml-auto md:flex-row-reverse'"
+            @click="expanded = !expanded"
+        >
+            {{ expanded ? "Show less" : "Read more" }}
+            <UIcon
+                :name="
+                    expanded ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'
+                "
+                class="size-4"
+            />
+        </button>
+    </div>
+</template>

--- a/apps/docs/app/pages/changelog.vue
+++ b/apps/docs/app/pages/changelog.vue
@@ -142,11 +142,15 @@ useSeoMeta({
                                         {{ entry.title }}
                                     </h2>
 
-                                    <div
-                                        class="text-muted mt-2 text-sm [&_a]:text-primary [&_code]:text-highlighted"
-                                    >
-                                        <ContentRenderer :value="entry" />
-                                    </div>
+                                    <ChangelogBody
+                                        :entry="entry"
+                                        :align="
+                                            entry.package === 'core'
+                                                ? 'right'
+                                                : 'left'
+                                        "
+                                        class="mt-2"
+                                    />
                                 </UCard>
                             </div>
                         </li>

--- a/apps/docs/content/6.roadmap.md
+++ b/apps/docs/content/6.roadmap.md
@@ -29,5 +29,7 @@ Expect breaking changes. Things will break. Don't ship this to production yet.
 - **Component documentation** — per-component reference, props, examples, demos — generated from real source so it stays in sync.
 - **Starter templates**.
 - **Cross-target testing (iOS / Android / Web)**.
-- **Web event parity** — normalise interaction events across targets so the same component handles native `tap`/long-press and web `click`/`hover` without per-target code.
+- :icon{name="i-lucide-globe"} **Web** — first-class web support so the same components run in the browser as cleanly as on native — see [Web event parity](#web-event-parity) below.
+- :icon{name="i-lucide-accessibility"} **Better accessibility** — deeper a11y coverage across primitives — see [Accessibility](/accessibility).
+- [**Web event parity**]{#web-event-parity} — normalise interaction events across targets so the same component handles native `tap`/long-press and web `click`/`hover` without per-target code.
 - **Internationalization (i18n)** — a locale provider, overridable built-in strings, `Intl`-based formatting helpers, and RTL layout — see [i18n](/i18n).


### PR DESCRIPTION
Collapses long changelog entries behind a Read more toggle and adds two linked roadmap items.

- ChangelogBody component clamps entries taller than 160px with a mask fade and Read more / Show less toggle; short entries render unchanged
- Fade uses CSS mask-image so it works over the card background regardless of theme; ResizeObserver re-measures on resize
- Toggle aligns to the right edge for core (left-rail) entries
- Roadmap: new Web item (globe icon) anchored to the existing Web event parity bullet
- Roadmap: new Better accessibility item linking to /accessibility

Typecheck passes.