### PR TITLE
fix(examples): swap island expand icon to collapse variant when dock opens

### DIFF
--- a/apps/examples/linear-demo/src/sections/BottomDock.vue
+++ b/apps/examples/linear-demo/src/sections/BottomDock.vue
@@ -1,105 +1,106 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
-import {
-  VyIsland,
-  VyIslandButton,
-  VyIslandGroup,
-} from '@vyui/kit'
-import AiChatDrawer from '../components/AiChatDrawer.vue'
+import { computed, ref } from "vue";
+import { VyIsland, VyIslandButton, VyIslandGroup } from "@vyui/kit";
+import AiChatDrawer from "../components/AiChatDrawer.vue";
 
 // Active tab is owned by the parent so it can swap the page contents (inbox
 // vs notifications). Mode stays local — drives row morphing (default →
 // search takeover) and doesn't affect routing.
-const tab = defineModel<string | number | null>('tab', { default: 'inbox' })
-const dockMode = ref<string>('default')
-const dockOpen = ref<boolean>(false)
+const tab = defineModel<string | number | null>("tab", { default: "inbox" });
+const dockMode = ref<string>("default");
+const dockOpen = ref<boolean>(false);
 
 // Search takes over the bar (full viewport width). The actions dropup keeps
 // the dock at its natural width and just sprouts a same-width panel above
 // it. AI pill is hidden in either case so the takeover (or the dropup) reads
 // as the focused surface.
-const isSearchMode = computed(() => dockMode.value === 'fullisland')
-const isTakeover = computed(() => isSearchMode.value || dockOpen.value)
+const isSearchMode = computed(() => dockMode.value === "fullisland");
+const isTakeover = computed(() => isSearchMode.value || dockOpen.value);
 </script>
 
 <template>
-  <!-- `position="bottom"` floats the group fixed over the viewport (the
+    <!-- `position="bottom"` floats the group fixed over the viewport (the
        component owns the Lynx-safe inline positioning). The `gap-2` :ui
        override tightens spacing between the main dock and trailing AI pill
        (default `lg` group gap reads as too airy here). -->
-  <VyIslandGroup
-    position="bottom"
-    size="lg"
-    :ui="{ root: 'gap-2' }"
-  >
-    <VyIsland
-      v-model:mode="dockMode"
-      v-model:value="tab"
-      v-model:open="dockOpen"
-      layer="inline"
-      size="lg"
-      expand-style="attached"
-      :style="isSearchMode
-        ? { flexGrow: 1, marginLeft: '16px', marginRight: '16px' }
-        : undefined"
-    >
-      <VyIslandButton value="inbox"     icon="icon-park-outline:inbox-in" />
-      <VyIslandButton mode="fullisland" icon="icon-park-outline:search" />
-      <VyIslandButton value="bell"      icon="icon-park-outline:remind" />
-      <VyIslandButton :expand="true" icon="icon-park-outline:expand-text-input" />
+    <VyIslandGroup position="bottom" size="lg" :ui="{ root: 'gap-2' }">
+        <VyIsland
+            v-model:mode="dockMode"
+            v-model:value="tab"
+            v-model:open="dockOpen"
+            layer="inline"
+            size="lg"
+            expand-style="attached"
+            :style="
+                isSearchMode
+                    ? { flexGrow: 1, marginLeft: '16px', marginRight: '16px' }
+                    : undefined
+            "
+        >
+            <VyIslandButton value="inbox" icon="icon-park-outline:inbox-in" />
+            <VyIslandButton mode="fullisland" icon="icon-park-outline:search" />
+            <VyIslandButton value="bell" icon="icon-park-outline:remind" />
+            <VyIslandButton
+                :expand="true"
+                :icon="
+                    dockOpen
+                        ? 'icon-park-outline:collapse-text-input'
+                        : 'icon-park-outline:expand-text-input'
+                "
+            />
 
-      <template #fullisland>
-        <!-- Search pill stretches to fill the (now full-width) island; the
+            <template #fullisland>
+                <!-- Search pill stretches to fill the (now full-width) island; the
              close pill stays icon-sized so the row reads as "input + X". -->
-        <VyIslandButton
-          reset
-          icon="icon-park-outline:search"
-          label="Search issues…"
-          :style="{ flexGrow: 1, justifyContent: 'flex-start' }"
-        />
-        <VyIslandButton reset icon="icon-park-outline:close" />
-      </template>
+                <VyIslandButton
+                    reset
+                    icon="icon-park-outline:search"
+                    label="Search issues…"
+                    :style="{ flexGrow: 1, justifyContent: 'flex-start' }"
+                />
+                <VyIslandButton reset icon="icon-park-outline:close" />
+            </template>
 
-      <template #expanded>
-        <!-- Dropup menu — panel renders above the row (island default for
+            <template #expanded>
+                <!-- Dropup menu — panel renders above the row (island default for
              non-`top` position). Each item dismisses the panel via `expand`,
              which toggles `open` (currently true → closes). Width follows the
              panel min-w override above; items left-align so labels read as a
              vertical list rather than centered chips. -->
-        <VyIslandButton
-          :expand="true"
-          icon="icon-park-outline:add"
-          label="New issue"
-          class="w-full justify-start"
-        />
-        <VyIslandButton
-          :expand="true"
-          icon="icon-park-outline:filter"
-          label="Filter"
-          class="w-full justify-start"
-        />
-        <VyIslandButton
-          :expand="true"
-          icon="icon-park-outline:setting"
-          label="Settings"
-          class="w-full justify-start"
-        />
-      </template>
-    </VyIsland>
+                <VyIslandButton
+                    :expand="true"
+                    icon="icon-park-outline:add"
+                    label="New issue"
+                    class="w-full justify-start"
+                />
+                <VyIslandButton
+                    :expand="true"
+                    icon="icon-park-outline:filter"
+                    label="Filter"
+                    class="w-full justify-start"
+                />
+                <VyIslandButton
+                    :expand="true"
+                    icon="icon-park-outline:setting"
+                    label="Settings"
+                    class="w-full justify-start"
+                />
+            </template>
+        </VyIsland>
 
-    <!-- Trailing companion island: standalone AI action pill. `px-0` drops the
+        <!-- Trailing companion island: standalone AI action pill. `px-0` drops the
          horizontal padding so the chrome hugs the single 56px button (avoids
          the chunky look next to the dense main dock); `py-2` is kept so the
          overall pill height matches the main dock. Hidden in search-takeover
          and while the actions dropup is open so attention stays on the
          focused surface. -->
-    <VyIsland
-      v-if="!isTakeover"
-      layer="inline"
-      size="lg"
-      :ui="{ row: 'px-0 py-2' }"
-    >
-      <AiChatDrawer />
-    </VyIsland>
-  </VyIslandGroup>
+        <VyIsland
+            v-if="!isTakeover"
+            layer="inline"
+            size="lg"
+            :ui="{ row: 'px-2 py-2' }"
+        >
+            <AiChatDrawer />
+        </VyIsland>
+    </VyIslandGroup>
 </template>


### PR DESCRIPTION
Fix up the icons to change between on the island, and also some styling for the side icon