### PR TITLE
feat(core): Sheet multi-snap drag settle + main-thread usage fixes

### DIFF
--- a/apps/examples/kit-demo/src/sections/OverlaySection.vue
+++ b/apps/examples/kit-demo/src/sections/OverlaySection.vue
@@ -13,6 +13,7 @@ import {
 
 const modalOpen = ref(false)
 const drawerOpen = ref(false)
+const drawerFullOpen = ref(false)
 const dropdownOpen = ref(false)
 
 // Notifications — each entry has a "Show" button that surfaces its detail as a
@@ -123,9 +124,30 @@ const fruitItems = [
 
     <view class="bg-white border border-slate-200 rounded-lg p-4 flex flex-col gap-2">
       <text class="text-slate-900 text-base font-semibold">Drawer</text>
-      <text class="text-slate-500 text-xs">Bottom-sheet via SheetRoot.</text>
-      <VyDrawer v-model:open="drawerOpen" title="Drawer title" description="Slide-up sheet.">
+      <text class="text-slate-500 text-xs">
+        Bottom-sheet via SheetRoot with multi-snap: opens at 90%, drag down
+        to catch the 40% snap, drag up to return, fling down to dismiss.
+      </text>
+      <VyDrawer
+        v-model:open="drawerOpen"
+        title="Drawer title"
+        description="Drag me between the 40% and 90% snaps."
+        :snap-points="[0.4, 0.9]"
+        :default-snap-index="1"
+      >
         <VyButton color="neutral" variant="subtle" label="Open drawer" />
+      </VyDrawer>
+      <!-- Single-snap full-screen control case: takes the classic
+           keyframe open/close path (no intermediate snaps, no inline
+           animation override) — useful for comparing against the
+           multi-snap drawer above. -->
+      <VyDrawer
+        v-model:open="drawerFullOpen"
+        title="Full-screen drawer"
+        description="Single snap at 100% — drag down or fling to dismiss."
+        :snap-points="[1]"
+      >
+        <VyButton color="neutral" variant="subtle" label="Open full-screen drawer" />
       </VyDrawer>
     </view>
 

--- a/packages/core/src/components/Draggable/Draggable.vue
+++ b/packages/core/src/components/Draggable/Draggable.vue
@@ -68,7 +68,7 @@ export type DraggableEmits = {
 </script>
 
 <script setup lang="ts">
-import { onUnmounted, ref, watch } from 'vue'
+import { ref, watch } from 'vue'
 import { runOnBackground, runOnMainThread, useMainThreadRef } from 'vue-lynx'
 
 const props = withDefaults(defineProps<DraggableProps>(), {
@@ -138,18 +138,65 @@ const xQueueRef = useMainThreadRef<number[]>([])
 const yQueueRef = useMainThreadRef<number[]>([])
 const tQueueRef = useMainThreadRef<number[]>([])
 
+// Handle of the in-flight `resetOnEnd` animation. Written only inside MT
+// worklets (BG writes to MainThreadRef.current are silently dropped).
+const resetAnimRef = useMainThreadRef<any>(null)
+
 // BG-side mirror so the slot's `dragging` prop is reactive.
 const draggingState = ref(false)
 
-watch(() => props.axis, (v) => { axisRef.current = encodeAxis(v) })
-watch(() => props.disabled, (v) => { disabledRef.current = v })
-watch(() => props.resetOnEnd, (v) => { resetOnEndRef.current = v })
-watch(() => props.duration, (v) => { durationRef.current = v })
-watch(() => props.emitMove, (v) => { emitMoveRef.current = v })
-watch(() => props.bounds?.left, (v) => { minXRef.current = resolveMin(v) })
-watch(() => props.bounds?.right, (v) => { maxXRef.current = resolveMax(v) })
-watch(() => props.bounds?.top, (v) => { minYRef.current = resolveMin(v) })
-watch(() => props.bounds?.bottom, (v) => { maxYRef.current = resolveMax(v) })
+function _syncConfig(
+  axis: 0 | 1 | 2,
+  disabled: boolean,
+  resetOnEnd: boolean,
+  duration: number,
+  emitMove: boolean,
+  minX: number,
+  maxX: number,
+  minY: number,
+  maxY: number,
+) {
+  'main thread'
+  axisRef.current = axis
+  disabledRef.current = disabled
+  resetOnEndRef.current = resetOnEnd
+  durationRef.current = duration
+  emitMoveRef.current = emitMove
+  minXRef.current = minX
+  maxXRef.current = maxX
+  minYRef.current = minY
+  maxYRef.current = maxY
+}
+
+// BG-side assignments to `MainThreadRef.current` are silently dropped by
+// vue-lynx (only the constructor transfers a value BG→MT), so prop updates
+// must be shipped over as a setter-worklet dispatch.
+watch(
+  () => [
+    props.axis,
+    props.disabled,
+    props.resetOnEnd,
+    props.duration,
+    props.emitMove,
+    props.bounds?.left,
+    props.bounds?.right,
+    props.bounds?.top,
+    props.bounds?.bottom,
+  ] as const,
+  () => {
+    runOnMainThread(_syncConfig as any)(
+      encodeAxis(props.axis),
+      props.disabled,
+      props.resetOnEnd,
+      props.duration,
+      props.emitMove,
+      resolveMin(props.bounds?.left),
+      resolveMax(props.bounds?.right),
+      resolveMin(props.bounds?.top),
+      resolveMax(props.bounds?.bottom),
+    )
+  },
+)
 
 function _setTransform(x: number, y: number) {
   'main thread'
@@ -172,7 +219,9 @@ function _animateTo(fromX: number, fromY: number, toX: number, toY: number) {
   currentXRef.current = toX
   currentYRef.current = toY
   if (typeof el.current?.animate === 'function') {
-    el.current.animate(
+    // Keep the handle: a fill-forwards animation outranks inline style in the
+    // cascade, so it must be cancelled before the next drag's transform writes.
+    resetAnimRef.current = el.current.animate(
       [
         { transform: `translate3d(${fromX}px, ${fromY}px, 0)` },
         { transform: `translate3d(${toX}px, ${toY}px, 0)` },
@@ -226,6 +275,20 @@ function _onTouchStart(e: { touches: Array<{ clientX: number, clientY: number }>
   if (disabledRef.current) return
   const t0 = e.touches[0]
   if (!t0) return
+
+  // Cancel any in-flight resetOnEnd animation: active animations beat inline
+  // style in the cascade, so leaving it running would mask this drag's
+  // `setStyleProperty('transform', …)` writes. Inline `animation: 'none'`
+  // (the Sheet's touchstart stomp) does NOT cancel programmatic `.animate()`
+  // animations — only the handle can. Re-assert the current transform so the
+  // element doesn't snap to the pre-animation position.
+  const anim = resetAnimRef.current
+  if (anim && typeof anim.cancel === 'function') {
+    anim.cancel()
+    resetAnimRef.current = null
+    _setTransform(currentXRef.current, currentYRef.current)
+  }
+
   isDraggingRef.current = true
   touchStartXRef.current = t0.clientX
   touchStartYRef.current = t0.clientY
@@ -303,11 +366,8 @@ function _emitEnd(x: number, y: number, dx: number, dy: number, vx: number, vy: 
   emits('dragEnd', { x, y, dx, dy, vx, vy })
 }
 
-onUnmounted(() => {
-  xQueueRef.current = []
-  yQueueRef.current = []
-  tQueueRef.current = []
-})
+// No BG-side unmount cleanup: the velocity queues live on the main thread
+// and die with the element; BG writes to MainThreadRef.current are no-ops.
 
 function reset(animate = true) {
   if (animate) {

--- a/packages/core/src/components/Sheet/Sheet.test.ts
+++ b/packages/core/src/components/Sheet/Sheet.test.ts
@@ -101,6 +101,30 @@ describe('SheetRoot — v-model:open / v-model:snapIndex', () => {
     const { ctx } = await mountRoot({ viewportHeight: 999 })
     expect(ctx.viewportHeight.value).toBe(999)
   })
+
+  // SheetContent's release worklets read these via MT refs synced from the
+  // context — assert the context carries the prop values (and defaults)
+  // rather than hardcoded physics.
+  it('exposes drag physics config (dismissVelocity, duration) from props', async () => {
+    const { ctx } = await mountRoot({ dismissVelocity: 900, duration: 400 })
+    expect(ctx.dismissVelocity.value).toBe(900)
+    expect(ctx.duration.value).toBe(400)
+  })
+
+  it('defaults dismissVelocity to 600 and duration to 280', async () => {
+    const { ctx } = await mountRoot()
+    expect(ctx.dismissVelocity.value).toBe(600)
+    expect(ctx.duration.value).toBe(280)
+  })
+
+  it('provides MT refs for drag progress and the backdrop element', async () => {
+    const { ctx } = await mountRoot()
+    // Drag worklets write progress on touchmove and paint opacity through
+    // the backdrop handle; both must exist on context even with no drag yet.
+    expect(ctx.progressMTRef).toBeDefined()
+    expect(ctx.backdropElRef).toBeDefined()
+    expect(ctx.backdropElRef.current).toBeNull()
+  })
 })
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/packages/core/src/components/Sheet/SheetBackdropImpl.vue
+++ b/packages/core/src/components/Sheet/SheetBackdropImpl.vue
@@ -21,8 +21,11 @@ const emits = defineEmits<{
 
 const ctx = injectSheetRootContext()
 
-// Same MT element handle SheetContent's drag worklets paint opacity into;
-// the keyframe-based fade below targets the same `<view>` via class.
+// Same MT element handle SheetContent's drag worklets paint inline
+// `opacity` into during drag; the keyframe-based fade below covers the
+// open / close transitions on the same `<view>` via class. Inline styles
+// from a drag can't leak across opens: Presence unmounts this view on
+// close, so each open starts from a fresh element.
 const overlayRef = ctx.backdropElRef
 
 const presence = inject(PresenceContextKey, null)

--- a/packages/core/src/components/Sheet/SheetContentImpl.vue
+++ b/packages/core/src/components/Sheet/SheetContentImpl.vue
@@ -7,8 +7,17 @@
        the `ui-entering` / `ui-leaving` class, applied by the Presence state
        machine. `@animationend` advances Presence to `Entered` / `Left`.
      - Drag is driven by MT touch worklets that paint inline `transform`
-       via `setStyleProperty`. On release we either snap back (CSS
-       transition) or dismiss (inline transition + `setOpen(false)`).
+       via `setStyleProperty`. On release we settle at the nearest snap
+       point (inline transition), or dismiss (inline transition +
+       `setOpen(false)`). The release decision mirrors `pickRelease` in
+       `useSheetBehavior.ts` — see `_onTouchEnd` for the divergences.
+     - Multi-snap: positions are px-from-open along the panel's travel
+       (`0` = fully open = largest snap; the panel is sized to it). The
+       authoritative current position lives in an MT ref (`posRef`) —
+       the BG side cannot read it (MainThreadRef reads on BG return the
+       init value), so BG-initiated moves hop to MT and decide there.
+       Settles sync back to BG `snapIndex`; `snapIndex` writes and
+       `setSnap` hop the other way.
      - Drag also paints the backdrop: `touchmove` writes `ctx.progressMTRef`
        and inline `opacity` on `ctx.backdropElRef` so the dim tracks the
        panel 1:1; release restores / fades it with a transition matching
@@ -33,11 +42,14 @@
      setter is a dev-warn no-op), and the watch dispatches fire post-mount
      so they don't hit the setup-time registration race above.
 
-     Inline `animation: 'none'` on the dismiss-after-drag path overrides
-     Presence's `.ui-leaving` keyframe so the panel slides smoothly from
-     its dragged position to off-screen instead of snapping back to
-     `translateY(0)` mid-flight. `@transitionend` then advances Presence
-     to `Left`. -->
+     Inline `animation: 'none'` overrides Presence's keyframes wherever
+     the panel isn't at the keyframes' assumed position: the dismiss-after-
+     drag path (slide off from the dragged position, not translateY(0)),
+     and any settle BELOW fully open (so a later non-drag close can't start
+     `.ui-leaving` from translateY(0) — `_slideOffFromCurrent` drives those
+     closes instead). Settling back at fully open clears the inline
+     `animation` so the normal keyframe paths apply again. In all inline
+     cases `@transitionend` advances Presence to `Left`. -->
 <script lang="ts">
 export interface SheetContentImplProps {
   /** Disable dragging. */
@@ -54,7 +66,8 @@ import {
   PresenceState,
   presenceClassVariants,
 } from '@/components/Presence'
-import { useA11y } from '@/shared/composables'
+import { useA11y, viewportSnapsToPositions } from '@/shared/composables'
+import { clamp } from '@/shared/clamp'
 import { injectSheetRootContext, provideSheetDragContext } from './sheetContext'
 
 const props = withDefaults(defineProps<SheetContentImplProps>(), {
@@ -94,10 +107,13 @@ const panelHeight = computed(() => {
 
 // Whether the content view should bind touch handlers. `handleOnly` makes
 // `SheetHandle` the only drag surface; props.dragDisabled fully disables drag.
+// With multiple snap points, drag stays enabled even when drag-to-close is
+// off — the user can still drag BETWEEN snaps; only the dismiss branch is
+// gated (by `enableDragToCloseRef` inside `_onTouchEnd`).
 const isDragEnabled = computed(() =>
   !props.dragDisabled
   && !ctx.handleOnly.value
-  && ctx.enableDragToClose.value,
+  && (ctx.enableDragToClose.value || ctx.snapPoints.value.length > 1),
 )
 
 // ---- MT refs for drag state -------------------------------------------
@@ -106,7 +122,6 @@ const isDragEnabled = computed(() =>
 const containerRef = useMainThreadRef<any>(null)
 const touchStartYRef = useMainThreadRef<number>(0)
 const isDraggingRef = useMainThreadRef<boolean>(false)
-const lastTouchYRef = useMainThreadRef<number>(0)
 // Ring-buffer for velocity. Each entry is `[y, timestampMs]`. We keep the
 // trailing 50ms of touch samples.
 const sampleRingRef = useMainThreadRef<Array<[number, number]>>([])
@@ -127,11 +142,37 @@ const panelHeightPx = computed(() => {
 })
 const panelHeightPxRef = useMainThreadRef<number>(panelHeightPx.value)
 
+// Snap positions in px-from-open, ascending (`[0]` = most open = 0, since
+// the panel is sized to the largest snap). Resolved by the unit-tested
+// helper; mirrored to MT for the release worklet.
+const snapPositionsPx = computed(() =>
+  viewportSnapsToPositions(ctx.snapPoints.value, ctx.viewportHeight.value, panelHeightPx.value),
+)
+
+// Position (px-from-open) that BG's `snapIndex` points at. `ctx.snapIndex`
+// is fraction-ordered (0 = smallest fraction = most CLOSED); positions are
+// most-open-first, hence the index flip.
+const snapTargetPos = computed(() => {
+  const positions = snapPositionsPx.value
+  const idx = clamp(ctx.snapIndex.value, 0, positions.length - 1)
+  return positions[positions.length - 1 - idx] ?? 0
+})
+
 // Release physics from SheetRoot's props. `ctx.velocityThreshold` is
-// deliberately not mirrored — it only matters for multi-snap drag settle,
-// which isn't implemented yet.
+// deliberately not mirrored — `pickRelease` (and the worklet mirror of it)
+// implements flick-advance via the coast projection instead.
 const dismissVelocityRef = useMainThreadRef<number>(ctx.dismissVelocity.value)
 const durationMsRef = useMainThreadRef<number>(ctx.duration.value)
+const snapPositionsRef = useMainThreadRef<number[]>(snapPositionsPx.value)
+const enableDragToCloseRef = useMainThreadRef<boolean>(ctx.enableDragToClose.value)
+
+// Authoritative panel position, px-from-open (0 = fully open). Written by
+// the drag/settle worklets the moment a move is COMMITTED (eagerly at
+// release, not when the transition finishes). The BG side cannot read it,
+// so BG-initiated moves dispatch to MT and decide against it there.
+const posRef = useMainThreadRef<number>(0)
+// Position the active drag started from (drags can begin at any snap).
+const touchStartPosRef = useMainThreadRef<number>(0)
 
 // ---- Config sync BG → MT ----------------------------------------------
 // vue-lynx@0.4.0 silently drops BG-thread writes to `MainThreadRef.current`
@@ -155,9 +196,21 @@ function _setDurationMs(v: number) {
   durationMsRef.current = v
 }
 
+function _setSnapPositions(v: number[]) {
+  'main thread'
+  snapPositionsRef.current = v
+}
+
+function _setEnableDragToClose(v: boolean) {
+  'main thread'
+  enableDragToCloseRef.current = v
+}
+
 watch(panelHeightPx, (v) => { void runOnMainThread(_setPanelHeightPx as any)(v) })
 watch(ctx.dismissVelocity, (v) => { void runOnMainThread(_setDismissVelocity as any)(v) })
 watch(ctx.duration, (v) => { void runOnMainThread(_setDurationMs as any)(v) })
+watch(snapPositionsPx, (v) => { void runOnMainThread(_setSnapPositions as any)(v) })
+watch(ctx.enableDragToClose, (v) => { void runOnMainThread(_setEnableDragToClose as any)(v) })
 
 // ---- Touch worklets ---------------------------------------------------
 
@@ -210,16 +263,17 @@ function _onTouchStart(e: { detail: { y: number } }) {
   isDraggingRef.current = true
   const y = e.detail.y
   touchStartYRef.current = y
-  lastTouchYRef.current = y
   sampleRingRef.current = [[y, Date.now()]]
-  // Kill any in-flight transition AND reset the panel to a known baseline
-  // (translateY(0) = fully open). Without resetting the transform here,
-  // touching mid-snap-back inherits whatever intermediate transform the
-  // CSS transition was computing — the browser can keep painting from
-  // that interpolated value, fighting our subsequent `touchmove` writes,
-  // which causes drag to "not pick up" the way the user expects.
-  // Snapping to 0 immediately gives the drag a clean origin to work from.
-  _setStyle({ transition: 'none', transform: 'translateY(0)' })
+  touchStartPosRef.current = posRef.current
+  // Kill any in-flight transition AND re-assert the last COMMITTED position.
+  // Without re-asserting the transform here, touching mid-settle inherits
+  // whatever intermediate transform the CSS transition was computing — the
+  // engine can keep painting from that interpolated value, fighting our
+  // subsequent `touchmove` writes, so drag doesn't "pick up". We can't read
+  // the interpolated transform on MT, so a mid-settle grab snaps to the
+  // settle's target (`posRef` is written eagerly at release) and drags from
+  // there — a small jump in the worst case, never a stuck panel.
+  _setStyle({ transition: 'none', transform: `translateY(${posRef.current}px)` })
   // The backdrop joins the drag: kill its transition so the per-frame
   // opacity writes in touchmove paint immediately instead of easing.
   _setBackdropStyle({ transition: 'none' })
@@ -229,16 +283,17 @@ function _onTouchMove(e: { detail: { y: number } }) {
   'main thread'
   if (!isDraggingRef.current) return
   const y = e.detail.y
-  lastTouchYRef.current = y
-  // Drag only downward (positive delta). Negative deltas (dragging up past
-  // the open position) are clamped to 0 — we don't have a snap above open.
-  let delta = y - touchStartYRef.current
-  if (delta < 0) delta = 0
-  _setStyle({ transform: `translateY(${delta}px)` })
+  // Position = drag origin + finger delta, clamped to the travel range:
+  // 0 (fully open — no snap above it) … panel height (fully off-screen).
+  const hpx = panelHeightPxRef.current
+  let pos = touchStartPosRef.current + (y - touchStartYRef.current)
+  if (pos < 0) pos = 0
+  if (pos > hpx) pos = hpx
+  posRef.current = pos
+  _setStyle({ transform: `translateY(${pos}px)` })
   // Drag-synced backdrop fade: 1 = fully open, 0 = dragged the full panel
   // height. Mirrored into the context's progressMTRef for other MT readers.
-  const hpx = panelHeightPxRef.current
-  let progress = hpx > 0 ? 1 - delta / hpx : 1
+  let progress = hpx > 0 ? 1 - pos / hpx : 1
   if (progress < 0) progress = 0
   if (progress > 1) progress = 1
   progressRef.current = progress
@@ -253,11 +308,7 @@ function _onTouchEnd() {
   if (!isDraggingRef.current) return
   isDraggingRef.current = false
 
-  const startY = touchStartYRef.current
-  const endY = lastTouchYRef.current
-  const delta = endY - startY
-
-  // Velocity from ring buffer (px/s). Positive = downward.
+  // Velocity from ring buffer (px/s). Positive = downward (toward close).
   const ring = sampleRingRef.current
   let velocity = 0
   if (ring.length >= 2) {
@@ -267,18 +318,33 @@ function _onTouchEnd() {
     if (dt > 0) velocity = (last[0] - first[0]) / dt
   }
 
-  const panelHpx = panelHeightPxRef.current
-  // Dismiss if dragged > 40% of panel height OR flicked down hard
-  // (faster than SheetRoot's `dismissVelocity` prop).
-  const DISMISS_DISTANCE = panelHpx * 0.4
-  const shouldDismiss = delta > DISMISS_DISTANCE
-    || (velocity > 0 && velocity > dismissVelocityRef.current)
+  const pos = posRef.current
+  const hpx = panelHeightPxRef.current
+  const positions = snapPositionsRef.current
+  const durationMs = durationMsRef.current
 
-  // Settle timings derive from SheetRoot's `duration` prop: snap-back uses
+  // Release decision — MIRRORS `pickRelease` in useSheetBehavior.ts (the
+  // unit-tested spec; worklets can't import it — keep the two in sync),
+  // with one deliberate divergence: the "≥15px past most-closed with no
+  // pull-back" mouse fallback is dropped. That rule exists for desktop
+  // Drawer drags (rarely any fling velocity) and would make a touch sheet
+  // dismiss on a 16px sag. Coast: 100ms of inertia biases the snap choice
+  // toward the fling direction, which is what makes a flick advance one
+  // snap without a separate velocity rule.
+  const projected = pos + velocity * 0.1
+  const mostClosed = positions.length > 0 ? positions[positions.length - 1] : 0
+  // Distance past the most-closed snap that dismisses with no velocity:
+  // 40% of panel height (the pre-multi-snap rule, generalized to measure
+  // from the most-closed snap instead of from open).
+  const shouldDismiss = enableDragToCloseRef.current
+    && (velocity >= dismissVelocityRef.current
+      || projected > mostClosed + hpx * 0.4)
+
+  // Settle timings derive from SheetRoot's `duration` prop: snap settle uses
   // the full duration; dismiss is a slightly quicker 0.9× cut (matches the
   // previous hardcoded 280 / 250ms feel at the default duration).
-  const durationMs = durationMsRef.current
   if (shouldDismiss) {
+    posRef.current = hpx
     const dismissMs = Math.round(durationMs * 0.9)
     // Suppress the `.ui-leaving` keyframe with inline `animation: none` so
     // the slide-off transitions smoothly from the current drag position
@@ -299,18 +365,38 @@ function _onTouchEnd() {
     runOnBackground(_emitClose as any)()
   }
   else {
-    // Snap back to open via a quick CSS transition. The .ui-open class
-    // statically holds `translateY(0)` once the inline transform matches.
+    // Settle at the snap nearest the coast-projected position.
+    let idx = 0
+    let best = positions.length > 0 ? Math.abs(projected - positions[0]) : 0
+    for (let i = 1; i < positions.length; i++) {
+      const d = Math.abs(projected - positions[i])
+      if (d < best) {
+        best = d
+        idx = i
+      }
+    }
+    const target = positions.length > 0 ? positions[idx] : 0
+    posRef.current = target
+    // Below fully open, inline `animation: none` stays on the panel so a
+    // later non-drag close can't start `.ui-leaving` from translateY(0)
+    // (`_slideOffFromCurrent` drives those closes). At fully open the
+    // inline animation is cleared so the keyframe paths apply again.
+    // DEVICE-VERIFY: clearing via empty-string setStyleProperty value.
     _setStyle({
+      animation: target === 0 ? '' : 'none',
       transition: `transform ${durationMs}ms ease-out`,
-      transform: 'translateY(0)',
+      transform: `translateY(${target}px)`,
     })
-    // Restore the backdrop dim in step with the panel's snap-back.
-    progressRef.current = 1
+    // Move the backdrop dim in step with the settle.
+    let progress = hpx > 0 ? 1 - target / hpx : 1
+    if (progress < 0) progress = 0
+    if (progress > 1) progress = 1
+    progressRef.current = progress
     _setBackdropStyle({
       transition: `opacity ${durationMs}ms ease-out`,
-      opacity: '1',
+      opacity: String(progress),
     })
+    runOnBackground(_settle as any)(idx)
   }
 }
 
@@ -318,23 +404,122 @@ function _onTouchCancel() {
   'main thread'
   if (!isDraggingRef.current) return
   isDraggingRef.current = false
-  // Cancel snaps back faster than a deliberate release — 0.7× the settle
-  // duration (matches the previous hardcoded 200ms at the 280ms default).
+  // Cancel returns to the position the drag STARTED from (always a snap),
+  // faster than a deliberate release — 0.7× the settle duration (matches
+  // the previous hardcoded 200ms at the 280ms default).
+  const target = touchStartPosRef.current
+  const hpx = panelHeightPxRef.current
+  posRef.current = target
   const cancelMs = Math.round(durationMsRef.current * 0.7)
   _setStyle({
+    animation: target === 0 ? '' : 'none',
     transition: `transform ${cancelMs}ms ease-out`,
-    transform: 'translateY(0)',
+    transform: `translateY(${target}px)`,
   })
-  progressRef.current = 1
+  let progress = hpx > 0 ? 1 - target / hpx : 1
+  if (progress < 0) progress = 0
+  if (progress > 1) progress = 1
+  progressRef.current = progress
   _setBackdropStyle({
     transition: `opacity ${cancelMs}ms ease-out`,
-    opacity: '1',
+    opacity: String(progress),
+  })
+}
+
+// Programmatic move (BG `snapIndex` watch / post-enter sync). Skips while
+// dragging, and skips the echo that arrives after a drag settle already
+// moved the panel (`posRef` is written eagerly at release, so the echoed
+// target compares equal).
+function _jumpToSnap(target: number) {
+  'main thread'
+  if (isDraggingRef.current) return
+  if (target === posRef.current) return
+  posRef.current = target
+  const ms = durationMsRef.current
+  _setStyle({
+    animation: target === 0 ? '' : 'none',
+    transition: `transform ${ms}ms ease-out`,
+    transform: `translateY(${target}px)`,
+  })
+  const hpx = panelHeightPxRef.current
+  let progress = hpx > 0 ? 1 - target / hpx : 1
+  if (progress < 0) progress = 0
+  if (progress > 1) progress = 1
+  progressRef.current = progress
+  _setBackdropStyle({
+    transition: `opacity ${ms}ms ease-out`,
+    opacity: String(progress),
+  })
+}
+
+// Non-drag close (backdrop tap / programmatic `setOpen(false)`) while the
+// panel sits below fully open. The `.ui-leaving` keyframe starts at
+// translateY(0) and would jump the panel up before sliding off; settles
+// below fully open left inline `animation: none` on the panel, so the
+// keyframe never starts and this transition drives the close instead. At
+// fully open (posRef 0) it bails and the keyframe path runs unchanged; at
+// >= panel height a drag-dismiss is already in flight — also bail.
+function _slideOffFromCurrent() {
+  'main thread'
+  if (isDraggingRef.current) return
+  const pos = posRef.current
+  const hpx = panelHeightPxRef.current
+  if (pos === 0 || pos >= hpx) return
+  posRef.current = hpx
+  const ms = Math.round(durationMsRef.current * 0.9)
+  _setStyle({
+    animation: 'none',
+    transition: `transform ${ms}ms ease-in`,
+    transform: 'translateY(100%)',
+  })
+  progressRef.current = 0
+  _setBackdropStyle({
+    transition: `opacity ${ms}ms ease-in`,
+    opacity: '0',
   })
 }
 
 function _emitClose() {
   ctx.setOpen(false)
 }
+
+// Drag settle → BG snapIndex. `ascIdx` indexes the most-open-first positions
+// array; flip back to the fraction-ordered ctx convention. The write echoes
+// through the snapIndex watch below, but `_jumpToSnap` no-ops on it (posRef
+// already equals the target).
+function _settle(ascIdx: number) {
+  const n = ctx.snapPoints.value.length
+  const ctxIdx = clamp(n - 1 - ascIdx, 0, n - 1)
+  if (ctx.snapIndex.value !== ctxIdx) ctx.snapIndex.value = ctxIdx
+}
+
+// BG-initiated moves. While Entering, the slide-in keyframe owns the
+// transform (inline writes lose to an active animation), so snapIndex
+// changes mid-enter are deferred to the Entered re-sync below. While
+// Leaving/Left the panel is on its way out — nothing to move.
+watch(snapTargetPos, (pos) => {
+  if (presenceState.value !== PresenceState.Entered) return
+  void runOnMainThread(_jumpToSnap as any)(pos)
+})
+
+// Entered re-sync: the enter keyframe always lands at translateY(0) (fully
+// open). If snapIndex points below that — preset before open, or changed
+// mid-enter — ease down to it now. Also the v1 "open at an intermediate
+// snap" story: slide fully in, then settle down. DEVICE-VERIFY: dispatch
+// rides a different channel than the Entered class patch, so the first
+// frames of the settle may still be masked by the outgoing keyframe.
+watch(presenceState, (s) => {
+  if (s === PresenceState.Entered && snapTargetPos.value !== 0) {
+    void runOnMainThread(_jumpToSnap as any)(snapTargetPos.value)
+  }
+})
+
+// Non-drag close hook for `_slideOffFromCurrent`. Dispatch unconditionally —
+// only MT knows the real position (`posRef`), and the worklet bails when the
+// keyframe path should run (fully open) or a drag-dismiss is in flight.
+watch(() => ctx.open.value, (isOpen) => {
+  if (!isOpen) void runOnMainThread(_slideOffFromCurrent as any)()
+})
 
 // SheetHandle uses the same MT touch handlers when handleOnly is true.
 provideSheetDragContext({

--- a/packages/core/src/components/Sheet/SheetContentImpl.vue
+++ b/packages/core/src/components/Sheet/SheetContentImpl.vue
@@ -9,6 +9,11 @@
      - Drag is driven by MT touch worklets that paint inline `transform`
        via `setStyleProperty`. On release we either snap back (CSS
        transition) or dismiss (inline transition + `setOpen(false)`).
+     - Drag also paints the backdrop: `touchmove` writes `ctx.progressMTRef`
+       and inline `opacity` on `ctx.backdropElRef` so the dim tracks the
+       panel 1:1; release restores / fades it with a transition matching
+       the panel's. The backdrop unmounts with Presence on close, so the
+       inline opacity can't leak into the next open.
 
      The MT refs (touchStart, dragging flag, velocity ring buffer, etc.)
      are only read INSIDE touch worklets, which fire on user input — long
@@ -19,6 +24,14 @@
      before refs are registered. Touch handlers attached via
      `:main-thread-bindtouchstart` go through `SET_WORKLET_EVENT` which
      flushes in the same batch as `INIT_MT_REF`.
+
+     Config (panel height px, dismiss velocity, settle duration) is
+     mirrored into MT refs: initial values ride the constructor's
+     `INIT_MT_REF` transfer; later changes hop through watch-triggered
+     `runOnMainThread` setter worklets. Plain BG writes to
+     `MainThreadRef.current` are silently dropped by vue-lynx@0.4.0 (the
+     setter is a dev-warn no-op), and the watch dispatches fire post-mount
+     so they don't hit the setup-time registration race above.
 
      Inline `animation: 'none'` on the dismiss-after-drag path overrides
      Presence's `.ui-leaving` keyframe so the panel slides smoothly from
@@ -33,8 +46,8 @@ export interface SheetContentImplProps {
 </script>
 
 <script setup lang="ts">
-import { computed, inject } from 'vue'
-import { runOnBackground, useMainThreadRef } from 'vue-lynx'
+import { computed, inject, watch } from 'vue'
+import { runOnBackground, runOnMainThread, useMainThreadRef } from 'vue-lynx'
 
 import {
   PresenceContextKey,
@@ -97,20 +110,82 @@ const lastTouchYRef = useMainThreadRef<number>(0)
 // Ring-buffer for velocity. Each entry is `[y, timestampMs]`. We keep the
 // trailing 50ms of touch samples.
 const sampleRingRef = useMainThreadRef<Array<[number, number]>>([])
-// Panel height in px on MT (for dismiss threshold). Derived from viewport.
-const panelHeightPxRef = useMainThreadRef<number>(
-  Math.round(ctx.viewportHeight.value * (
-    ctx.snapPoints.value.length > 0
-      ? ctx.snapPoints.value[ctx.snapPoints.value.length - 1] ?? 1
-      : 1
-  )),
-)
+
+// Root-owned MT refs (created and INIT_MT_REF-registered by SheetRoot).
+// Bound to local consts so the worklet transform captures the
+// MainThreadRef itself rather than the whole BG context object.
+const backdropRef = ctx.backdropElRef
+const progressRef = ctx.progressMTRef
+
+// Panel height in px on MT (for the dismiss threshold and backdrop fade
+// progress). Recomputes on rotation / late-resolving SystemInfo /
+// snapPoint changes; the watch below re-syncs it to MT.
+const panelHeightPx = computed(() => {
+  const snaps = ctx.snapPoints.value
+  const maxSnap = snaps.length > 0 ? snaps[snaps.length - 1] ?? 1 : 1
+  return Math.round(ctx.viewportHeight.value * maxSnap)
+})
+const panelHeightPxRef = useMainThreadRef<number>(panelHeightPx.value)
+
+// Release physics from SheetRoot's props. `ctx.velocityThreshold` is
+// deliberately not mirrored — it only matters for multi-snap drag settle,
+// which isn't implemented yet.
+const dismissVelocityRef = useMainThreadRef<number>(ctx.dismissVelocity.value)
+const durationMsRef = useMainThreadRef<number>(ctx.duration.value)
+
+// ---- Config sync BG → MT ----------------------------------------------
+// vue-lynx@0.4.0 silently drops BG-thread writes to `MainThreadRef.current`
+// (only the constructor's INIT_MT_REF transfers a value BG → MT), so these
+// syncs have to hop through `runOnMainThread`. That's safe here: watch
+// callbacks fire post-mount, long after the refs are registered — the
+// setup-time dispatch race in the header comment doesn't apply.
+
+function _setPanelHeightPx(v: number) {
+  'main thread'
+  panelHeightPxRef.current = v
+}
+
+function _setDismissVelocity(v: number) {
+  'main thread'
+  dismissVelocityRef.current = v
+}
+
+function _setDurationMs(v: number) {
+  'main thread'
+  durationMsRef.current = v
+}
+
+watch(panelHeightPx, (v) => { void runOnMainThread(_setPanelHeightPx as any)(v) })
+watch(ctx.dismissVelocity, (v) => { void runOnMainThread(_setDismissVelocity as any)(v) })
+watch(ctx.duration, (v) => { void runOnMainThread(_setDurationMs as any)(v) })
 
 // ---- Touch worklets ---------------------------------------------------
 
 function _setStyle(decl: Record<string, string>) {
   'main thread'
   const el = containerRef as unknown as {
+    current?: {
+      setStyleProperties?(s: Record<string, string>): void
+      setStyleProperty?(k: string, v: string): void
+    }
+  }
+  if (el.current?.setStyleProperties) {
+    el.current.setStyleProperties(decl)
+  }
+  else if (el.current?.setStyleProperty) {
+    for (const k in decl) el.current.setStyleProperty(k, decl[k])
+  }
+}
+
+// DEVICE-VERIFY: painting a SECOND element (the backdrop) from the
+// content's touch worklets hasn't been device-verified — it's the same
+// setStyleProperty surface as the panel, but through a ref populated by
+// a sibling component (`SheetBackdropImpl`'s `:main-thread-ref`).
+function _setBackdropStyle(decl: Record<string, string>) {
+  'main thread'
+  // The backdrop is optional (sheets can render without one) and unmounts
+  // with Presence on close, so `current` may be null — bail quietly.
+  const el = backdropRef as unknown as {
     current?: {
       setStyleProperties?(s: Record<string, string>): void
       setStyleProperty?(k: string, v: string): void
@@ -145,6 +220,9 @@ function _onTouchStart(e: { detail: { y: number } }) {
   // which causes drag to "not pick up" the way the user expects.
   // Snapping to 0 immediately gives the drag a clean origin to work from.
   _setStyle({ transition: 'none', transform: 'translateY(0)' })
+  // The backdrop joins the drag: kill its transition so the per-frame
+  // opacity writes in touchmove paint immediately instead of easing.
+  _setBackdropStyle({ transition: 'none' })
 }
 
 function _onTouchMove(e: { detail: { y: number } }) {
@@ -157,6 +235,14 @@ function _onTouchMove(e: { detail: { y: number } }) {
   let delta = y - touchStartYRef.current
   if (delta < 0) delta = 0
   _setStyle({ transform: `translateY(${delta}px)` })
+  // Drag-synced backdrop fade: 1 = fully open, 0 = dragged the full panel
+  // height. Mirrored into the context's progressMTRef for other MT readers.
+  const hpx = panelHeightPxRef.current
+  let progress = hpx > 0 ? 1 - delta / hpx : 1
+  if (progress < 0) progress = 0
+  if (progress > 1) progress = 1
+  progressRef.current = progress
+  _setBackdropStyle({ opacity: String(progress) })
   const now = Date.now()
   sampleRingRef.current.push([y, now])
   _pruneRing(now)
@@ -182,21 +268,33 @@ function _onTouchEnd() {
   }
 
   const panelHpx = panelHeightPxRef.current
-  // Dismiss if dragged > 40% of panel height OR flicked down hard.
+  // Dismiss if dragged > 40% of panel height OR flicked down hard
+  // (faster than SheetRoot's `dismissVelocity` prop).
   const DISMISS_DISTANCE = panelHpx * 0.4
-  const FLING_VELOCITY = 600
   const shouldDismiss = delta > DISMISS_DISTANCE
-    || (velocity > 0 && velocity > FLING_VELOCITY)
+    || (velocity > 0 && velocity > dismissVelocityRef.current)
 
+  // Settle timings derive from SheetRoot's `duration` prop: snap-back uses
+  // the full duration; dismiss is a slightly quicker 0.9× cut (matches the
+  // previous hardcoded 280 / 250ms feel at the default duration).
+  const durationMs = durationMsRef.current
   if (shouldDismiss) {
+    const dismissMs = Math.round(durationMs * 0.9)
     // Suppress the `.ui-leaving` keyframe with inline `animation: none` so
     // the slide-off transitions smoothly from the current drag position
     // instead of snapping back to translateY(0) first. The
     // `@transitionend` listener then advances Presence to `Left`.
     _setStyle({
       animation: 'none',
-      transition: 'transform 250ms ease-in',
+      transition: `transform ${dismissMs}ms ease-in`,
       transform: 'translateY(100%)',
+    })
+    // Fade the backdrop out alongside the slide-off. Presence unmounts it
+    // once the close completes, so the inline opacity can't stick around.
+    progressRef.current = 0
+    _setBackdropStyle({
+      transition: `opacity ${dismissMs}ms ease-in`,
+      opacity: '0',
     })
     runOnBackground(_emitClose as any)()
   }
@@ -204,8 +302,14 @@ function _onTouchEnd() {
     // Snap back to open via a quick CSS transition. The .ui-open class
     // statically holds `translateY(0)` once the inline transform matches.
     _setStyle({
-      transition: 'transform 280ms ease-out',
+      transition: `transform ${durationMs}ms ease-out`,
       transform: 'translateY(0)',
+    })
+    // Restore the backdrop dim in step with the panel's snap-back.
+    progressRef.current = 1
+    _setBackdropStyle({
+      transition: `opacity ${durationMs}ms ease-out`,
+      opacity: '1',
     })
   }
 }
@@ -214,9 +318,17 @@ function _onTouchCancel() {
   'main thread'
   if (!isDraggingRef.current) return
   isDraggingRef.current = false
+  // Cancel snaps back faster than a deliberate release — 0.7× the settle
+  // duration (matches the previous hardcoded 200ms at the 280ms default).
+  const cancelMs = Math.round(durationMsRef.current * 0.7)
   _setStyle({
-    transition: 'transform 200ms ease-out',
+    transition: `transform ${cancelMs}ms ease-out`,
     transform: 'translateY(0)',
+  })
+  progressRef.current = 1
+  _setBackdropStyle({
+    transition: `opacity ${cancelMs}ms ease-out`,
+    opacity: '1',
   })
 }
 

--- a/packages/core/src/components/Sheet/SheetRoot.vue
+++ b/packages/core/src/components/Sheet/SheetRoot.vue
@@ -9,9 +9,18 @@ export interface SheetRootProps {
   open?: boolean
   /** Initial open state when uncontrolled. */
   defaultOpen?: boolean
-  /** Controlled current snap index. Bind with `v-model:snapIndex`. */
+  /**
+   * Controlled current snap index. Bind with `v-model:snapIndex`. Indexes
+   * the SORTED `snapPoints` (0 = smallest fraction = most closed). Updated
+   * by drag settles; writing it animates the open sheet to that snap.
+   */
   snapIndex?: number
-  /** Initial snap index when uncontrolled (defaults to 0). */
+  /**
+   * Initial snap index when uncontrolled (defaults to 0). The enter
+   * animation always slides fully in first; when this points below the
+   * largest snap the sheet then settles down to it. The index persists
+   * across close/reopen.
+   */
   defaultSnapIndex?: number
   /**
    * Snap points as fractions of viewport height, low → high. e.g. `[0.25, 0.5, 0.9]`.
@@ -25,13 +34,15 @@ export interface SheetRootProps {
   viewportHeight?: number
   /**
    * Absolute velocity (px/s) above which a fling advances by one snap regardless
-   * of position. Currently unused — reserved for multi-snap drag settle,
-   * which isn't implemented yet.
+   * of position. Currently unused — the release logic (mirroring
+   * `pickRelease`) implements flick-advance via a 100ms coast projection
+   * instead. Reserved.
    * @defaultValue `400`
    */
   velocityThreshold?: number
   /**
-   * Downward velocity (px/s) past the first snap that triggers dismiss.
+   * Downward velocity (px/s) at which a fling dismisses from any position
+   * (when `enableDragToClose`).
    * @defaultValue `600`
    */
   dismissVelocity?: number
@@ -42,7 +53,9 @@ export interface SheetRootProps {
    */
   duration?: number
   /**
-   * Allow drag below the first snap to dismiss.
+   * Allow drag below the most-closed snap to dismiss. When `false` with
+   * multiple snap points, drag between snaps still works — only the
+   * dismiss branch is disabled.
    * @defaultValue `true`
    */
   enableDragToClose?: boolean
@@ -112,10 +125,12 @@ const viewportHeight = computed(() => {
 const progressMTRef = useMainThreadRef<number>(0)
 const backdropElRef = useMainThreadRef<any>(null)
 
+// Close does NOT reset snapIndex: the index persists so reopen restores the
+// last snap (and a settled v-model value isn't silently rewritten mid-close,
+// which would misfire SheetContentImpl's close-time position logic).
 function setOpen(next: boolean) {
   if (open.value === next) return
   open.value = next
-  if (!next) snapIndex.value = 0
 }
 
 function setSnap(idx: number) {

--- a/packages/core/src/components/Sheet/SheetRoot.vue
+++ b/packages/core/src/components/Sheet/SheetRoot.vue
@@ -25,7 +25,8 @@ export interface SheetRootProps {
   viewportHeight?: number
   /**
    * Absolute velocity (px/s) above which a fling advances by one snap regardless
-   * of position.
+   * of position. Currently unused — reserved for multi-snap drag settle,
+   * which isn't implemented yet.
    * @defaultValue `400`
    */
   velocityThreshold?: number
@@ -34,7 +35,11 @@ export interface SheetRootProps {
    * @defaultValue `600`
    */
   dismissVelocity?: number
-  /** Settle animation duration in ms. */
+  /**
+   * Settle animation duration in ms. Drag release snap-back uses it
+   * directly; drag-dismiss and touch-cancel use shorter cuts of it.
+   * @defaultValue `280`
+   */
   duration?: number
   /**
    * Allow drag below the first snap to dismiss.
@@ -101,8 +106,9 @@ const viewportHeight = computed(() => {
   return 800
 })
 
-// MT progress (0 closed → 1 fully open). Lives at the root so the backdrop
-// can read it without injecting through SheetContent.
+// MT drag progress (1 fully open → 0 dragged to dismiss; only written
+// during drag — see sheetContext). Lives at the root so the backdrop can
+// read it without injecting through SheetContent.
 const progressMTRef = useMainThreadRef<number>(0)
 const backdropElRef = useMainThreadRef<any>(null)
 

--- a/packages/core/src/components/Sheet/sheetContext.ts
+++ b/packages/core/src/components/Sheet/sheetContext.ts
@@ -9,22 +9,30 @@ import { createContext } from '../../shared/createContext'
 export interface SheetRootContext {
   /** Controlled open state. */
   open: Ref<boolean>
-  /** Current snap index. 0..snapPoints.length-1 when open. */
+  /**
+   * Current snap index, 0..snapPoints.length-1 (0 = smallest fraction =
+   * most closed). Drag settles write it; writing it moves the open sheet.
+   * Persists across close/reopen.
+   */
   snapIndex: Ref<number>
   /** Snap points (0-1 fractions of viewport height), low to high. */
   snapPoints: ComputedRef<number[]>
   /** Viewport height in px (resolved from prop / runtime). */
   viewportHeight: ComputedRef<number>
   /**
-   * Velocity threshold for fling-to-snap (px/s). Currently unused —
-   * reserved for multi-snap drag settle, which isn't implemented yet.
+   * Velocity threshold for fling-to-snap (px/s). Currently unused — the
+   * release logic (mirroring `pickRelease`) implements flick-advance via
+   * its coast projection instead. Reserved.
    */
   velocityThreshold: ComputedRef<number>
   /** Velocity threshold for fling-to-dismiss (px/s). */
   dismissVelocity: ComputedRef<number>
   /** Animation duration for settle (ms). */
   duration: ComputedRef<number>
-  /** Whether the user can drag below the first snap to dismiss. */
+  /**
+   * Whether drag past the most-closed snap dismisses. `false` with multiple
+   * snap points still allows drag between snaps.
+   */
   enableDragToClose: ComputedRef<boolean>
   /** Restrict drag to the SheetHandle when true. */
   handleOnly: ComputedRef<boolean>
@@ -33,11 +41,12 @@ export interface SheetRootContext {
   /** Snap to a specific index, animated. */
   setSnap: (index: number) => void
   /**
-   * MT-side drag progress (1 = fully open, 0 = dragged the full panel
-   * height). SheetContent's touch worklets write it on touchmove and on
-   * release/cancel. Only updated during drag — CSS-driven open/close
-   * animations do NOT touch it, so MT readers must not treat it as a
-   * general open-ness signal.
+   * MT-side panel progress (1 = fully open, 0 = the full panel height
+   * toward closed). SheetContent's worklets write it on touchmove,
+   * release/cancel, programmatic snap moves, and the non-drag close from
+   * an intermediate snap. The CSS keyframe open/close animations do NOT
+   * touch it, so MT readers must not treat it as a general open-ness
+   * signal.
    */
   progressMTRef: MainThreadRef<number>
   /**

--- a/packages/core/src/components/Sheet/sheetContext.ts
+++ b/packages/core/src/components/Sheet/sheetContext.ts
@@ -15,7 +15,10 @@ export interface SheetRootContext {
   snapPoints: ComputedRef<number[]>
   /** Viewport height in px (resolved from prop / runtime). */
   viewportHeight: ComputedRef<number>
-  /** Velocity threshold for fling-to-snap (px/s). */
+  /**
+   * Velocity threshold for fling-to-snap (px/s). Currently unused —
+   * reserved for multi-snap drag settle, which isn't implemented yet.
+   */
   velocityThreshold: ComputedRef<number>
   /** Velocity threshold for fling-to-dismiss (px/s). */
   dismissVelocity: ComputedRef<number>
@@ -30,14 +33,19 @@ export interface SheetRootContext {
   /** Snap to a specific index, animated. */
   setSnap: (index: number) => void
   /**
-   * MT-side progress (0 = closed, 1 = fully open). SheetContent writes to it
-   * from its drag worklets; exposed on context so other parts can read.
+   * MT-side drag progress (1 = fully open, 0 = dragged the full panel
+   * height). SheetContent's touch worklets write it on touchmove and on
+   * release/cancel. Only updated during drag — CSS-driven open/close
+   * animations do NOT touch it, so MT readers must not treat it as a
+   * general open-ness signal.
    */
   progressMTRef: MainThreadRef<number>
   /**
-   * MT element handle for the backdrop. SheetBackdrop populates it on mount;
-   * SheetContent's drag worklets paint `opacity` on it directly so the fade
-   * is sync'd to drag position with no extra polling loop.
+   * MT element handle for the backdrop. SheetBackdrop populates it via
+   * `:main-thread-ref` on mount; SheetContent's drag worklets paint inline
+   * `opacity` on it directly so the fade is sync'd to drag position with no
+   * extra polling loop. May be null — sheets can render without a backdrop,
+   * and Presence unmounts it on close — so painters must null-check.
    */
   backdropElRef: MainThreadRef<any>
 }

--- a/packages/core/src/shared/composables/index.ts
+++ b/packages/core/src/shared/composables/index.ts
@@ -40,6 +40,7 @@ export {
   resolveSnapPositions,
   resolveSnapToPosition,
   useSheetBehavior,
+  viewportSnapsToPositions,
 } from './useSheetBehavior.js'
 export type {
   PickReleaseOptions,

--- a/packages/core/src/shared/composables/useSheetBehavior.test.ts
+++ b/packages/core/src/shared/composables/useSheetBehavior.test.ts
@@ -9,6 +9,7 @@ import {
   resolveSnapPositions,
   resolveSnapToPosition,
   useSheetBehavior,
+  viewportSnapsToPositions,
 } from './useSheetBehavior.js'
 
 describe('directionAxis', () => {
@@ -77,6 +78,28 @@ describe('resolveSnapPositions', () => {
 
   it('returns an empty array when input is empty', () => {
     expect(resolveSnapPositions([], 800)).toEqual([])
+  })
+})
+
+describe('viewportSnapsToPositions', () => {
+  // SheetRoot semantics: fractions of VIEWPORT height, panel sized to the
+  // largest snap (travel = maxSnap × viewport).
+  it('maps the largest snap to 0 (fully open) and smaller ones to px offsets', () => {
+    // snaps [0.4, 0.9], viewport 800 → travel 720; 0.9 → 0, 0.4 → 720 - 320.
+    expect(viewportSnapsToPositions([0.4, 0.9], 800, 720)).toEqual([0, 400])
+  })
+
+  it('returns ascending positions regardless of input order', () => {
+    expect(viewportSnapsToPositions([0.9, 0.25, 0.5], 800, 720)).toEqual([0, 320, 520])
+  })
+
+  it('maps the single-snap default [1] to position 0', () => {
+    expect(viewportSnapsToPositions([1], 800, 800)).toEqual([0])
+  })
+
+  it('returns [] for no snaps and 0s for unmeasured travel', () => {
+    expect(viewportSnapsToPositions([], 800, 720)).toEqual([])
+    expect(viewportSnapsToPositions([0.4, 0.9], 800, 0)).toEqual([0, 0])
   })
 })
 

--- a/packages/core/src/shared/composables/useSheetBehavior.ts
+++ b/packages/core/src/shared/composables/useSheetBehavior.ts
@@ -84,6 +84,25 @@ export function resolveSnapPositions(
     .sort((a, b) => a - b)
 }
 
+/**
+ * Map `SheetRoot`-style snap fractions (of **viewport** height, any order)
+ * to px-from-open positions along the panel's travel. The panel is sized to
+ * the largest snap (`travel = maxSnap × viewportHeight`), so the largest
+ * fraction always maps to position `0` (fully open) and smaller fractions
+ * to positive offsets. Returns ascending positions (`[0]` = most open),
+ * ready for `pickRelease`.
+ */
+export function viewportSnapsToPositions(
+  snaps: readonly number[],
+  viewportHeight: number,
+  travel: number,
+): number[] {
+  return resolveSnapPositions(
+    snaps.map(s => `${s * viewportHeight}px`),
+    travel,
+  )
+}
+
 /** 0 = closed, 1 = fully open. Clamps out-of-range positions. */
 export function progressFor(position: number, travel: number): number {
   if (travel <= 0) return 0

--- a/packages/core/src/shared/gesture/useDragGesture.ts
+++ b/packages/core/src/shared/gesture/useDragGesture.ts
@@ -6,6 +6,13 @@
 // velocity queue, the rAF snap animation, and the MT↔BG hops, so a component
 // only supplies config + settle callbacks.
 //
+// BG → MT sync: in vue-lynx@0.4.0 a background-thread write to
+// `MainThreadRef.current` is silently dropped (the setter is a no-op; only the
+// constructor's `INIT_MT_REF` op transfers a value BG→MT). So every prop
+// change is pushed by dispatching a setter worklet via `runOnMainThread`
+// (`_syncConfig` below), and writes to `.current` happen only INSIDE worklets,
+// where they are MT-local and stick.
+//
 // Worklet constraints, learned the hard way in `SwiperRoot.vue`:
 //   - `'main thread'` bodies are INLINE and SELF-CONTAINED. They do NOT call
 //     worklets in another file (cross-file worklet calls don't resolve), so
@@ -24,7 +31,7 @@
 // source module being a `.ts` instead of an SFC.
 
 import type { Ref } from 'vue'
-import { onMounted, onUnmounted, watch } from 'vue'
+import { nextTick, onMounted, onUnmounted, watch } from 'vue'
 import { runOnBackground, runOnMainThread, useMainThreadRef } from 'vue-lynx'
 
 export interface DragGestureConfig {
@@ -69,7 +76,14 @@ export function useDragGesture(config: DragGestureConfig): DragGesture {
   const touchStartXRef = useMainThreadRef<number>(0)
   const touchStartOffsetRef = useMainThreadRef<number>(0)
   const isDraggingRef = useMainThreadRef<boolean>(false)
-  const internalCommitRef = useMainThreadRef<boolean>(false)
+  // Offset a drag just settled to, pending consumption by `_jumpAndAnimate`.
+  // NaN is the "nothing pending" sentinel (no valid offset is NaN). An offset
+  // rather than a boolean flag because `_settle` only writes `currentIndex`
+  // when the index actually changed — a same-index snap-back never fires the
+  // watch, and a stale boolean would swallow the NEXT programmatic change.
+  // Comparing offsets makes a stale value harmless: a later change to a
+  // different index produces a different target and still animates.
+  const expectedOffsetRef = useMainThreadRef<number>(Number.NaN)
 
   const itemWidthRef = useMainThreadRef<number>(config.itemWidth())
   const itemCountRef = useMainThreadRef<number>(config.itemCount())
@@ -86,12 +100,25 @@ export function useDragGesture(config: DragGestureConfig): DragGesture {
   const animGenRef = useMainThreadRef<number>(0)
 
   // --- BG → MT sync --------------------------------------------------------
-  watch(config.itemWidth, (v) => { itemWidthRef.current = v })
-  watch(config.itemCount, (v) => { itemCountRef.current = v })
-  watch(config.duration, (v) => { durationRef.current = v })
-  watch(config.threshold, (v) => { thresholdRef.current = v })
-  watch(config.velocityThreshold, (v) => { velocityThresholdRef.current = v })
-  watch(config.disabled, (v) => { disabledRef.current = v })
+  // One combined watch dispatching one setter worklet: BG-side writes to
+  // `MainThreadRef.current` are silently dropped in vue-lynx@0.4.0, so the
+  // values must hop via `runOnMainThread` (see header). The MT refs stay —
+  // worklets read them per-frame without a BG round-trip.
+  watch(
+    [
+      config.itemWidth,
+      config.itemCount,
+      config.duration,
+      config.threshold,
+      config.velocityThreshold,
+      config.disabled,
+    ],
+    ([itemWidth, itemCount, duration, threshold, velocityThreshold, disabled]) => {
+      runOnMainThread(_syncConfig as any)(
+        itemWidth, itemCount, duration, threshold, velocityThreshold, disabled,
+      )
+    },
+  )
 
   watch(currentIndex, (next, prev) => {
     if (next === prev) return
@@ -99,6 +126,23 @@ export function useDragGesture(config: DragGestureConfig): DragGesture {
   })
 
   // --- Worklets (all inline; no cross-file calls, no stored worklets) ------
+
+  function _syncConfig(
+    itemWidth: number,
+    itemCount: number,
+    duration: number,
+    threshold: number,
+    velocityThreshold: number,
+    disabled: boolean,
+  ) {
+    'main thread'
+    itemWidthRef.current = itemWidth
+    itemCountRef.current = itemCount
+    durationRef.current = duration
+    thresholdRef.current = threshold
+    velocityThresholdRef.current = velocityThreshold
+    disabledRef.current = disabled
+  }
 
   function _setTransform(offset: number) {
     'main thread'
@@ -148,11 +192,13 @@ export function useDragGesture(config: DragGestureConfig): DragGesture {
   function _jumpAndAnimate(targetIndex: number) {
     'main thread'
     if (isDraggingRef.current) return
-    if (internalCommitRef.current) {
-      internalCommitRef.current = false
-      return
-    }
     const target = -targetIndex * itemWidthRef.current
+    const expected = expectedOffsetRef.current
+    expectedOffsetRef.current = Number.NaN
+    // Skip only when this change is the echo of a drag settle we already
+    // animated in `_onTouchEnd`. The NaN sentinel falls through on its own:
+    // `NaN === target` is always false (inline Number.isNaN-equivalent).
+    if (expected === target) return
     _animateTo(target)
   }
 
@@ -240,9 +286,20 @@ export function useDragGesture(config: DragGestureConfig): DragGesture {
     if (target > count - 1) target = count - 1
 
     const targetOffset = -target * width
-    internalCommitRef.current = true
+    expectedOffsetRef.current = targetOffset
     _animateTo(targetOffset)
     runOnBackground(_settle as any)(target)
+  }
+
+  function _teardown() {
+    'main thread'
+    // Bump the generation so an in-flight rAF `step` bails on its next frame,
+    // and drop the velocity queues. Must run ON MT — the equivalent BG-side
+    // `.current` writes are silently dropped (see header).
+    animGenRef.current = animGenRef.current + 1
+    isDraggingRef.current = false
+    posQueueRef.current = []
+    timeQueueRef.current = []
   }
 
   // --- BG callbacks --------------------------------------------------------
@@ -268,13 +325,27 @@ export function useDragGesture(config: DragGestureConfig): DragGesture {
   // --- Lifecycle -----------------------------------------------------------
 
   onMounted(() => {
-    runOnMainThread(_setTransform as any)(offsetRef.current)
+    const initialOffset = -(currentIndex.value ?? 0) * config.itemWidth()
+    // Index 0 → translateX(0) is already the laid-out position, so skip the
+    // dispatch: `runOnMainThread` during mount travels over
+    // `coreContext.dispatchEvent`, a different channel from the batched op
+    // queue carrying `INIT_MT_REF`, and can reach MT before the refs are
+    // registered (vue-lynx@0.4.0 — see SheetContentImpl.vue). Touch handlers
+    // are immune: `SET_WORKLET_EVENT` flushes in the same batch as
+    // `INIT_MT_REF`.
+    if (initialOffset === 0) return
+    // Nonzero initial index: defer past the post-flush op batch. nextTick
+    // narrows but does NOT close the cross-channel race — only vue-lynx's
+    // `waitForFlush` could, and it is not publicly exported in 0.4.0.
+    void nextTick().then(() => {
+      runOnMainThread(_setTransform as any)(initialOffset)
+    })
   })
 
   onUnmounted(() => {
-    animGenRef.current = animGenRef.current + 1
-    posQueueRef.current = []
-    timeQueueRef.current = []
+    // Fire-and-forget MT hop — direct `.current` writes here would be BG-side
+    // no-ops and the in-flight rAF snap would keep painting after unmount.
+    runOnMainThread(_teardown as any)()
   })
 
   return {


### PR DESCRIPTION
Fixes from a main-thread usage audit of Sheet/Draggable/useDragGesture, plus multi-snap-point drag settle for the Sheet.

- fix: BG-thread writes to `MainThreadRef.current` are silently dropped by vue-lynx@0.4.0 — all watch-based prop syncs now hop via `runOnMainThread` setter worklets (Draggable, useDragGesture, Sheet)
- fix: stale `internalCommitRef` in useDragGesture swallowed the next programmatic index change after a same-index settle (now an expected-offset sentinel)
- fix: Draggable's `resetOnEnd` fill-forwards animation is cancelled on the next touchstart so drags can't go dead behind it
- fix: Sheet panel-height/dismiss-velocity/duration MT state now tracks the props instead of freezing at setup
- feat: drag-synced backdrop fade (`progressMTRef` is now actually written; backdrop opacity tracks the panel)
- feat: multi-snap drag settle — release mirrors the unit-tested `pickRelease` (coast projection), settles sync `v-model:snapIndex`, `setSnap` animates, non-drag closes slide off from the settled position
- feat(kit-demo): multi-snap `[0.4, 0.9]` drawer + full-screen `[1]` control example

Notes: `snapIndex` now persists across close/reopen; hard flings ≥ `dismissVelocity` dismiss from any snap (per spec); `enableDragToClose: false` with multiple snaps still allows between-snap drag. Device-verified on kit-demo; remaining DEVICE-VERIFY comments cover inline-`animation` clearing and the post-enter settle race.