### PR TITLE
refactor(core): headless Dialog motion + fix first-open backdrop flash

### DIFF
--- a/packages/core/src/components/Dialog/DialogContentImpl.vue
+++ b/packages/core/src/components/Dialog/DialogContentImpl.vue
@@ -34,11 +34,21 @@ export interface DialogContentImplProps extends PrimitiveProps {
    */
   backdropStyle?: Record<string, any>
   /**
+   * Class merged onto the full-screen backdrop wrapper (the `OverlayBackdrop`
+   * that centers the panel). Core ships no dim or animation of its own — the
+   * styled layer passes the dim colour + a marker class here so the backdrop
+   * fades in step with the panel. The element carries the Presence lifecycle
+   * classes (`ui-entering` / `ui-leaving` / `ui-open` / `ui-closed`) and the
+   * `bindanimation*` hooks, so the styled layer's keyframes (keyed off those
+   * classes) drive the Presence lifecycle just like the panel's.
+   */
+  backdropClass?: string
+  /**
    * Opt the backdrop / panel into the animating-state classes
    * (`ui-entering` / `ui-leaving` / `ui-animating` alongside the static
    * `ui-open` / `ui-closed` pair). Off by default so callers that don't
    * style transitions don't get extra classes; on for any caller wiring up
-   * `vyui-fade-*` / `vyui-zoom-*` keyframes.
+   * keyframes.
    * @defaultValue true
    */
   transition?: boolean
@@ -135,6 +145,7 @@ const BackdropLayer = defineComponent({
   name: 'DialogBackdropLayer',
   props: {
     backdropStyle: { type: Object, default: () => ({}) },
+    backdropClass: { type: String, default: '' },
   },
   emits: ['tap'],
   setup(p, { slots, emit }) {
@@ -158,7 +169,7 @@ const BackdropLayer = defineComponent({
       OverlayBackdrop,
       {
         'backdropStyle': p.backdropStyle,
-        'class': className.value,
+        'class': [className.value, p.backdropClass],
         'data-state': dataState.value,
         'onTap': () => emit('tap'),
         // Lynx animation/transition lifecycle bindings — without these the
@@ -244,6 +255,7 @@ const PanelLayer = defineComponent({
   >
     <BackdropLayer
       :backdrop-style="props.backdropStyle"
+      :backdrop-class="props.backdropClass"
       @tap="onInteractOutside"
     >
       <Presence
@@ -268,27 +280,11 @@ const PanelLayer = defineComponent({
 </template>
 
 <!--
-  Backdrop fade + panel zoom — the `vyui-fade-*` / `vyui-zoom-*` keyframes
-  themselves ship from `components/Presence/presence.css` (side-effect
-  imported via `components/Presence/index.ts`) so they're shared across
-  Dialog / AlertDialog / Sheet. This block just wires the per-class
-  selectors that fire the `ui-entering` / `ui-leaving` animations on the
-  Dialog-specific classes (`vyui-dialog-backdrop` / `vyui-dialog-content`).
-
-  Enter: 250ms, `cubic-bezier(0.16, 1, 0.3, 1)` (decel out).
-  Exit:  200ms, `cubic-bezier(0.5, 0, 0.75, 0)` (accel in).
+  Headless: core ships no animation of its own. `vyui-dialog-backdrop` /
+  `vyui-dialog-content` are stable hook classes carrying `data-state` +
+  `ui-entering` / `ui-leaving` + the `bindanimation*` lifecycle bindings; the
+  styled layer (`@vyui/kit`) supplies the keyframes — keyed off those lifecycle
+  classes — on the backdrop (`backdropClass`) and panel (`class`). With no
+  keyframes the panel simply mounts/unmounts — Presence's 24-frame fallback
+  covers it.
 -->
-<style scoped>
-.vyui-dialog-backdrop.ui-entering {
-  animation: vyui-fade-in 250ms cubic-bezier(0.16, 1, 0.3, 1) both;
-}
-.vyui-dialog-backdrop.ui-leaving {
-  animation: vyui-fade-out 200ms cubic-bezier(0.5, 0, 0.75, 0) both;
-}
-.vyui-dialog-content.ui-entering {
-  animation: vyui-zoom-in 250ms cubic-bezier(0.16, 1, 0.3, 1) both;
-}
-.vyui-dialog-content.ui-leaving {
-  animation: vyui-zoom-out 200ms cubic-bezier(0.5, 0, 0.75, 0) both;
-}
-</style>

--- a/packages/core/src/components/Dialog/DialogContentModal.vue
+++ b/packages/core/src/components/Dialog/DialogContentModal.vue
@@ -39,7 +39,8 @@ function render() {
       ...emitsAsProps,
       ...attrs,
       // Modal: focus would be trapped on the DOM; no-op on Lynx but kept for
-      // API parity. The screen behind is dimmed by `DialogOverlay`, not here.
+      // API parity. The screen behind is dimmed via `backdropClass` on the
+      // Presence-wired backdrop (so the dim fades with the panel).
       trapFocus: rootContext.open.value,
     },
     () => slots.default?.(),

--- a/packages/core/src/components/Sheet/SheetBackdropImpl.vue
+++ b/packages/core/src/components/Sheet/SheetBackdropImpl.vue
@@ -77,6 +77,19 @@ const handlers = presence?.animationHandlers
 </template>
 
 <style>
+/* Hidden at rest AND through Presence's mount→enter gap (the element mounts
+   ~8 frames before the state flips to Entering). Without this the dim paints
+   at full opacity for those frames, then snaps to 0 and fades in — the
+   first-open flash. `ui-open` is the resting-visible state; the keyframes
+   bridge the transitions. */
+.vyui-sheet__backdrop {
+  opacity: 0;
+}
+
+.vyui-sheet__backdrop.ui-open {
+  opacity: 1;
+}
+
 .vyui-sheet__backdrop.ui-entering {
   animation: vyui-fade-in 280ms ease-out both;
 }

--- a/packages/kit/src/components/Modal.vue
+++ b/packages/kit/src/components/Modal.vue
@@ -106,7 +106,6 @@ import {
   DialogRoot,
   DialogTrigger,
   DialogPortal,
-  DialogOverlay,
   DialogContent,
   DialogTitle,
   DialogDescription,
@@ -165,12 +164,8 @@ const resolvedCloseIcon = computed(() => props.closeIcon || appConfig.ui.icons?.
     </DialogTrigger>
 
     <DialogPortal>
-      <DialogOverlay
-        v-if="overlay"
-        :class="ui.overlay({ class: props.ui?.overlay })"
-      />
-
       <DialogContent
+        :backdrop-class="overlay ? ui.overlay({ class: props.ui?.overlay }) : undefined"
         :class="ui.content({ class: props.ui?.content })"
       >
         <slot v-if="hasContentSlot" name="content" :close="close" />

--- a/packages/kit/src/style.css
+++ b/packages/kit/src/style.css
@@ -146,3 +146,33 @@
   --ui-warning:   var(--ui-color-warning-400);
   --ui-error:     var(--ui-color-error-400);
 }
+
+/*
+ * ── Modal (Dialog) open/close motion ───────────────────────────────────────
+ * @vyui/core is headless — it ships no animation, only the Presence lifecycle
+ * hook classes (`ui-entering` / `ui-leaving` / `ui-open` / `ui-closed`) on the
+ * backdrop + panel. `VyModal`'s theme tags those elements with the
+ * `vy-modal-overlay` / `vy-modal-content` markers (the `transition` variant);
+ * the choreography lives here.
+ *
+ * Why lifecycle classes and not `data-[state]`: Presence mounts the surface ~8
+ * frames before it flips to `Entering`. The base rule below keeps it at
+ * `opacity: 0` through that mount→enter gap, so the dim never paints
+ * full-opacity before the fade-in (the long-standing first-open flash). And
+ * `ui-leaving` fires the exit ONLY on a real close — `data-[state=closed]`
+ * can't tell "freshly mounted, closed" from "closing", so it would wrongly run
+ * the exit animation on open.
+ *
+ * Keyframes (`vyui-fade-*` / `vyui-zoom-*`) ship from `@vyui/core`'s
+ * `presence.css`. `both` fill-mode holds the start state before and the end
+ * state after each run.
+ */
+.vy-modal-overlay { opacity: 0; }
+.vy-modal-overlay.ui-open { opacity: 1; }
+.vy-modal-overlay.ui-entering { animation: vyui-fade-in 250ms ease-out both; }
+.vy-modal-overlay.ui-leaving  { animation: vyui-fade-out 200ms ease-in both; }
+
+.vy-modal-content { opacity: 0; }
+.vy-modal-content.ui-open { opacity: 1; }
+.vy-modal-content.ui-entering { animation: vyui-zoom-in 250ms ease-out both; }
+.vy-modal-content.ui-leaving  { animation: vyui-zoom-out 200ms ease-in both; }

--- a/packages/kit/src/theme/modal.ts
+++ b/packages/kit/src/theme/modal.ts
@@ -11,7 +11,17 @@
  *
  * Stripped: all `dark:*`, `focus:*`, `focus-visible:*`, `shadow-*`,
  * `transition-shadow`. `ring-*` converted to `border-*` (Lynx preset has no
- * ringWidth plugin). Kept `data-[state=...]:*` animation classes.
+ * ringWidth plugin).
+ *
+ * Motion: core is headless (ships no animation). `overlay` lands on the
+ * Presence-wired backdrop via the Dialog's `backdropClass`; `content` lands on
+ * the panel. Both elements carry the Presence lifecycle classes
+ * (`ui-entering` / `ui-leaving` / `ui-open` / `ui-closed`), so the open/close
+ * choreography is keyed off the `vy-modal-overlay` / `vy-modal-content` marker
+ * classes in `style.css` — NOT `data-[state]`. Lifecycle classes are required
+ * here: they keep the surface hidden during Presence's mount→enter gap (so the
+ * dim doesn't flash full-opacity before fading in) and fire the exit animation
+ * only on a real close.
  */
 export default {
   slots: {
@@ -28,8 +38,8 @@ export default {
   variants: {
     transition: {
       true: {
-        overlay: 'data-[state=open]:animate-[fade-in_200ms_ease-out] data-[state=closed]:animate-[fade-out_200ms_ease-in]',
-        content: 'data-[state=open]:animate-[scale-in_200ms_ease-out] data-[state=closed]:animate-[scale-out_200ms_ease-in]',
+        overlay: 'vy-modal-overlay',
+        content: 'vy-modal-content',
       },
     },
   },


### PR DESCRIPTION
Makes core's Dialog motion headless — core ships only the Presence lifecycle hooks (`data-state`, `ui-*`, `bindanimation*`); the open/close keyframes move to `@vyui/kit`. Also fixes the long-standing flash where the dim painted full-opacity before fading in.

- core Dialog: add `backdropClass`, routing the dim onto the Presence-wired animated backdrop; strip the baked fade/zoom `<style>`
- kit Modal: drop the separate non-animated `<DialogOverlay>` — the dim now rides the animated backdrop via `backdrop-class`, so it fades instead of popping (was a real bug)
- kit: move the choreography to `style.css`, keyed off the `ui-*` lifecycle classes rather than `data-[state]` — keeps the surface hidden through Presence's mount→enter gap and fires the exit only on a real close
- core Sheet: hide the backdrop until `ui-open` so Drawer/ActionSheet stop flashing on first open

Scoped out deliberately: the Sheet *slide* stays in core (it's the drag-to-dismiss kinematics); AlertDialog untouched (core-only, no kit consumer).

Verified: 819 core tests pass; both packages typecheck clean.