### PR TITLE
fix(core): reject Icon color values that could inject SVG markup

### DIFF
--- a/packages/core/src/components/Icon/Icon.test.ts
+++ b/packages/core/src/components/Icon/Icon.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it } from 'vitest'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h } from 'vue'
 import { render } from '@vyui/testing-utils'
 import Icon, { type IconProps } from './Icon.vue'
@@ -90,6 +90,31 @@ describe('resolveIconSvg (cache)', () => {
       icons: { account: { body: '<path d="M12 4a4 4 0 1 0 0 8 4 4 0 0 0 0-8"/>' } },
     })
     expect(resolveIconSvg('mdi:account', { size: 16 })).not.toBeNull()
+  })
+})
+
+describe('resolveIconSvg (color sanitisation)', () => {
+  it('accepts the CSS color syntaxes consumers legitimately pass', () => {
+    for (const color of ['red', '#ff0000', 'rgb(255, 0, 0)', 'rgb(255 0 0 / 50%)', 'hsl(210, 50%, 40%)']) {
+      const svg = resolveIconSvg('lucide:check', { size: 16, color })
+      expect(svg).toContain(color)
+      expect(svg).not.toContain('currentColor')
+    }
+  })
+
+  it('ignores a color that would break out of the SVG attribute', () => {
+    const payload = '"><image href="x" onerror="alert(1)"><path fill="'
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const svg = resolveIconSvg('lucide:check', { size: 16, color: payload })
+      expect(svg).not.toContain('onerror')
+      expect(svg).toContain('currentColor')
+      expect(warn).toHaveBeenCalledOnce()
+      expect(warn.mock.calls[0][0]).toContain('[vyui/Icon]')
+    }
+    finally {
+      warn.mockRestore()
+    }
   })
 })
 

--- a/packages/core/src/components/Icon/resolve.ts
+++ b/packages/core/src/components/Icon/resolve.ts
@@ -49,6 +49,16 @@ export function registerIconSet(prefix: string, data: IconifyJSON): void {
   svgCache.clear()
 }
 
+/**
+ * `color` is spliced verbatim into SVG markup where `currentColor` sits inside
+ * attribute values (`fill="currentColor"`), so a value containing `"` or `<`
+ * could break out of the attribute and inject elements into the XML that
+ * Lynx's `<svg content>` (and the web `x-svg` element) parses. Allow only the
+ * characters CSS color syntaxes need — named colors, `#hex`, `rgb()`/`hsl()`
+ * including modern space/`/`-alpha forms — and ignore anything else.
+ */
+const SAFE_COLOR_RE = /^[\w#(),.%/ -]+$/
+
 export interface ResolveIconOptions {
   /** Pixel size applied to the SVG `width`/`height`. */
   size?: number
@@ -109,5 +119,16 @@ function computeIconSvg(name: string, opts: ResolveIconOptions): string | null {
     width: opts.size,
   })
   const svg = iconToHTML(body, attributes)
-  return opts.color ? svg.replace(/currentColor/g, opts.color) : svg
+  if (!opts.color)
+    return svg
+  if (!SAFE_COLOR_RE.test(opts.color)) {
+    if (__DEV__) {
+      console.warn(
+        `[vyui/Icon] \`color\` value ${JSON.stringify(opts.color)} contains characters `
+        + 'that are invalid in a CSS color; ignoring it so it cannot inject SVG markup.',
+      )
+    }
+    return svg
+  }
+  return svg.replace(/currentColor/g, opts.color)
 }


### PR DESCRIPTION
Hardens the Icon resolver against SVG markup injection through the `color` prop.

- `color` was substituted verbatim for `currentColor` inside attribute values, so a string containing `"` or `<` could break out of `fill="..."` and inject elements into the XML parsed by Lynx's `<svg content>` / the web `x-svg` element
- Validate `color` against the characters CSS color syntaxes need (named, `#hex`, `rgb()`/`hsl()` incl. modern space/`/`-alpha forms); invalid values are ignored and keep `currentColor`
- Warn in dev (`__DEV__`-guarded, `[vyui/Icon]` prefix) when a value is rejected
- Tests cover the legitimate syntaxes and an attribute-breakout payload

Low risk on Lynx native (the SVG is rasterized), but the same string feeds the web custom element where user-controlled colors could become XSS.