### PR TITLE
chore: add changeset covering #67/#68/#70 + AGENTS.md changeset requirement

### DIFF
--- a/.changeset/icon-drawer-css-fixes.md
+++ b/.changeset/icon-drawer-css-fixes.md
@@ -1,0 +1,10 @@
+---
+"@vyui/core": patch
+"@vyui/kit": patch
+---
+
+Fix icon styling pass-through and Drawer rendering (#70).
+
+`@vyui/core`: treat `image` as a self-closing leaf in `Primitive` — Vue's empty-slot fragment/comment anchors were materialized as real children by vue-lynx, and a native `<image>` with any child fails to render (native-only breakage; lynx-web tolerated it).
+
+`@vyui/kit`: forward icon classes/props through ActionSheet, Alert, Button, Tabs, Toast, ToggleGroup and DropdownMenu items, and fix Drawer/theme slot classes so drawer animations work again.

--- a/.changeset/icon-drawer-css-fixes.md
+++ b/.changeset/icon-drawer-css-fixes.md
@@ -3,8 +3,14 @@
 "@vyui/kit": patch
 ---
 
-Fix icon styling pass-through and Drawer rendering (#70).
+Fixes from #67, #68 and #70.
 
-`@vyui/core`: treat `image` as a self-closing leaf in `Primitive` — Vue's empty-slot fragment/comment anchors were materialized as real children by vue-lynx, and a native `<image>` with any child fails to render (native-only breakage; lynx-web tolerated it).
+`@vyui/core`:
 
-`@vyui/kit`: forward icon classes/props through ActionSheet, Alert, Button, Tabs, Toast, ToggleGroup and DropdownMenu items, and fix Drawer/theme slot classes so drawer animations work again.
+- Icon: reject `color` values that could inject SVG markup when resolving icon sources (#67).
+- Sheet: multi-snap drag now settles to the nearest snap point, with main-thread usage fixes across `SheetContentImpl`, `Draggable` and `useDragGesture` (#68).
+- Primitive: treat `image` as a self-closing leaf — Vue's empty-slot fragment/comment anchors were materialized as real children by vue-lynx, and a native `<image>` with any child fails to render (native-only breakage; lynx-web tolerated it) (#70).
+
+`@vyui/kit`:
+
+- Forward icon classes/props through ActionSheet, Alert, Button, Tabs, Toast, ToggleGroup and DropdownMenu items, and fix Drawer/theme slot classes so drawer animations work again (#70).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+Agent-facing notes for working in this repo. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full development guide.
+
+## Changesets are required
+
+Every PR that changes published package source (`packages/core/**` or `packages/kit/**`) must include a changeset:
+
+```bash
+pnpm exec changeset
+```
+
+- Pick the affected package(s) and bump level (almost always `patch` pre-1.0).
+- For breaking changes, flag the breaking nature in the changeset summary — reviewers rely on that line.
+- Commit the generated `.changeset/*.md` file with the PR. If a PR merged without one, add it in a small follow-up PR before releasing.
+
+## Releasing (manual-only)
+
+Publishing never happens on merge to main. The flow is:
+
+1. GitHub → Actions → **Release** → Run workflow (gated by the `npm-publish` protected environment).
+2. The changesets action opens a **"chore: release packages"** PR — merge it.
+3. Run the **Release** workflow again to publish to npm (OIDC trusted publishing, no token).
+
+## Pre-PR checks
+
+- `pnpm --filter @vyui/core test` / `pnpm --filter @vyui/kit test` for touched packages.
+- `pnpm --filter <pkg> typecheck` for any package changed.
+- If you touched `packages/core/src/**`, verify the demo via `dev:local` against a fresh dist.


### PR DESCRIPTION
Adds the missing changeset for the last three package-touching PRs (none shipped with one), and documents the changeset requirement for agents.

- Add `.changeset/icon-drawer-css-fixes.md` — patch bump for `@vyui/core` and `@vyui/kit`, covering #67 (Icon color injection fix), #68 (Sheet multi-snap drag settle + MT fixes) and #70 (icon pass-through + drawer CSS fixes)
- Add root `AGENTS.md` — changesets required for published-package changes, manual release flow, pre-PR checks