### PR TITLE
Feat/issue 9 UI class migration

### DIFF
--- a/apps/examples/kit-demo/src/sections/OverlaySection.vue
+++ b/apps/examples/kit-demo/src/sections/OverlaySection.vue
@@ -1,23 +1,22 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import { ToastProvider, ToastViewport } from '@vyui/core'
 import {
   VyButton,
   VyCombobox,
   VyDrawer,
   VyDropdownMenu,
   VyModal,
-  VyPopover,
   VySelect,
+  VyToast,
 } from '@vyui/kit'
 
 const modalOpen = ref(false)
 const drawerOpen = ref(false)
 const dropdownOpen = ref(false)
 
-// Notifications — each entry gets its own popover open state so tapping one
-// reveals its "bit of info" without affecting the others. Replaces the
-// retired Tooltip component (Lynx is touch-first; popover-on-tap is the
-// idiomatic substitute for hover-only tooltip semantics).
+// Notifications — each entry has a "Show" button that surfaces its detail as a
+// transient Toast (one at a time, auto-dismissing).
 const notifications = [
   {
     id: 'n1',
@@ -41,7 +40,18 @@ const notifications = [
     detail: 'Diff: packages/kit/src/components/Island.vue. Open the PR to view the inline thread.',
   },
 ]
-const notificationOpen = ref<string | null>(null)
+// Each notification surfaces its detail as a transient Toast — tapping a row's
+// button shows it, and it auto-dismisses. Only one toast is shown at a time.
+type Notification = (typeof notifications)[number]
+const activeToast = ref<Notification | null>(null)
+let toastTimer: ReturnType<typeof setTimeout> | undefined
+function showNotification(n: Notification) {
+  activeToast.value = n
+  if (toastTimer) clearTimeout(toastTimer)
+  toastTimer = setTimeout(() => {
+    activeToast.value = null
+  }, 3200)
+}
 const dropdownItems = [
   [
     { label: 'Profile',  icon: 'icon-park-outline:user' },
@@ -91,32 +101,23 @@ const fruitItems = [
     <view class="bg-white border border-slate-200 rounded-lg p-4 flex flex-col gap-2">
       <text class="text-slate-900 text-base font-semibold">Notifications</text>
       <text class="text-slate-500 text-xs">
-        Tap a notification to reveal the full detail in a popover — touch
-        analogue of a hover tooltip.
+        Tap a notification's button to surface its detail as a transient toast.
       </text>
       <view class="flex flex-col gap-2">
-        <VyPopover
+        <view
           v-for="n in notifications"
           :key="n.id"
-          :open="notificationOpen === n.id"
-          @update:open="(v) => { notificationOpen = v ? n.id : null }"
+          class="flex flex-row items-center gap-3 px-3 py-2.5 bg-slate-50 border border-slate-200 rounded-lg"
         >
-          <view class="flex flex-row items-center gap-3 px-3 py-2.5 bg-slate-50 border border-slate-200 rounded-lg">
-            <view class="w-8 h-8 rounded-full bg-white border border-slate-200 flex flex-row items-center justify-center shrink-0">
-              <text class="text-slate-700 text-base">•</text>
-            </view>
-            <view class="flex flex-col flex-1 min-w-0 gap-0.5">
-              <text class="text-slate-900 text-sm font-medium truncate">{{ n.title }}</text>
-              <text class="text-slate-500 text-xs truncate">{{ n.summary }}</text>
-            </view>
+          <view class="w-8 h-8 rounded-full bg-white border border-slate-200 flex flex-row items-center justify-center shrink-0">
+            <text class="text-slate-700 text-base">•</text>
           </view>
-          <template #content>
-            <view class="flex flex-col gap-1.5 p-3 max-w-72">
-              <text class="text-slate-900 text-sm font-semibold">{{ n.title }}</text>
-              <text class="text-slate-700 text-xs">{{ n.detail }}</text>
-            </view>
-          </template>
-        </VyPopover>
+          <view class="flex flex-col flex-1 min-w-0 gap-0.5">
+            <text class="text-slate-900 text-sm font-medium truncate">{{ n.title }}</text>
+            <text class="text-slate-500 text-xs truncate">{{ n.summary }}</text>
+          </view>
+          <VyButton color="neutral" variant="soft" size="sm" label="Show" @tap="showNotification(n)" />
+        </view>
       </view>
     </view>
 
@@ -150,4 +151,21 @@ const fruitItems = [
       <text class="text-slate-500 text-xs">Fruit: {{ comboboxFruit }}</text>
     </view>
   </view>
+
+  <!-- Transient toast for the tapped notification. Kept OUTSIDE the section's
+       gapped flex column (a second template root) so its placeholder doesn't add
+       a `gap-4` slot. `ToastViewport` paints through the app-root OverlayRoot
+       portal and owns the fixed positioning; `ToastProvider` gives ToastRoot its
+       context. Bindings are null-safe — the portal can re-render the captured
+       slot once `activeToast` flips back to null, before the v-if unmounts. -->
+  <ToastProvider v-if="activeToast">
+    <ToastViewport position="top" :style="{ paddingTop: '16px', zIndex: 60 }">
+      <VyToast
+        :title="activeToast?.title"
+        :description="activeToast?.detail"
+        :icon="activeToast?.icon"
+        :close="false"
+      />
+    </ToastViewport>
+  </ToastProvider>
 </template>

--- a/apps/examples/kit-demo/src/sections/OverlaySection.vue
+++ b/apps/examples/kit-demo/src/sections/OverlaySection.vue
@@ -8,21 +8,11 @@ import {
   VyModal,
   VyPopover,
   VySelect,
-  VySwiper,
 } from '@vyui/kit'
 
 const modalOpen = ref(false)
 const drawerOpen = ref(false)
 const dropdownOpen = ref(false)
-
-// Swiper hosted inside the modal — confirms `useDragGesture` works within the
-// overlay layer (gestures aren't swallowed by the backdrop / portal).
-const modalSwiperIndex = ref(0)
-const modalSlides = [
-  { label: 'Slide 1', tint: 'bg-sky-500' },
-  { label: 'Slide 2', tint: 'bg-violet-500' },
-  { label: 'Slide 3', tint: 'bg-emerald-500' },
-]
 
 // Notifications — each entry gets its own popover open state so tapping one
 // reveals its "bit of info" without affecting the others. Replaces the
@@ -85,24 +75,14 @@ const fruitItems = [
   <view class="flex flex-col gap-4 pt-2">
     <view class="bg-white border border-slate-200 rounded-lg p-4 flex flex-col gap-2">
       <text class="text-slate-900 text-base font-semibold">Modal</text>
-      <text class="text-slate-500 text-xs">Dialog with overlay backdrop — hosts an interactive Swiper.</text>
-      <VyModal v-model:open="modalOpen" title="Modal title" description="Drag the carousel below — gestures work inside the dialog.">
+      <text class="text-slate-500 text-xs">Dialog with overlay backdrop.</text>
+      <VyModal v-model:open="modalOpen" title="Modal title" description="A centered dialog with an overlay backdrop.">
         <VyButton color="neutral" variant="subtle" label="Open modal" />
         <template #content>
           <view class="flex flex-col gap-3 p-4">
-            <VySwiper
-              v-model="modalSwiperIndex"
-              :items="modalSlides"
-              :item-width="260"
-              show-indicators
-            >
-              <template #item="{ item }">
-                <view :class="['h-32 rounded-lg flex items-center justify-center', item.tint]" :style="{ width: '244px' }">
-                  <text class="text-white text-lg font-bold">{{ item.label }}</text>
-                </view>
-              </template>
-            </VySwiper>
-            <text class="text-slate-500 text-xs">Active: {{ modalSwiperIndex + 1 }} / {{ modalSlides.length }}</text>
+            <text class="text-slate-600 text-sm">
+              Modal content goes here. Tap the backdrop or the close control to dismiss.
+            </text>
           </view>
         </template>
       </VyModal>

--- a/apps/examples/kit-demo/tailwind.config.ts
+++ b/apps/examples/kit-demo/tailwind.config.ts
@@ -1,6 +1,20 @@
 import type { Config } from 'tailwindcss'
-import lynxPreset from '@lynx-js/tailwind-preset'
-import { COLORS, createVyuiPreset } from '@vyui/kit/tailwind'
+import { createLynxPreset } from '@lynx-js/tailwind-preset'
+import { COLORS, createVyuiPreset, VYUI_UI_STATES } from '@vyui/kit/tailwind'
+
+// Extend the lynx preset's `uiVariants` with the extra `ui-*` state markers the
+// kit themes use (`ui-on:`, `group-ui-completed:`, …) — the class-based
+// replacements for Lynx-incompatible `data-[state=…]` selectors (issue #9).
+const lynxPreset = createLynxPreset({
+  lynxUIPlugins: {
+    uiVariants: {
+      prefixes: defaults => ({
+        ...defaults,
+        ui: [...defaults.ui, ...VYUI_UI_STATES],
+      }),
+    },
+  },
+})
 
 // Lynx-targeted Tailwind v3 config. Two presets:
 //   - `@lynx-js/tailwind-preset`: utility set + variants Lynx understands.

--- a/packages/core/src/components/Accordion/AccordionTrigger.vue
+++ b/packages/core/src/components/Accordion/AccordionTrigger.vue
@@ -26,6 +26,11 @@ itemContext.triggerId ||= useId(undefined, 'vy-accordion-trigger')
     data-vyui-collection-item
     :as="props.as"
     :as-child="props.asChild"
+    :class="{
+      'ui-open': itemContext.dataState.value === 'open',
+      'ui-closed': itemContext.dataState.value === 'closed',
+      'ui-disabled': itemContext.disabled.value,
+    }"
     :data-disabled="itemContext.dataDisabled.value"
     :data-orientation="rootContext.orientation"
     :data-state="itemContext.dataState.value"

--- a/packages/core/src/components/Combobox/ComboboxItem.vue
+++ b/packages/core/src/components/Combobox/ComboboxItem.vue
@@ -113,6 +113,7 @@ provideComboboxItemContext({ isSelected })
     :as-child="asChild"
     :id="id"
     data-vyui-combobox-item=""
+    :class="{ 'ui-checked': isSelected, 'ui-disabled': isDisabled, 'ui-highlighted': isSelected }"
     :data-state="isSelected ? 'checked' : 'unchecked'"
     :data-disabled="isDisabled ? '' : undefined"
     :data-highlighted="isSelected ? '' : undefined"

--- a/packages/core/src/components/Dialog/DialogContentImpl.vue
+++ b/packages/core/src/components/Dialog/DialogContentImpl.vue
@@ -57,7 +57,7 @@ export interface DialogContentImplProps extends PrimitiveProps {
 
 <script setup lang="ts">
 import type { PropType } from 'vue'
-import { computed, defineComponent, h, inject } from 'vue'
+import { computed, defineComponent, h, inject, mergeProps } from 'vue'
 import { OverlayBackdrop } from '@/components/OverlayRoot'
 import { Primitive, type AsTag } from '@/components/Primitive'
 import {
@@ -217,28 +217,35 @@ const PanelLayer = defineComponent({
       className: 'vyui-dialog-content',
       transition: props.transition,
     }))
+    // `mergeProps` (not object spread) so the inbound `$attrs` class — the kit
+    // panel class (`vy-modal-content …`) — is CONCATENATED with the Presence
+    // lifecycle classes instead of overwriting them. A plain `{ class, ...attrs }`
+    // lets `attrs.class` clobber `ui-open` / `ui-entering`, leaving the panel
+    // stuck at the `vy-modal-content { opacity: 0 }` base (dialog opens invisible).
     return () => h(
       Primitive,
-      {
-        'as': p.as,
-        'asChild': p.asChild,
-        'data-state': p.dataState,
-        'class': className.value,
-        'bindanimationstart': handlers?.handleKFStart,
-        'bindanimationend': handlers?.handleKFEnd,
-        'bindanimationcancel': handlers?.handleKFCancel,
-        'bindtransitionstart': handlers?.handleTransitionStart,
-        'bindtransitionend': handlers?.handleTransitionEnd,
-        'bindtransitioncancel': handlers?.handleTransitionCancel,
-        ...attrs,
-        ...a11y.value,
-        // tap.stop is wired on Primitive's root via the Vue event-modifier
-        // shim; emulate it here by attaching an explicit handler that
-        // doesn't bubble. The DismissableLayer's tap is on OverlayBackdrop;
-        // we deliberately leave the panel inert so a tap on it doesn't
-        // dismiss.
-        'onTap': (e: any) => e?.stopPropagation?.(),
-      },
+      mergeProps(
+        attrs,
+        {
+          'as': p.as,
+          'asChild': p.asChild,
+          'data-state': p.dataState,
+          'class': className.value,
+          'bindanimationstart': handlers?.handleKFStart,
+          'bindanimationend': handlers?.handleKFEnd,
+          'bindanimationcancel': handlers?.handleKFCancel,
+          'bindtransitionstart': handlers?.handleTransitionStart,
+          'bindtransitionend': handlers?.handleTransitionEnd,
+          'bindtransitioncancel': handlers?.handleTransitionCancel,
+          ...a11y.value,
+          // tap.stop is wired on Primitive's root via the Vue event-modifier
+          // shim; emulate it here by attaching an explicit handler that
+          // doesn't bubble. The DismissableLayer's tap is on OverlayBackdrop;
+          // we deliberately leave the panel inert so a tap on it doesn't
+          // dismiss.
+          'onTap': (e: any) => e?.stopPropagation?.(),
+        },
+      ),
       { default: () => slots.default?.() },
     )
   },

--- a/packages/core/src/components/DropdownMenu/DropdownMenuCheckboxItem.vue
+++ b/packages/core/src/components/DropdownMenu/DropdownMenuCheckboxItem.vue
@@ -59,6 +59,11 @@ function handleTap() {
 <template>
   <Primitive
     :as="as"
+    :class="{
+      'ui-indeterminate': checked === 'indeterminate',
+      'ui-checked': checked === true,
+      'ui-disabled': disabled,
+    }"
     :data-state="checked === 'indeterminate' ? 'indeterminate' : checked ? 'checked' : 'unchecked'"
     :data-disabled="disabled ? '' : undefined"
     v-bind="{ ...$attrs, ...a11y }"

--- a/packages/core/src/components/DropdownMenu/DropdownMenuItem.vue
+++ b/packages/core/src/components/DropdownMenu/DropdownMenuItem.vue
@@ -44,6 +44,7 @@ function handleSelect() {
 <template>
   <Primitive
     :as="as"
+    :class="{ 'ui-disabled': disabled }"
     :data-disabled="disabled ? '' : undefined"
     :data-value="textValue"
     v-bind="{ ...$attrs, ...a11y }"

--- a/packages/core/src/components/DropdownMenu/DropdownMenuRadioItem.vue
+++ b/packages/core/src/components/DropdownMenu/DropdownMenuRadioItem.vue
@@ -58,6 +58,7 @@ function handleTap() {
 <template>
   <Primitive
     :as="as"
+    :class="{ 'ui-checked': isChecked, 'ui-disabled': disabled }"
     :data-state="isChecked ? 'checked' : 'unchecked'"
     :data-disabled="disabled ? '' : undefined"
     v-bind="{ ...$attrs, ...a11y }"

--- a/packages/core/src/components/DropdownMenu/DropdownMenuSubTrigger.vue
+++ b/packages/core/src/components/DropdownMenu/DropdownMenuSubTrigger.vue
@@ -29,6 +29,7 @@ const a11y = useA11y(() => ({
 <template>
   <Primitive
     :as="as"
+    :class="{ 'ui-open': subContext.open.value, 'ui-closed': !subContext.open.value, 'ui-disabled': disabled }"
     :data-state="subContext.open.value ? 'open' : 'closed'"
     :data-disabled="disabled ? '' : undefined"
     v-bind="{ ...$attrs, ...a11y }"

--- a/packages/core/src/components/NumberField/NumberFieldDecrement.vue
+++ b/packages/core/src/components/NumberField/NumberFieldDecrement.vue
@@ -42,6 +42,7 @@ const a11y = useA11y(() => ({
 <template>
   <Primitive
     v-bind="{ ...primitiveProps, ...a11y }"
+    :class="{ 'ui-disabled': disabled }"
     :disabled="disabled || undefined"
     :data-disabled="disabled ? '' : undefined"
     @tap="!disabled && context.decrement(multiplier)"

--- a/packages/core/src/components/NumberField/NumberFieldIncrement.vue
+++ b/packages/core/src/components/NumberField/NumberFieldIncrement.vue
@@ -42,6 +42,7 @@ const a11y = useA11y(() => ({
 <template>
   <Primitive
     v-bind="{ ...primitiveProps, ...a11y }"
+    :class="{ 'ui-disabled': disabled }"
     :disabled="disabled || undefined"
     :data-disabled="disabled ? '' : undefined"
     @tap="!disabled && context.increment(multiplier)"

--- a/packages/core/src/components/Popover/PopoverContentImpl.vue
+++ b/packages/core/src/components/Popover/PopoverContentImpl.vue
@@ -63,6 +63,7 @@ const a11y = useA11y(() => ({
     :ref="forwardRef"
     :as="as"
     :as-child="props.asChild"
+    :class="{ 'ui-open': rootContext.open.value, 'ui-closed': !rootContext.open.value }"
     :data-state="rootContext.open.value ? 'open' : 'closed'"
     v-bind="{ ...$attrs, ...a11y }"
     @tap.stop

--- a/packages/core/src/components/Progress/ProgressIndicator.vue
+++ b/packages/core/src/components/Progress/ProgressIndicator.vue
@@ -18,6 +18,7 @@ useForwardExpose()
 <template>
   <Primitive
     v-bind="props"
+    :class="{ 'ui-indeterminate': rootContext.progressState.value === 'indeterminate' }"
     :data-state="rootContext.progressState.value"
     :data-value="rootContext.modelValue?.value ?? undefined"
     :data-max="rootContext.max.value"

--- a/packages/core/src/components/Rating/RatingItemIndicator.vue
+++ b/packages/core/src/components/Rating/RatingItemIndicator.vue
@@ -59,6 +59,7 @@ const a11y = useA11y(() => ({
     :as="as"
     :as-child="asChild"
     v-bind="{ ...$attrs, ...a11y }"
+    :class="{ 'ui-active': isActive, 'ui-disabled': rootContext.disabled.value }"
     :data-state="isActive ? 'active' : undefined"
     :data-disabled="rootContext.disabled.value ? '' : undefined"
     :disabled="rootContext.disabled.value ? '' : undefined"

--- a/packages/core/src/components/Select/SelectItem.vue
+++ b/packages/core/src/components/Select/SelectItem.vue
@@ -76,6 +76,7 @@ provideSelectItemContext({
   <Primitive
     :as="as"
     :as-child="asChild"
+    :class="{ 'ui-checked': isSelected, 'ui-disabled': disabled }"
     :data-state="isSelected ? 'checked' : 'unchecked'"
     :data-disabled="disabled ? '' : undefined"
     v-bind="{ ...$attrs, ...a11y }"

--- a/packages/core/src/components/Stepper/StepperItem.vue
+++ b/packages/core/src/components/Stepper/StepperItem.vue
@@ -86,6 +86,12 @@ provideStepperItemContext({
     :ref="forwardRef"
     :as="as"
     :as-child="asChild"
+    :class="{
+      'ui-completed': itemState === 'completed',
+      'ui-active': itemState === 'active',
+      'ui-inactive': itemState === 'inactive',
+      'ui-disabled': disabled || !isFocusable,
+    }"
     :data-state="itemState"
     :disabled="disabled || !isFocusable ? '' : undefined"
     :data-disabled="disabled || !isFocusable ? '' : undefined"

--- a/packages/core/src/components/Tabs/TabsTrigger.vue
+++ b/packages/core/src/components/Tabs/TabsTrigger.vue
@@ -68,6 +68,7 @@ const a11y = useA11y(() => ({
     :ref="forwardRef"
     :as="as"
     :as-child="asChild"
+    :class="{ 'ui-active': isSelected, 'ui-inactive': !isSelected, 'ui-disabled': disabled }"
     :data-state="isSelected ? 'active' : 'inactive'"
     :disabled="disabled"
     :data-disabled="disabled ? '' : undefined"

--- a/packages/core/src/components/Toast/ToastRoot.vue
+++ b/packages/core/src/components/Toast/ToastRoot.vue
@@ -146,6 +146,7 @@ const a11y = useA11y(() => ({
     :as="as"
     :as-child="asChild"
     v-bind="a11y"
+    :class="{ 'ui-open': open, 'ui-closed': !open }"
     :data-state="open ? 'open' : 'closed'"
     :data-type="type"
     :data-front="isFront ? '' : undefined"

--- a/packages/core/src/components/Toggle/Toggle.vue
+++ b/packages/core/src/components/Toggle/Toggle.vue
@@ -79,6 +79,7 @@ const a11y = useA11y(() => ({
     :ref="forwardRef"
     :as-child="props.asChild"
     :as="as"
+    :class="{ 'ui-on': dataState === 'on', 'ui-off': dataState === 'off', 'ui-disabled': disabled }"
     :data-state="dataState"
     :data-disabled="disabled ? '' : undefined"
     :disabled="disabled ? '' : undefined"

--- a/packages/kit/src/tailwind.d.ts
+++ b/packages/kit/src/tailwind.d.ts
@@ -18,6 +18,10 @@ export declare const COLORS: readonly ['primary', 'secondary', 'success', 'info'
 /** Neutral color name. */
 export declare const NEUTRAL: 'neutral'
 
+/** Extra `ui-*` state markers (beyond the lynx preset's built-ins) the kit
+ *  themes rely on for class-based state variants — feed into `uiVariants`. */
+export declare const VYUI_UI_STATES: readonly ['on', 'off', 'completed', 'highlighted', 'inactive']
+
 /** Default preset built with the standard color set. */
 declare const preset: Partial<Config>
 export default preset

--- a/packages/kit/src/tailwind.js
+++ b/packages/kit/src/tailwind.js
@@ -38,6 +38,26 @@ import { COLORS, NEUTRAL, SHADES } from './theme/color-constants.js'
 //   import vyuiPreset, { createVyuiPreset, COLORS } from '@vyui/kit/tailwind'
 export { COLORS, NEUTRAL } from './theme/color-constants.js'
 
+/**
+ * Extra `ui-*` state markers the kit themes use beyond the lynx preset's
+ * built-in set (`open/closed/active/checked/disabled/...`). These back the
+ * class-based variants (`ui-on:`, `group-ui-completed:`, etc.) that replace
+ * Lynx-incompatible `data-[state=…]` attribute selectors (issue #9). Feed them
+ * into the lynx preset's `uiVariants` plugin so it generates the self/group/
+ * peer/parent forms:
+ *
+ * ```ts
+ * import { createLynxPreset } from '@lynx-js/tailwind-preset'
+ * import { VYUI_UI_STATES } from '@vyui/kit/tailwind'
+ * const lynxPreset = createLynxPreset({
+ *   lynxUIPlugins: {
+ *     uiVariants: { prefixes: (d) => ({ ...d, ui: [...d.ui, ...VYUI_UI_STATES] }) },
+ *   },
+ * })
+ * ```
+ */
+export const VYUI_UI_STATES = ['on', 'off', 'completed', 'highlighted', 'inactive']
+
 const buildScale = (name, neutral, shades) =>
   Object.fromEntries([
     ...shades.map((shade) => [shade, `var(--ui-color-${name}-${shade})`]),
@@ -100,16 +120,30 @@ export function createVyuiPreset({ colors = COLORS, neutral = NEUTRAL, shades = 
         pattern: new RegExp(
           `(bg|text|ring|border)-(${allColors.join('|')})-(${shades.join('|')})`,
         ),
-        // State/attribute variants the kit themes pair with dynamic color
-        // utilities. CSS inheritance is off on Lynx, so state-driven foreground
-        // colors live on child text/icon slots and read the parent's state via
-        // the `group-data-[…]` forms — both the self (`data-[…]`) and group
-        // (`group-data-[…]`) forms must be safelisted or the scanner purges them.
+        // State variants the kit themes pair with dynamic color utilities. CSS
+        // inheritance is off on Lynx, so state-driven foreground colors live on
+        // child text/icon slots and read the parent's state via the `group-*`
+        // forms — both self and group forms must be safelisted or the scanner
+        // purges them. The `ui-*` class variants replace Lynx-incompatible
+        // `data-[state=…]` selectors (issue #9); the `data-[…]` entries remain
+        // only for not-yet-migrated themes and can be dropped once #9 lands.
         variants: [
           'hover',
           'active',
           'focus',
           'disabled',
+          'ui-highlighted',
+          'ui-active',
+          'ui-on',
+          'ui-open',
+          'ui-checked',
+          'group-ui-highlighted',
+          'group-ui-active',
+          'group-ui-completed',
+          'group-ui-inactive',
+          'group-ui-on',
+          'group-ui-open',
+          'group-ui-checked',
           'data-[highlighted]',
           'data-[state=active]',
           'data-[state=on]',

--- a/packages/kit/src/theme/accordion.ts
+++ b/packages/kit/src/theme/accordion.ts
@@ -22,7 +22,7 @@ export default {
     bodyText: 'text-sm text-neutral-700',
     leadingIcon: 'shrink-0 size-5 text-neutral-500',
     trailingIcon:
-      'shrink-0 size-5 ms-auto text-neutral-500 group-data-[state=open]:rotate-180 transition-transform duration-200',
+      'shrink-0 size-5 ms-auto text-neutral-500 group-ui-open:rotate-180 transition-transform duration-200',
     label: 'text-start break-words text-neutral-900',
   },
   variants: {

--- a/packages/kit/src/theme/actionSheet.ts
+++ b/packages/kit/src/theme/actionSheet.ts
@@ -11,7 +11,7 @@ import type { Color } from './colors'
 
 export default (colors: Color[]) => ({
   slots: {
-    overlay: 'fixed inset-0 bg-neutral-900/40 data-[state=open]:animate-[fade-in_200ms_ease-out] data-[state=closed]:animate-[fade-out_200ms_ease-in]',
+    overlay: 'fixed inset-0 bg-neutral-900/40 ui-open:animate-[fade-in_200ms_ease-out] ui-closed:animate-[fade-out_200ms_ease-in]',
     content: 'flex flex-col',
     handle: 'self-center w-9 h-1 rounded-full bg-neutral-300 mt-2 mb-1',
     header: 'flex flex-col gap-0.5 px-4 pt-2 pb-3',

--- a/packages/kit/src/theme/combobox.ts
+++ b/packages/kit/src/theme/combobox.ts
@@ -31,12 +31,12 @@ export default (colors: Color[]) => ({
     // `itemLabel` (the row's <text>): CSS inheritance is OFF in the Lynx build
     // (`enableCSSInheritance: false`), so a `text-*` on the row <view> never
     // reaches the label <text>.
-    item: 'group relative w-full flex flex-row items-center select-none rounded-md data-[disabled]:cursor-not-allowed data-[disabled]:opacity-75 transition-colors',
+    item: 'group relative w-full flex flex-row items-center select-none rounded-md ui-disabled:cursor-not-allowed ui-disabled:opacity-75 transition-colors',
     itemLeadingIcon: 'shrink-0 transition-colors',
     itemLeadingAvatar: 'shrink-0',
     itemTrailing: 'ms-auto flex flex-row gap-1.5 items-center',
     itemTrailingIcon: 'shrink-0',
-    itemLabel: 'truncate text-neutral-700 group-data-[state=checked]:text-neutral-900',
+    itemLabel: 'truncate text-neutral-700 group-ui-checked:text-neutral-900',
     leading: 'flex flex-row items-center shrink-0',
     leadingIcon: 'shrink-0',
     leadingAvatar: 'shrink-0',

--- a/packages/kit/src/theme/drawer.ts
+++ b/packages/kit/src/theme/drawer.ts
@@ -13,7 +13,7 @@
  */
 export default {
   slots: {
-    overlay: 'fixed inset-0 bg-neutral-900/50 data-[state=open]:animate-[fade-in_200ms_ease-out] data-[state=closed]:animate-[fade-out_200ms_ease-in]',
+    overlay: 'fixed inset-0 bg-neutral-900/50 ui-open:animate-[fade-in_200ms_ease-out] ui-closed:animate-[fade-out_200ms_ease-in]',
     content: 'fixed bg-white border border-neutral-200 flex flex-col',
     handle: 'self-center w-9 h-1 rounded-full bg-neutral-300 mt-2 mb-1',
     header: 'flex flex-row items-center gap-1.5 p-4 min-h-16',
@@ -41,7 +41,7 @@ export default {
     },
     transition: {
       true: {
-        content: 'data-[state=open]:animate-[slide-in_200ms_ease-out] data-[state=closed]:animate-[slide-out_200ms_ease-in]',
+        content: 'ui-open:animate-[slide-in_200ms_ease-out] ui-closed:animate-[slide-out_200ms_ease-in]',
       },
     },
   },

--- a/packages/kit/src/theme/dropdownMenu.ts
+++ b/packages/kit/src/theme/dropdownMenu.ts
@@ -2,7 +2,7 @@
  * DropdownMenu theme — adapted from nuxt/ui v3.0.2 `theme/dropdown-menu.ts`
  * for Vue-Lynx. Light-mode only; `dark:*`, `focus:*`, `focus-visible:*`, and
  * `transition-shadow` classes are dropped. Hover/active states keep
- * `data-[state=...]`, `data-[highlighted]`, `data-[disabled]`.
+ * `data-[state=...]`, `ui-highlighted`, `ui-disabled`.
  * `shadow-lg shadow-black/10` matches `IslandContainer` so floating surfaces
  * share one elevation language.
  *
@@ -13,11 +13,11 @@ import type { Color } from './colors'
 
 export default (colors: Color[]) => ({
   slots: {
-    content: 'min-w-32 bg-white rounded-lg border border-neutral-200 shadow-lg shadow-black/10 divide-y divide-neutral-200 overflow-y-auto data-[state=open]:animate-[scale-in_100ms_ease-out] data-[state=closed]:animate-[scale-out_100ms_ease-in]',
+    content: 'min-w-32 bg-white rounded-lg border border-neutral-200 shadow-lg shadow-black/10 divide-y divide-neutral-200 overflow-y-auto ui-open:animate-[scale-in_100ms_ease-out] ui-closed:animate-[scale-out_100ms_ease-in]',
     group: 'p-1',
     label: 'w-full flex flex-row items-center font-semibold text-neutral-900',
     separator: '-mx-1 my-1 h-px bg-neutral-200',
-    item: 'group relative w-full flex flex-row items-start rounded-md data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed transition-colors',
+    item: 'group relative w-full flex flex-row items-start rounded-md ui-disabled:opacity-50 ui-disabled:cursor-not-allowed transition-colors',
     itemLeadingIcon: 'shrink-0',
     itemLeadingAvatar: 'shrink-0',
     itemLeadingAvatarSize: '',
@@ -41,9 +41,9 @@ export default (colors: Color[]) => ({
         itemLeadingIcon: 'text-neutral-700',
       },
       false: {
-        item: 'data-[highlighted]:bg-neutral-100 data-[state=open]:bg-neutral-100',
-        itemLabel: 'text-neutral-700 group-data-[highlighted]:text-neutral-900 group-data-[state=open]:text-neutral-900',
-        itemLeadingIcon: 'text-neutral-500 group-data-[highlighted]:text-neutral-700 group-data-[state=open]:text-neutral-700',
+        item: 'ui-highlighted:bg-neutral-100 ui-open:bg-neutral-100',
+        itemLabel: 'text-neutral-700 group-ui-highlighted:text-neutral-900 group-ui-open:text-neutral-900',
+        itemLeadingIcon: 'text-neutral-500 group-ui-highlighted:text-neutral-700 group-ui-open:text-neutral-700',
       },
     },
     loading: {
@@ -87,9 +87,9 @@ export default (colors: Color[]) => ({
       color,
       active: false as const,
       class: {
-        item: `data-[highlighted]:bg-${color}-50 data-[state=open]:bg-${color}-50`,
-        itemLabel: `text-${color}-500 group-data-[highlighted]:text-${color}-600`,
-        itemLeadingIcon: `text-${color}-500 group-data-[highlighted]:text-${color}-600 group-data-[state=open]:text-${color}-600`,
+        item: `ui-highlighted:bg-${color}-50 ui-open:bg-${color}-50`,
+        itemLabel: `text-${color}-500 group-ui-highlighted:text-${color}-600`,
+        itemLeadingIcon: `text-${color}-500 group-ui-highlighted:text-${color}-600 group-ui-open:text-${color}-600`,
       },
     })),
     ...colors.map(color => ({

--- a/packages/kit/src/theme/numberField.ts
+++ b/packages/kit/src/theme/numberField.ts
@@ -15,8 +15,8 @@ export default (colors: Color[]) => ({
   slots: {
     root: 'flex flex-row items-center w-full rounded-md border bg-white overflow-hidden',
     base: 'flex-1 min-w-0 bg-transparent text-center text-neutral-900 placeholder:text-neutral-400 focus:outline-none disabled:cursor-not-allowed disabled:opacity-75',
-    increment: 'shrink-0 flex flex-row items-center justify-center text-neutral-600 active:bg-neutral-100 data-[disabled]:opacity-50',
-    decrement: 'shrink-0 flex flex-row items-center justify-center text-neutral-600 active:bg-neutral-100 data-[disabled]:opacity-50',
+    increment: 'shrink-0 flex flex-row items-center justify-center text-neutral-600 active:bg-neutral-100 ui-disabled:opacity-50',
+    decrement: 'shrink-0 flex flex-row items-center justify-center text-neutral-600 active:bg-neutral-100 ui-disabled:opacity-50',
     incrementIcon: 'shrink-0',
     decrementIcon: 'shrink-0',
   },

--- a/packages/kit/src/theme/popover.ts
+++ b/packages/kit/src/theme/popover.ts
@@ -9,7 +9,7 @@
  */
 export default {
   slots: {
-    content: 'bg-white rounded-md border border-neutral-200 shadow-lg shadow-black/10 data-[state=open]:animate-[scale-in_100ms_ease-out] data-[state=closed]:animate-[scale-out_100ms_ease-in] pointer-events-auto',
+    content: 'bg-white rounded-md border border-neutral-200 shadow-lg shadow-black/10 ui-open:animate-[scale-in_100ms_ease-out] ui-closed:animate-[scale-out_100ms_ease-in] pointer-events-auto',
     handle: 'self-center w-9 h-1 rounded-full bg-neutral-300 mt-2 mb-1',
     arrow: 'fill-neutral-200',
   },

--- a/packages/kit/src/theme/progress.ts
+++ b/packages/kit/src/theme/progress.ts
@@ -6,7 +6,7 @@
  * `apps/examples/kit-demo/src/index.css`.
  *
  * Bar variant only — Nuxt UI's circular progress relies on inline SVG which
- * Lynx does not render. The `data-[state=indeterminate]:animate-*` keyframe
+ * Lynx does not render. The `ui-indeterminate:animate-*` keyframe
  * references are retained; the consuming app must declare matching
  * `carousel`, `carousel-vertical`, `carousel-inverse`, `swing`, `elastic`
  * keyframes in its Tailwind config (or skip indeterminate animations).
@@ -87,42 +87,42 @@ export default (colors: Color[]) => ({
     {
       orientation: 'horizontal' as const,
       animation: 'carousel' as const,
-      class: { indicator: 'data-[state=indeterminate]:animate-[carousel_2s_ease-in-out_infinite]' },
+      class: { indicator: 'ui-indeterminate:animate-[carousel_2s_ease-in-out_infinite]' },
     },
     {
       orientation: 'vertical' as const,
       animation: 'carousel' as const,
-      class: { indicator: 'data-[state=indeterminate]:animate-[carousel-vertical_2s_ease-in-out_infinite]' },
+      class: { indicator: 'ui-indeterminate:animate-[carousel-vertical_2s_ease-in-out_infinite]' },
     },
     {
       orientation: 'horizontal' as const,
       animation: 'carousel-inverse' as const,
-      class: { indicator: 'data-[state=indeterminate]:animate-[carousel-inverse_2s_ease-in-out_infinite]' },
+      class: { indicator: 'ui-indeterminate:animate-[carousel-inverse_2s_ease-in-out_infinite]' },
     },
     {
       orientation: 'vertical' as const,
       animation: 'carousel-inverse' as const,
-      class: { indicator: 'data-[state=indeterminate]:animate-[carousel-inverse-vertical_2s_ease-in-out_infinite]' },
+      class: { indicator: 'ui-indeterminate:animate-[carousel-inverse-vertical_2s_ease-in-out_infinite]' },
     },
     {
       orientation: 'horizontal' as const,
       animation: 'swing' as const,
-      class: { indicator: 'data-[state=indeterminate]:animate-[swing_2s_ease-in-out_infinite]' },
+      class: { indicator: 'ui-indeterminate:animate-[swing_2s_ease-in-out_infinite]' },
     },
     {
       orientation: 'vertical' as const,
       animation: 'swing' as const,
-      class: { indicator: 'data-[state=indeterminate]:animate-[swing-vertical_2s_ease-in-out_infinite]' },
+      class: { indicator: 'ui-indeterminate:animate-[swing-vertical_2s_ease-in-out_infinite]' },
     },
     {
       orientation: 'horizontal' as const,
       animation: 'elastic' as const,
-      class: { indicator: 'data-[state=indeterminate]:animate-[elastic_2s_ease-in-out_infinite]' },
+      class: { indicator: 'ui-indeterminate:animate-[elastic_2s_ease-in-out_infinite]' },
     },
     {
       orientation: 'vertical' as const,
       animation: 'elastic' as const,
-      class: { indicator: 'data-[state=indeterminate]:animate-[elastic-vertical_2s_ease-in-out_infinite]' },
+      class: { indicator: 'ui-indeterminate:animate-[elastic-vertical_2s_ease-in-out_infinite]' },
     },
   ],
   defaultVariants: {

--- a/packages/kit/src/theme/rating.ts
+++ b/packages/kit/src/theme/rating.ts
@@ -30,7 +30,7 @@ export default (colors: Color[]) => ({
     },
   },
   compoundVariants: [
-    ...colors.map(c => ({ color: c, class: { icon: `data-[state=active]:text-${c}-500` } })),
+    ...colors.map(c => ({ color: c, class: { icon: `ui-active:text-${c}-500` } })),
   ],
   defaultVariants: {
     color: 'warning' as const,

--- a/packages/kit/src/theme/select.ts
+++ b/packages/kit/src/theme/select.ts
@@ -37,12 +37,12 @@ export default (colors: Color[]) => ({
     // `itemLabel` (the SelectItemText <text>): CSS inheritance is OFF in the
     // Lynx build (`enableCSSInheritance: false`), so a `text-*` on the row
     // <view> never reaches the label <text>.
-    item: 'group relative w-full flex flex-row items-center select-none rounded-md data-[disabled]:cursor-not-allowed data-[disabled]:opacity-75 transition-colors',
+    item: 'group relative w-full flex flex-row items-center select-none rounded-md ui-disabled:cursor-not-allowed ui-disabled:opacity-75 transition-colors',
     itemLeadingIcon: 'shrink-0 transition-colors',
     itemLeadingAvatar: 'shrink-0',
     itemTrailing: 'ms-auto flex flex-row gap-1.5 items-center',
     itemTrailingIcon: 'shrink-0',
-    itemLabel: 'truncate text-neutral-700 group-data-[state=checked]:text-neutral-900',
+    itemLabel: 'truncate text-neutral-700 group-ui-checked:text-neutral-900',
     leading: 'flex flex-row items-center shrink-0',
     leadingIcon: 'shrink-0',
     leadingAvatar: 'shrink-0',

--- a/packages/kit/src/theme/stepper.ts
+++ b/packages/kit/src/theme/stepper.ts
@@ -19,8 +19,8 @@ export default (colors: Color[]) => ({
     // `bg-*` fill stays on `trigger`.
     trigger: 'rounded-full font-medium text-center align-middle flex flex-row items-center justify-center font-semibold bg-neutral-100',
     indicator: 'flex flex-row items-center justify-center size-full',
-    icon: 'shrink-0 group-data-[state=completed]:text-white group-data-[state=active]:text-white text-neutral-500',
-    separator: 'absolute rounded-full group-data-[disabled]:opacity-75 bg-neutral-200',
+    icon: 'shrink-0 group-ui-completed:text-white group-ui-active:text-white text-neutral-500',
+    separator: 'absolute rounded-full group-ui-disabled:opacity-75 bg-neutral-200',
     wrapper: '',
     title: 'font-medium text-neutral-900',
     description: 'text-neutral-500 text-wrap',
@@ -78,8 +78,8 @@ export default (colors: Color[]) => ({
     ...colors.map(color => ({
       color,
       class: {
-        trigger: `group-data-[state=completed]:bg-${color}-500 group-data-[state=active]:bg-${color}-500`,
-        separator: `group-data-[state=completed]:bg-${color}-500`,
+        trigger: `group-ui-completed:bg-${color}-500 group-ui-active:bg-${color}-500`,
+        separator: `group-ui-completed:bg-${color}-500`,
       },
     })),
     // horizontal separator x-positioning per size

--- a/packages/kit/src/theme/tabs.ts
+++ b/packages/kit/src/theme/tabs.ts
@@ -24,13 +24,13 @@ import type { Color } from './colors'
 // to the child label as a reliable `group-active:` on Lynx. State colors use
 // `group-data-[state=…]:` (the trigger owns the `group` + `data-state`).
 const pillLabel = (_c: string) =>
-  `group-data-[state=active]:text-white group-data-[state=inactive]:text-neutral-500`
+  `group-ui-active:text-white group-ui-inactive:text-neutral-500`
 
 const pillIndicator = (c: string) => `bg-${c}-500`
 
 // `link`: underline indicator + colored active label.
 const linkLabel = (c: string) =>
-  `group-data-[state=active]:text-${c}-500 group-data-[state=inactive]:text-neutral-500`
+  `group-ui-active:text-${c}-500 group-ui-inactive:text-neutral-500`
 
 const linkIndicator = (c: string) => `bg-${c}-500`
 

--- a/packages/kit/src/theme/toast.ts
+++ b/packages/kit/src/theme/toast.ts
@@ -17,7 +17,7 @@ import type { Color } from './colors'
 // pixel values instead of via custom-property indirection.
 export default (colors: Color[]) => ({
   slots: {
-    root: 'relative group overflow-hidden bg-white rounded-lg border border-neutral-200 p-4 flex flex-row gap-2.5 data-[state=open]:animate-[slide-in_200ms_ease-out] data-[state=closed]:animate-[fade-out_100ms_ease-in]',
+    root: 'relative group overflow-hidden bg-white rounded-lg border border-neutral-200 p-4 flex flex-row gap-2.5 ui-open:animate-[slide-in_200ms_ease-out] ui-closed:animate-[fade-out_100ms_ease-in]',
     wrapper: 'w-0 flex-1 flex flex-col',
     title: 'text-sm font-medium text-neutral-900',
     description: 'text-sm text-neutral-500',

--- a/packages/kit/src/theme/toast.ts
+++ b/packages/kit/src/theme/toast.ts
@@ -17,7 +17,7 @@ import type { Color } from './colors'
 // pixel values instead of via custom-property indirection.
 export default (colors: Color[]) => ({
   slots: {
-    root: 'relative group overflow-hidden bg-white rounded-lg border border-neutral-200 p-4 flex flex-row gap-2.5 ui-open:animate-[slide-in_200ms_ease-out] ui-closed:animate-[fade-out_100ms_ease-in]',
+    root: 'relative group overflow-hidden bg-white rounded-lg border border-neutral-200 p-4 flex flex-row gap-2.5 w-[calc(100vw-2rem)] max-w-sm ui-open:animate-[slide-in_200ms_ease-out] ui-closed:animate-[fade-out_100ms_ease-in]',
     wrapper: 'w-0 flex-1 flex flex-col',
     title: 'text-sm font-medium text-neutral-900',
     description: 'text-sm text-neutral-500',

--- a/packages/kit/src/theme/toggleGroup.ts
+++ b/packages/kit/src/theme/toggleGroup.ts
@@ -4,7 +4,7 @@
  * `theme/button-group.ts` orientation rounding). Light-only port for Vue-Lynx.
  *
  * Each item renders a `ToggleGroupItem` styled like a button; the
- * `data-[state=on]` attribute is used to flip into the active appearance per
+ * `ui-on` attribute is used to flip into the active appearance per
  * color × variant. Variants supported: `outline`, `soft`, `subtle` (matches
  * what nuxt/ui surfaces for non-solid toggles).
  */
@@ -16,28 +16,28 @@ import type { Color } from './colors'
 // (`enableCSSInheritance: false`), so a `text-*` on the item <view> never
 // reaches the `leadingIcon` / `label` children — `fg` is spread onto those
 // slots directly. The item <view> carries `group` + `data-state`, so the
-// on-state color shift uses `group-data-[state=on]:text-*` on the children
+// on-state color shift uses `group-ui-on:text-*` on the children
 // (the children don't get `data-state` themselves). Same convention as
 // `dropdownMenu.ts` / `stepper.ts`.
 const outline = (c: string) =>
   ({
     base: `border border-neutral-300 bg-white active:bg-${c}-50 active:bg-${c}-100`
-      + ` data-[state=on]:border-${c}-500 data-[state=on]:bg-${c}-50`,
-    fg: `text-neutral-700 group-data-[state=on]:text-${c}-600`,
+      + ` ui-on:border-${c}-500 ui-on:bg-${c}-50`,
+    fg: `text-neutral-700 group-ui-on:text-${c}-600`,
   })
 
 const soft = (c: string) =>
   ({
     base: `bg-neutral-100 active:bg-${c}-50 active:bg-${c}-100`
-      + ` data-[state=on]:bg-${c}-100`,
-    fg: `text-neutral-700 group-data-[state=on]:text-${c}-600`,
+      + ` ui-on:bg-${c}-100`,
+    fg: `text-neutral-700 group-ui-on:text-${c}-600`,
   })
 
 const subtle = (c: string) =>
   ({
     base: `border border-neutral-200 bg-white active:bg-${c}-50 active:bg-${c}-100`
-      + ` data-[state=on]:border-${c}-300 data-[state=on]:bg-${c}-100`,
-    fg: `text-neutral-700 group-data-[state=on]:text-${c}-600`,
+      + ` ui-on:border-${c}-300 ui-on:bg-${c}-100`,
+    fg: `text-neutral-700 group-ui-on:text-${c}-600`,
   })
 
 const VARIANT_BUILDERS = { outline, soft, subtle } as const
@@ -51,7 +51,7 @@ export default (colors: Color[]) => ({
     // `root` direction is set per orientation variant (flex-row/flex-col).
     root: 'flex',
     // `group` so children can read the item's `data-state` via
-    // `group-data-[state=on]:*` (Lynx won't cascade `text-*`).
+    // `group-ui-on:*` (Lynx won't cascade `text-*`).
     item: 'group flex flex-row items-center justify-center font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50',
     leadingIcon: 'shrink-0',
     label: 'truncate',


### PR DESCRIPTION
📝 Description

This PR resolves Issue #9 by migrating core and kit components away from standard data-[state=...] selectors—which are incompatible with Lynx—to a class-based state system using ui-* class markers.

By injecting custom state prefixes into the @lynx-js/tailwind-preset, components can now conditionally apply Tailwind utility variants (e.g., ui-open:, ui-checked:, ui-disabled:) cross-platform without breaking.
🛠️ Changes Made
1. Packages & Core Components (packages/core)

    Class Mapping: Added reactive class bindings mapping component states (open, checked, disabled, active, etc.) directly to standard ui-* classes (e.g., :class="{ 'ui-open': isOpen, 'ui-disabled': isDisabled }").

    Components Updated: Accordion, Combobox, Dialog, DropdownMenu, NumberField, Popover, Progress, Rating, Select, Stepper, Tabs, Toast, and Toggle.

    Dialog Content Fix: Replaced object spreading with Vue's mergeProps in DialogContentImpl.vue so that incoming UI kit layout classes are properly concatenated with Presence lifecycle classes rather than being clobbered.

2. Kit & Theming System (packages/kit)

    Theme Updates: Updated all static theme definitions (accordion.ts, dropdownMenu.ts, stepper.ts, etc.) to consume the new class-based Tailwind state variants.

    Preset Configuration: Exposed VYUI_UI_STATES in the Tailwind configuration to provide explicit type declarations and definitions for additional state extensions (on, off, completed, highlighted, inactive).

3. Documentation & Demo Application (apps/examples)

    Updated tailwind.config.ts to extend the standard lynxPreset configuration with the new custom VYUI_UI_STATES.

    Refactored OverlaySection.vue within the kit-demo app:

        Simplified modal descriptions.

        Replaced the touch-incompatible Tooltip implementation with a touch-first VyPopover workflow.

        Embedded an active ToastProvider outside of layout wrappers to contextually surface temporary notifications via the OverlayRoot portal without introducing flex gap layout side-effects.

🧪 How to Test

    Run the kit demo application locally.

    Navigate to the Overlay Section.

    Verify that interactive states still style correctly on runtime interaction:

        Modal: Check that opening/closing transitions apply correctly (verifying mergeProps behavior).

        Notifications: Tap to ensure popovers trigger and transient toasts auto-dismiss after 3200ms.

        Form / Selection fields: Ensure toggles, dropdown selections, and disabled states visually adapt dynamically.