### PR TITLE
fix(core): animate DropdownMenu open/close + kill the close-linger

### DIFF
--- a/packages/core/src/components/DropdownMenu/DropdownMenu.test.ts
+++ b/packages/core/src/components/DropdownMenu/DropdownMenu.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, waitForUpdate } from '@vyui/testing-utils'
 import { overlayEntries } from '@/components/OverlayRoot/overlayStore'
 import DropdownMenu from './story/_DropdownMenu.vue'
@@ -28,6 +28,23 @@ describe('dropdownMenu', () => {
     await waitForUpdate()
     expect(q(container, 'content')).not.toBeNull()
     expect(q(container, 'trigger')!.getAttribute('data-state')).toBe('open')
+  })
+
+  it('content carries the Presence animation hook + reaches open state', async () => {
+    // Proves the Impl is animated: `DropdownMenuContent` bridges its
+    // `PresenceContextKey` through the overlay portal, so the menu surface
+    // gets the `vyui-dropdown-content` hook + presence-derived `data-state`
+    // the enter/leave keyframes rely on. (A missing bridge would default the
+    // injected state to `Entered`; instead the live Presence lifecycle drives
+    // it Initial → Entering → Entered as the rAF frames advance.)
+    const { container } = render(DropdownMenu)
+    fireEvent.tap(q(container, 'trigger')!)
+    await waitForUpdate()
+    expect(q(container, 'content')!.className).toContain('vyui-dropdown-content')
+    await vi.waitFor(
+      () => expect(q(container, 'content')!.getAttribute('data-state')).toBe('open'),
+      { timeout: 1000, interval: 20 },
+    )
   })
 
   it('toggles closed on a second trigger tap', async () => {

--- a/packages/core/src/components/DropdownMenu/DropdownMenuContent.vue
+++ b/packages/core/src/components/DropdownMenu/DropdownMenuContent.vue
@@ -30,16 +30,18 @@ const id = useId()
 const attrs = useAttrs()
 const slots = useSlots()
 const emitAsProps = useEmitAsProps(emit)
-// `provides` is captured from this instance so menu items rendered through the
-// OverlayRoot portal still inject DropdownMenuRootContext — DropdownMenuRoot is
-// an ancestor, so its provided context is already on this chain.
-const capturedProvides = captureProvides()
 
 // Registered with the overlay store while present, unregistered when gone. It
 // is its own component so `Presence` owns the mount/unmount (and exit anim).
 const PortalRegistration = defineComponent({
   name: 'DropdownMenuContentPortal',
   setup() {
+    // Capture provides HERE — inside the `<Presence>` subtree — so the
+    // portaled Impl injects BOTH `DropdownMenuRootContext` (from the ancestor
+    // Root) AND `PresenceContextKey` (provided by the `<Presence>` parent).
+    // The latter is what lets the Impl wire enter/leave animation handlers;
+    // capturing in the outer setup (above Presence) misses that key.
+    const capturedProvides = captureProvides()
     registerOverlay(id, () => h(
       DropdownMenuContentImpl,
       {

--- a/packages/core/src/components/DropdownMenu/DropdownMenuContentImpl.vue
+++ b/packages/core/src/components/DropdownMenu/DropdownMenuContentImpl.vue
@@ -14,8 +14,14 @@ export type DropdownMenuContentImplEmits = DismissableLayerEmits
 </script>
 
 <script setup lang="ts">
+import { computed, inject } from 'vue'
 import { OverlayBackdrop } from '@/components/OverlayRoot'
 import { Primitive } from '@/components/Primitive'
+import {
+  PresenceContextKey,
+  PresenceState,
+  presenceClassVariants,
+} from '@/components/Presence'
 import { useA11y, useDismissableLayer } from '@/shared/composables'
 import { injectDropdownMenuRootContext } from './DropdownMenuRoot.vue'
 
@@ -33,6 +39,40 @@ const { onInteractOutside } = useDismissableLayer({
   onDismiss: () => rootContext.onOpenChange(false),
 })
 
+// --- Enter / leave animation -------------------------------------------
+// `DropdownMenuContent` wraps this Impl in `<Presence>` and captures its
+// provides through the overlay portal, so `PresenceContextKey` resolves here
+// even though we render outside the original tree. Wiring the animation
+// handlers + a leave keyframe is what stops the ~400ms `MAX_WAIT_FRAMES`
+// linger on close (Presence sat in `Leaving` waiting for an `animationstart`
+// that never fired) and gives the menu a real scale/fade on open.
+const presence = inject(PresenceContextKey, null)
+
+const presenceState = computed<PresenceState>(() =>
+  presence?.controllers.state.value ?? PresenceState.Entered,
+)
+
+// `transition: true` opts into the `ui-entering` / `ui-leaving` classes the
+// keyframes below hook; `className` carries the stable hook the CSS targets
+// (the kit surface classes arrive separately via `$attrs`).
+const presenceClass = computed(() =>
+  presenceClassVariants({
+    state: presenceState.value,
+    enableDelay: false,
+    transition: true,
+    className: 'vyui-dropdown-content',
+  }),
+)
+
+const dataState = computed(() =>
+  presenceState.value === PresenceState.Leaving
+  || presenceState.value === PresenceState.Left
+    ? 'closed'
+    : 'open',
+)
+
+const handlers = presence?.animationHandlers
+
 /** Swallow taps on the menu surface so they don't reach the backdrop. */
 function stopTap(event: any) {
   event?.stopPropagation?.()
@@ -47,11 +87,59 @@ function stopTap(event: any) {
   >
     <Primitive
       :as="as"
-      :data-state="rootContext.open.value ? 'open' : 'closed'"
+      :data-state="dataState"
+      :class="presenceClass"
       v-bind="{ ...$attrs, ...a11y }"
       @tap="stopTap"
+      @animationstart="handlers?.handleKFStart"
+      @animationend="handlers?.handleKFEnd"
+      @animationcancel="handlers?.handleKFCancel"
+      @transitionstart="handlers?.handleTransitionStart"
+      @transitionend="handlers?.handleTransitionEnd"
+      @transitioncancel="handlers?.handleTransitionCancel"
     >
       <slot />
     </Primitive>
   </OverlayBackdrop>
 </template>
+
+<style>
+/* Animation hook only — the menu's surface (bg / border / radius / shadow /
+   padding) comes from the kit `ui.content` classes via `$attrs`. We add just
+   the transform-origin + the resting hidden state so the entrance plays from
+   the anchored (top) edge. Open/close are driven by the Presence state machine
+   toggling `ui-entering` / `ui-leaving`; `@animationend` advances it so the
+   menu unmounts the instant the slide-out finishes (no MAX_WAIT_FRAMES wait). */
+.vyui-dropdown-content {
+  transform-origin: top center;
+  /* Hidden at rest so the freshly-mounted menu doesn't flash before the
+     entrance keyframe runs (Presence holds `ui-closed` for a few frames while
+     layout settles). `ui-open` + the keyframes' `both` fill take over from
+     here. */
+  opacity: 0;
+  transform: scale(0.96);
+}
+
+.vyui-dropdown-content.ui-open {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.vyui-dropdown-content.ui-entering {
+  animation: vyui-dropdown-in 150ms ease-out both;
+}
+
+.vyui-dropdown-content.ui-leaving {
+  animation: vyui-dropdown-out 120ms ease-in both;
+}
+
+@keyframes vyui-dropdown-in {
+  from { opacity: 0; transform: scale(0.96) translateY(-4px); }
+  to   { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+@keyframes vyui-dropdown-out {
+  from { opacity: 1; transform: scale(1) translateY(0); }
+  to   { opacity: 0; transform: scale(0.96) translateY(-4px); }
+}
+</style>


### PR DESCRIPTION
Adds a real enter/leave animation to `DropdownMenu` and fixes the open/close hesitation.

The menu surface had no keyframes and never wired Presence's animation handlers, so on close Presence sat in `Leaving` waiting up to `MAX_WAIT_FRAMES` (~400ms) for an `animationstart` that never fired before unmounting — the menu visibly lingered. Open had no entrance at all.

- Bridge `PresenceContextKey` through the overlay portal by capturing provides inside the portal registration (within the `<Presence>` subtree), so the portaled Impl can inject it.
- Wire the Impl surface to `presenceClass` + the Presence animation handlers; `@animationend` now advances the state machine so the menu unmounts the instant the slide-out finishes.
- Add scale/fade enter/leave keyframes (`vyui-dropdown-content`), gated on the Presence lifecycle so a freshly-mounted menu doesn't flash before it animates.
- Drive content `data-state` off the Presence lifecycle (matches Sheet).

Mirrors how `SheetContentImpl` wires Presence. Animation is CSS-keyframe based (works on Lynx + web); no main-thread worklets involved.

Tests: added a case asserting the menu bridges Presence (carries the `vyui-dropdown-content` hook and advances to the `open` state); full core suite green (820 passed).