### PR TITLE
fix(kit): depend on @vyui/core as a regular dependency

### DIFF
--- a/.changeset/aspect-ratio.md
+++ b/.changeset/aspect-ratio.md
@@ -1,5 +1,5 @@
 ---
-"@vyui/core": minor
+"@vyui/core": patch
 ---
 
 Add AspectRatio — headless `@vyui/core` primitive (`AspectRatioRoot`, exported as both `AspectRatio` and `AspectRatioRoot`) that constrains its default slot to a given `ratio` (number, default `1`).

--- a/.changeset/avatar-core-primitives.md
+++ b/.changeset/avatar-core-primitives.md
@@ -1,6 +1,6 @@
 ---
-"@vyui/core": minor
-"@vyui/kit": minor
+"@vyui/core": patch
+"@vyui/kit": patch
 ---
 
 Add Avatar — headless `@vyui/core` primitives (`AvatarRoot` / `AvatarImage` / `AvatarFallback`) ported from reka-ui. `AvatarRoot` provides image load-status context; `AvatarImage` renders a Lynx `<image>` and downgrades to the error state on `binderror` (`@error`); `AvatarFallback` shows when no image is loaded, with reka's `delayMs` flash-avoidance delay.

--- a/.changeset/configurable-colors.md
+++ b/.changeset/configurable-colors.md
@@ -1,5 +1,5 @@
 ---
-"@vyui/kit": minor
+"@vyui/kit": patch
 ---
 
 Configurable semantic colors (nuxt/ui-style), defined once and extensible.

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -60,17 +60,16 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "peerDependencies": {
-    "@vyui/core": "workspace:~",
     "vue": ">= 3.4.0",
     "vue-lynx": "^0.4.0",
     "tailwindcss": "^3.4.0"
   },
   "dependencies": {
+    "@vyui/core": "workspace:^",
     "defu": "^6.1.5",
     "tailwind-variants": "^0.3.1"
   },
   "devDependencies": {
-    "@vyui/core": "workspace:*",
     "@vyui/shared-build-config": "workspace:*",
     "@vyui/testing-utils": "workspace:*",
     "@rsbuild/plugin-vue": "^1.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,6 +295,9 @@ importers:
 
   packages/kit:
     dependencies:
+      '@vyui/core':
+        specifier: workspace:^
+        version: link:../core
       defu:
         specifier: ^6.1.5
         version: 6.1.7
@@ -314,9 +317,6 @@ importers:
       '@vue/tsconfig':
         specifier: ^0.7.0
         version: 0.7.0(typescript@5.9.3)(vue@3.5.17(typescript@5.9.3))
-      '@vyui/core':
-        specifier: workspace:*
-        version: link:../core
       '@vyui/shared-build-config':
         specifier: workspace:*
         version: link:../shared-build-config


### PR DESCRIPTION
Stops the changeset release PR from bumping `@vyui/kit` to 1.0.0.

- Moved `@vyui/core` from `peerDependencies` (`workspace:~`) to `dependencies` (`workspace:^`); dropped the redundant `devDependencies` entry.
- Peer-dep out-of-range bumps force a major in changesets, so core `0.0.4 → 0.1.0` dragged kit to `1.0.0`.
- As a regular dependency the `updateInternalDependencies: patch` rule applies; `changeset status` now reports both at `0.1.0`.
- Consumers now get `@vyui/core` transitively instead of installing it themselves.

Once merged to main, the changesets bot regenerates PR #51 with the corrected `0.1.0` versions.