### PR TITLE
feat: vyai Ollama demo + input keyboard/focus events, island-button icon color, sortable & feedlist fixes

### DIFF
--- a/.changeset/feedlist-no-more-data-prop.md
+++ b/.changeset/feedlist-no-more-data-prop.md
@@ -1,0 +1,7 @@
+---
+"@vyui/core": patch
+---
+
+FeedList: honour a `noMoreData` prop so the end-of-list footer no longer shows while more pages remain.
+
+Previously the core `FeedList` rendered the `noMoreDataFooter` slot whenever `loadingMore` was false, so "no more items" appeared immediately even with pages still loadable (the kit `VyFeedList` already forwarded `noMoreData`, but core ignored it). The footer row now only renders while `loadingMore` (load-more spinner) or once `noMoreData` is `true` (end-of-list); otherwise no footer renders.

--- a/.changeset/input-forward-focus-blur.md
+++ b/.changeset/input-forward-focus-blur.md
@@ -1,0 +1,7 @@
+---
+"@vyui/kit": patch
+---
+
+Input: forward `@focus` and `@blur` events.
+
+- The core `Input` emits `focus`/`blur` (with the current value), but the `VyInput` wrapper only re-emitted `update:modelValue` and `confirm`, so consumers couldn't react to focus changes (e.g. to drive a keyboard-aware lift). It now forwards both.

--- a/.changeset/input-keyboard-event.md
+++ b/.changeset/input-keyboard-event.md
@@ -1,0 +1,10 @@
+---
+"@vyui/core": minor
+"@vyui/kit": minor
+---
+
+Input/Textarea: surface the on-screen keyboard via a normalized `keyboard` event.
+
+- `Input` and `Textarea` (core) and `VyInput`/`VyTextarea` (kit) now emit `keyboard` with `{ visible: boolean, height: number, safeAreaBottom: number }`, normalized from Lynx's raw element payload `{ show, keyBoardHeight, safeAreaBottom }` (note the capital B in `keyBoardHeight`).
+- This is the reliable keyboard signal under vue-lynx: the global `GlobalEventEmitter` `keyboardstatuschanged` event is emitted natively but is not delivered to the vue-lynx background runtime, so the per-element event is what consumers (and keyboard-aware lifts) should use. See `docs/upstream/vue-lynx-keyboard.md`.
+- `VyTextarea` also now forwards `confirm`/`focus`/`blur` (previously only `update:modelValue`), matching `VyInput`.

--- a/.changeset/island-button-icon-color.md
+++ b/.changeset/island-button-icon-color.md
@@ -1,0 +1,8 @@
+---
+"@vyui/kit": patch
+---
+
+IslandButton: bake the icon color so the theme's foreground actually applies.
+
+- `IslandButton` rendered its glyph through Lynx's `<svg>`, which rasterizes the XML and can't inherit `currentColor` — so the `text-slate-*` utility on the `leadingIcon` slot (and the darker `text-slate-900` active shade) never reached the icon, leaving it stuck on its default fill (invisible on dark/active pills).
+- It now resolves the foreground utility off the merged `leadingIcon` class — honoring the active state and any consumer `ui.leadingIcon` override — and passes it to `<VyIcon :color>`, matching the pattern already used by `Button`, `Input`, `Alert`, and `Combobox`. Non-palette colors (e.g. arbitrary `text-[#abc]`) fall back to the icon's `currentColor` default.

--- a/.changeset/sortable-mt-registry-drag.md
+++ b/.changeset/sortable-mt-registry-drag.md
@@ -1,0 +1,10 @@
+---
+"@vyui/core": patch
+---
+
+Fix Sortable drag-to-reorder doing nothing on device/web:
+
+- **Registry was empty on the main thread.** Items registered their handle via a background-thread write to the `itemHandlesMT` `MainThreadRef`, which vue-lynx 0.4.0 silently drops. The lifted row never moved, siblings never shifted, and the drop saw `count === 0` so no reorder committed. Registration (element + index) now runs on the main thread, bound to `main-thread-binduiappear`, with MT teardown on unmount and `runOnMainThread` setter worklets for index/disabled sync.
+- **Long-press used MT `setTimeout`.** The main-thread worklet runtime does not expose `setTimeout`/`clearTimeout` (internal in `@lynx-js/types`), so the long-press timer threw and the row never lifted for any `longPressMs > 0`. The hold is now timed by polling `requestAnimationFrame` on the main thread.
+
+Public props/emits/slots unchanged.

--- a/apps/examples/kit-demo/src/sections/OverlaySection.vue
+++ b/apps/examples/kit-demo/src/sections/OverlaySection.vue
@@ -172,10 +172,20 @@ const fruitItems = [
       <VyDrawer
         v-model:open="drawerFullOpen"
         title="Full-screen drawer"
-        description="Single snap at 100% — drag down or fling to dismiss."
+        description="Single snap at 100% — drag the handle down, or use Close below."
         :snap-points="[1]"
       >
         <VyButton color="neutral" variant="subtle" label="Open full-screen drawer" />
+        <!-- A full-screen drawer covers the backdrop, so there's nothing to tap
+             outside it to dismiss. Give the body an explicit close affordance. -->
+        <template #body="{ close }">
+          <view class="flex flex-col gap-3 px-4 py-2">
+            <text class="text-slate-600 text-sm">
+              This drawer fills the viewport. Drag the handle down to dismiss, or tap Close.
+            </text>
+            <VyButton color="neutral" variant="solid" label="Close" block @tap="close()" />
+          </view>
+        </template>
       </VyDrawer>
     </view>
 

--- a/apps/examples/vyai/lynx.config.ts
+++ b/apps/examples/vyai/lynx.config.ts
@@ -1,0 +1,46 @@
+import { defineConfig } from '@lynx-js/rspeedy'
+import { pluginVueLynx } from 'vue-lynx/plugin'
+import { pluginTailwindCSS } from 'rsbuild-plugin-tailwindcss'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createLynxFullscreenHintPlugin } from '../_shared/lynx-fullscreen-hint.ts'
+import { createVyuiAliases } from '../_shared/vyui-aliases.ts'
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url))
+
+export default defineConfig({
+  environments: {
+    web: {},
+    lynx: {},
+  },
+  source: {
+    entry: {
+      main: './src/index.ts',
+    },
+  },
+  resolve: {
+    alias: {
+      ...createVyuiAliases(__dirname),
+    },
+  },
+  tools: {
+    rspack: {
+      resolve: {
+        modules: [
+          resolve(__dirname, 'node_modules'),
+          'node_modules',
+        ],
+      },
+    },
+  },
+  plugins: [
+    pluginVueLynx({
+      optionsApi: false,
+    }),
+    pluginTailwindCSS({
+      config: 'tailwind.config.ts',
+      exclude: [/[\\/]node_modules[\\/]/],
+    }),
+    createLynxFullscreenHintPlugin('vyai-demo:lynx-fullscreen-hint'),
+  ],
+})

--- a/apps/examples/vyai/package.json
+++ b/apps/examples/vyai/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@vyui/vyai-demo",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "rspeedy dev",
+    "build": "rspeedy build"
+  },
+  "dependencies": {
+    "@vyui/core": "workspace:*",
+    "@vyui/kit": "workspace:*",
+    "vue-lynx": "^0.4.0"
+  },
+  "devDependencies": {
+    "@iconify-json/icon-park-outline": "^1.2.0",
+    "@iconify-json/icon-park-solid": "^1.2.4",
+    "@iconify-json/lucide": "^1.2.108",
+    "@iconify-json/tabler": "^1.2.35",
+    "@lynx-js/rspeedy": "^0.13.5",
+    "@lynx-js/tailwind-preset": "^0.4.0",
+    "@lynx-js/types": "^3.8.0",
+    "@rsbuild/plugin-vue": "^1.2.6",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.49",
+    "rsbuild-plugin-tailwindcss": "^0.2.4",
+    "tailwindcss": "^3.4.17",
+    "typescript": "^5.0.0",
+    "vue": "3.5.17"
+  }
+}

--- a/apps/examples/vyai/postcss.config.js
+++ b/apps/examples/vyai/postcss.config.js
@@ -1,0 +1,5 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+  },
+}

--- a/apps/examples/vyai/src/App.vue
+++ b/apps/examples/vyai/src/App.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { OverlayRoot } from '@vyui/core'
+import ChatThread from './sections/ChatThread.vue'
+import TopBar from './sections/TopBar.vue'
+import Composer from './sections/Composer.vue'
+import ConversationsDrawer from './components/ConversationsDrawer.vue'
+import { useDrawer } from './composables/useDrawer'
+
+const { open: drawerOpen, close: closeDrawer } = useDrawer()
+</script>
+
+<template>
+  <!-- Root clips the shell's off-screen overhang when it slides right. -->
+  <view class="w-full h-full bg-white relative overflow-hidden">
+    <!-- Under-sheet menu, parked behind the shell on the left. -->
+    <ConversationsDrawer />
+
+    <!-- The whole app rides in an opaque shell that slides right to reveal the
+         under-sheet. OverlayRoot stays the first child inside so portalled
+         surfaces (island panels) render above the thread; the composer sits
+         below the thread in flow so its keyboard spacer can push it up. -->
+    <view class="vyai-shell flex flex-col" :class="drawerOpen ? 'vyai-shell--open' : ''">
+      <OverlayRoot />
+
+      <ChatThread class="w-full flex-1 min-h-0" />
+
+      <TopBar />
+      <Composer />
+
+      <!-- Tap-to-close catch layer. Only mounted while the drawer is open, so
+           it can't swallow taps when closed. Covers the slid-over shell (the
+           visible app area on the right) — tapping it slides everything back.
+           z-40 keeps it under the fixed top pills (z-50) so the burger still
+           toggles. -->
+      <view
+        v-if="drawerOpen"
+        class="absolute inset-0 z-40"
+        @tap="closeDrawer"
+      />
+    </view>
+  </view>
+</template>

--- a/apps/examples/vyai/src/components/ChatBubble.vue
+++ b/apps/examples/vyai/src/components/ChatBubble.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { VyIcon } from '@vyui/kit'
+import type { ChatTurn } from '../composables/useChat'
+import VyMark from './VyMark.vue'
+
+const props = defineProps<{ turn: ChatTurn }>()
+
+// Lynx <text> does not reflow on raw \n, so split into lines and render each
+// as its own <text>. Blank lines (paragraph gaps) become small spacers.
+const lines = computed(() => (props.turn.text ?? '').split('\n'))
+const isUser = computed(() => props.turn.role === 'user')
+const isThinking = computed(() => props.turn.state === 'thinking')
+const isStreaming = computed(() => props.turn.state === 'streaming')
+
+// Reasoning trace, split into discrete steps. Models emit it as prose with
+// newlines (often numbered) — one bullet per non-empty line reads as a step
+// list. Empty when the model isn't reasoning.
+const steps = computed(() =>
+  (props.turn.thinking ?? '')
+    .split('\n')
+    .map(l => l.trim())
+    .filter(Boolean),
+)
+const hasReasoning = computed(() => steps.value.length > 0)
+// Live one-liner while thinking: the latest step, so it reads like a status
+// ticking through "checking language… weighing options…". Falls back to the
+// cheeky placeholder copy before any reasoning has streamed in.
+const status = computed(() => (hasReasoning.value ? steps.value[steps.value.length - 1] : (props.turn.text ?? '')))
+
+// Expanded trace. Auto-open while actively reasoning so the steps stream into
+// view; user can collapse/expand once the answer lands.
+const open = ref(false)
+const showTrace = computed(() => (isThinking.value ? true : open.value))
+
+// While reasoning streams, cap the rendered trace to the most recent steps —
+// a long chain-of-thought can run to hundreds of lines, and re-rendering all
+// of them every token janks the thread to a standstill. The full trace is
+// available once it's done and the user expands it.
+const MAX_LIVE_STEPS = 6
+const visibleSteps = computed(() =>
+  isThinking.value ? steps.value.slice(-MAX_LIVE_STEPS) : steps.value,
+)
+</script>
+
+<template>
+  <!-- Assistant "thinking" — shimmering status line beside the logo dot, with
+       the live reasoning trace streaming in below when available. -->
+  <view v-if="isThinking" class="flex flex-col gap-2 px-1">
+    <view class="flex flex-row items-center gap-3">
+      <VyMark :size="28" class="vyai-breathe" />
+      <text class="flex-1 text-slate-400 text-sm italic vyai-breathe">{{ status }}</text>
+    </view>
+    <view v-if="hasReasoning && showTrace" class="ml-10 pl-3 border-l-2 border-slate-100 flex flex-col gap-1.5">
+      <view v-for="(s, i) in visibleSteps" :key="i" class="flex flex-row gap-2">
+        <text class="text-slate-300 text-[13px] leading-5">•</text>
+        <text class="flex-1 text-slate-400 text-[13px] leading-5">{{ s }}</text>
+      </view>
+    </view>
+  </view>
+
+  <!-- User turn — compact gray bubble, right aligned. -->
+  <view v-else-if="isUser" class="flex flex-row justify-end px-1">
+    <view class="bg-slate-100 rounded-3xl px-4 py-2.5 max-w-[80%]">
+      <text class="text-slate-900 text-[15px] leading-6">{{ turn.text }}</text>
+    </view>
+  </view>
+
+  <!-- Assistant answer — full width, no bubble (ChatGPT style), logo leading. -->
+  <view v-else class="flex flex-row gap-3 px-1">
+    <VyMark :size="28" />
+    <view class="flex-1 flex flex-col pt-0.5">
+      <!-- Collapsed "thought process" disclosure, kept after reasoning turns. -->
+      <view v-if="hasReasoning" class="mb-2 flex flex-col gap-1.5">
+        <view class="flex flex-row items-center gap-1.5 self-start" @tap="open = !open">
+          <VyIcon name="i-tabler-bulb" :size="14" color="#94a3b8" />
+          <text class="text-slate-400 text-[13px] font-medium">Thought process</text>
+          <VyIcon :name="open ? 'i-tabler-chevron-up' : 'i-tabler-chevron-down'" :size="14" color="#94a3b8" />
+        </view>
+        <view v-if="showTrace" class="pl-3 border-l-2 border-slate-100 flex flex-col gap-1.5">
+          <view v-for="(s, i) in visibleSteps" :key="i" class="flex flex-row gap-2">
+            <text class="text-slate-300 text-[13px] leading-5">•</text>
+            <text class="flex-1 text-slate-400 text-[13px] leading-5">{{ s }}</text>
+          </view>
+        </view>
+      </view>
+
+      <view v-for="(line, i) in lines" :key="i">
+        <view v-if="line === ''" class="h-2" />
+        <text v-else class="text-slate-900 text-[15px] leading-6">{{ line }}</text>
+      </view>
+      <!-- Blinking caret while streaming. -->
+      <view v-if="isStreaming" class="h-1 w-2 mt-1 rounded-full bg-slate-900 vyai-breathe" />
+    </view>
+  </view>
+</template>

--- a/apps/examples/vyai/src/components/ComposerActions.vue
+++ b/apps/examples/vyai/src/components/ComposerActions.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { VyIcon } from '@vyui/kit'
+
+// The trailing action button of the composer row. It's a pure function of two
+// flags — responding? has text? — and emits the matching intent. Keeping the
+// state out here lets the composer own the chat lifecycle.
+defineProps<{
+  isResponding: boolean
+  hasText: boolean
+}>()
+
+defineEmits<{
+  send: []
+  stop: []
+  voice: []
+}>()
+</script>
+
+<template>
+  <!-- Responding → stop. Has text → send. Otherwise → voice. The active
+       buttons sit on Ash Border with an ink-dark glyph (the Lynx <svg> bakes
+       its color from the `color` prop, not CSS). -->
+  <view
+    v-if="isResponding"
+    class="size-9 rounded-full bg-ash-border flex items-center justify-center"
+    @tap="$emit('stop')"
+  >
+    <view class="size-3 rounded-[3px] bg-[#1c1917]" />
+  </view>
+  <view
+    v-else-if="hasText"
+    class="size-9 rounded-full bg-ash-border flex items-center justify-center"
+    @tap="$emit('send')"
+  >
+    <VyIcon name="i-tabler-arrow-up" :size="22" color="#1c1917" />
+  </view>
+  <view
+    v-else
+    class="size-9 rounded-full bg-slate-100 flex items-center justify-center"
+    @tap="$emit('voice')"
+  >
+    <VyIcon name="i-tabler-microphone" :size="20" color="#334155" />
+  </view>
+</template>

--- a/apps/examples/vyai/src/components/ConversationsDrawer.vue
+++ b/apps/examples/vyai/src/components/ConversationsDrawer.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import { VyIcon } from '@vyui/kit'
+import { useChat } from '../composables/useChat'
+import { useDrawer } from '../composables/useDrawer'
+import VyMark from './VyMark.vue'
+
+const { conversations, activeConversationId, newChat, openConversation } = useChat()
+const { close } = useDrawer()
+
+function startNewChat() {
+  newChat()
+  close()
+}
+
+function pick(id: number) {
+  openConversation(id)
+  close()
+}
+</script>
+
+<template>
+  <!-- Under-sheet: pinned to the left and sitting BEHIND the main shell (see
+       App.vue). It's permanently mounted but hidden — the opaque shell covers
+       it until the burger slides the shell to the right to reveal it. Because
+       it never floats above the shell, it can't intercept taps while closed
+       (the bug the old overlay drawer had). -->
+  <view class="vyai-undersheet flex flex-col">
+    <!-- Header -->
+    <view class="flex flex-row items-center gap-2.5 px-4 pt-[91px] pb-3">
+      <VyMark :size="26" variant="square" />
+      <text class="flex-1 text-slate-900 text-lg font-semibold">vyai</text>
+      <view
+        class="size-9 rounded-full flex items-center justify-center active:bg-slate-200"
+        @tap="close"
+      >
+        <VyIcon name="i-tabler-x" :size="20" color="#334155" />
+      </view>
+    </view>
+
+    <!-- New chat -->
+    <view class="px-3 pb-2">
+      <view
+        class="flex flex-row items-center gap-2.5 px-3 py-2.5 rounded-xl active:bg-slate-200"
+        @tap="startNewChat"
+      >
+        <VyIcon name="i-tabler-edit" :size="20" color="#334155" />
+        <text class="text-slate-900 text-[15px] font-medium">New chat</text>
+      </view>
+    </view>
+
+    <view class="h-px bg-slate-200 mx-3" />
+
+    <!-- History -->
+    <scroll-view class="flex-1 min-h-0" scroll-orientation="vertical">
+      <view class="flex flex-col px-3 py-2">
+        <text class="text-slate-400 text-xs font-medium px-3 pb-1">Recent</text>
+        <view
+          v-for="c in conversations"
+          :key="c.id"
+          class="flex flex-row items-center gap-2.5 px-3 py-2.5 rounded-xl active:bg-slate-200"
+          :class="c.id === activeConversationId ? 'bg-slate-200' : ''"
+          @tap="pick(c.id)"
+        >
+          <VyIcon name="i-tabler-message" :size="18" color="#64748b" />
+          <text class="flex-1 text-slate-700 text-sm truncate">{{ c.title }}</text>
+        </view>
+      </view>
+    </scroll-view>
+  </view>
+</template>

--- a/apps/examples/vyai/src/components/EmptyState.vue
+++ b/apps/examples/vyai/src/components/EmptyState.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { VyIcon } from '@vyui/kit'
+import type { Suggestion } from '../data/chat'
+import VyMark from './VyMark.vue'
+
+// Pure presentational: the greeting + prompt-chip grid for a fresh thread.
+// State stays in the parent — this just renders props and reports taps.
+defineProps<{
+  modelName: string
+  suggestions: Suggestion[]
+}>()
+
+const emit = defineEmits<{
+  /** A chip was tapped — carries the prompt to send. */
+  pick: [prompt: string]
+}>()
+</script>
+
+<template>
+  <view class="flex flex-col items-center justify-center pt-24 gap-6">
+    <VyMark :size="64" variant="square" />
+    <view class="flex flex-col items-center gap-1">
+      <text class="text-slate-900 text-2xl font-semibold">What can I help with?</text>
+      <text class="text-slate-400 text-sm">{{ modelName }} · a vyui demo</text>
+    </view>
+
+    <view class="flex flex-row flex-wrap justify-center gap-2 pt-2">
+      <view
+        v-for="s in suggestions"
+        :key="s.label"
+        class="flex flex-row items-center gap-2 px-4 py-2.5 rounded-2xl border border-ash-border bg-white active:bg-slate-50"
+        @tap="emit('pick', s.prompt)"
+      >
+        <VyIcon :name="s.icon" :size="18" color="#64748b" />
+        <text class="text-slate-700 text-sm">{{ s.label }}</text>
+      </view>
+    </view>
+  </view>
+</template>

--- a/apps/examples/vyai/src/components/MessageList.vue
+++ b/apps/examples/vyai/src/components/MessageList.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import type { ChatTurn } from '../composables/useChat'
+import ChatBubble from './ChatBubble.vue'
+
+// Renders the conversation. Stateless — the thread is owned upstream and
+// passed straight through to one <ChatBubble> per turn.
+defineProps<{
+  messages: ChatTurn[]
+}>()
+</script>
+
+<template>
+  <view class="flex flex-col gap-5">
+    <ChatBubble
+      v-for="turn in messages"
+      :key="turn.id"
+      :turn="turn"
+    />
+  </view>
+</template>

--- a/apps/examples/vyai/src/components/ModelMenu.vue
+++ b/apps/examples/vyai/src/components/ModelMenu.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { VyIcon } from '@vyui/kit'
+import type { Model } from '../data/chat'
+
+// The model-picker list shown in the composer's island panel. Takes the list
+// + current selection as props; reports the chosen id via `select`. The parent
+// owns the model state and what "selecting" does (set + close the panel).
+defineProps<{
+  models: Model[]
+  selectedId: string
+}>()
+
+const emit = defineEmits<{
+  select: [id: string]
+}>()
+</script>
+
+<template>
+  <view class="flex flex-col gap-1 min-w-[15rem] py-1">
+    <text class="text-slate-400 text-xs font-medium px-3 pb-1">Choose a model</text>
+    <view
+      v-for="m in models"
+      :key="m.id"
+      class="flex flex-row items-center gap-3 px-3 py-2.5 rounded-xl active:bg-slate-100"
+      @tap="emit('select', m.id)"
+    >
+      <VyIcon :name="m.icon" :size="20" color="#334155" />
+      <view class="flex-1 flex flex-col">
+        <text class="text-slate-900 text-sm font-medium">{{ m.name }}</text>
+        <text class="text-slate-400 text-xs">{{ m.blurb }}</text>
+      </view>
+      <VyIcon
+        v-if="m.id === selectedId"
+        name="i-tabler-check"
+        :size="18"
+        color="#3b82f6"
+      />
+    </view>
+  </view>
+</template>

--- a/apps/examples/vyai/src/components/ModelPill.vue
+++ b/apps/examples/vyai/src/components/ModelPill.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { VyIcon, VySwitch } from '@vyui/kit'
+import type { Model } from '../data/chat'
+import VyMark from './VyMark.vue'
+
+// The little model-selector pill parked under the composer input. Reports taps
+// via `tap`; the chevron flips when the picker is open. Sits on the same
+// sunken surface as the sidebar so they read as one tone.
+//
+// When the selected model supports reasoning (`canThink`), a compact "Think"
+// toggle rides on the right of the same row — out of the model menu, where it
+// only matters for local models.
+defineProps<{
+  model: Model
+  open: boolean
+  canThink?: boolean
+  thinking?: boolean
+}>()
+
+defineEmits<{
+  tap: []
+  'toggle-think': [on: boolean]
+}>()
+</script>
+
+<template>
+  <view class="flex flex-row items-center w-full pl-1.5 gap-2">
+    <view
+      class="flex flex-row items-center gap-1.5 pl-1.5 pr-2.5 py-1 rounded-full bg-parchment-sunken active:bg-ash-border"
+      @tap="$emit('tap')"
+    >
+      <VyMark :size="18" variant="square" />
+      <text class="text-slate-700 text-[13px] font-medium">{{ model.name }}</text>
+      <VyIcon
+        :name="open ? 'i-tabler-chevron-down' : 'i-tabler-chevron-up'"
+        :size="14"
+        color="#94a3b8"
+      />
+    </view>
+
+    <view class="flex-1" />
+
+    <!-- Reasoning switch — basic on/off, "Thinking" label alongside. Only for
+         models that support it. -->
+    <view v-if="canThink" class="flex flex-row items-center gap-2 pr-1">
+      <text class="text-slate-600 text-[13px] font-medium">Thinking</text>
+      <VySwitch
+        :model-value="thinking"
+        size="sm"
+        :ui="{ base: thinking ? 'bg-black' : '' }"
+        @update:model-value="$emit('toggle-think', $event)"
+      />
+    </view>
+  </view>
+</template>

--- a/apps/examples/vyai/src/components/ToolsTray.vue
+++ b/apps/examples/vyai/src/components/ToolsTray.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { VyIcon } from '@vyui/kit'
+import type { Tool } from '../data/chat'
+
+// The "+" quick-tools tray shown in the composer's island panel. Tools are
+// passed in; taps bubble up by label. Voice mode is its own affordance so it
+// gets a dedicated `voice` emit rather than masquerading as a tool.
+defineProps<{
+  tools: Tool[]
+}>()
+
+const emit = defineEmits<{
+  select: [label: string]
+  voice: []
+}>()
+</script>
+
+<template>
+  <view class="flex flex-col gap-1 min-w-[14rem] py-1">
+    <view
+      v-for="t in tools"
+      :key="t.label"
+      class="flex flex-row items-center gap-3 px-3 py-2.5 rounded-xl active:bg-slate-100"
+      @tap="emit('select', t.label)"
+    >
+      <VyIcon :name="t.icon" :size="22" color="#334155" />
+      <text class="text-slate-900 text-sm font-medium">{{ t.label }}</text>
+    </view>
+    <view
+      class="flex flex-row items-center gap-3 px-3 py-2.5 rounded-xl active:bg-slate-100"
+      @tap="emit('voice')"
+    >
+      <VyIcon name="i-tabler-microphone" :size="22" color="#334155" />
+      <text class="text-slate-900 text-sm font-medium">Voice mode</text>
+    </view>
+  </view>
+</template>

--- a/apps/examples/vyai/src/components/VyMark.vue
+++ b/apps/examples/vyai/src/components/VyMark.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+// The "Vy" wordmark — same glyph as the repo favicon
+// (apps/docs/public/favicon.svg): bold "Vy" on a dark tile. Used as the
+// assistant avatar + app logo throughout the demo. Rendered as text rather
+// than the SVG so it scales crisply and needs no asset import.
+const props = withDefaults(defineProps<{
+  /** Tile edge length in px. */
+  size?: number
+  /** `circle` for avatars, `square` (rounded tile) for app-logo spots. */
+  variant?: 'circle' | 'square'
+  class?: any
+}>(), {
+  size: 28,
+  variant: 'circle',
+})
+
+const radius = computed(() => props.variant === 'circle' ? '9999px' : `${Math.round(props.size * 0.28)}px`)
+const fontSize = computed(() => `${Math.round(props.size * 0.5)}px`)
+</script>
+
+<template>
+  <view
+    :class="['bg-black flex items-center justify-center shrink-0', props.class]"
+    :style="{ width: `${size}px`, height: `${size}px`, borderRadius: radius }"
+  >
+    <text
+      class="text-white font-bold"
+      :style="{ fontSize, lineHeight: fontSize, letterSpacing: '-0.5px' }"
+    >Vy</text>
+  </view>
+</template>

--- a/apps/examples/vyai/src/composables/useChat.ts
+++ b/apps/examples/vyai/src/composables/useChat.ts
@@ -1,0 +1,299 @@
+import { computed, ref } from 'vue'
+import { DEFAULT_MODEL_ID, MODELS, replyFor, sampleThinking } from '../data/chat'
+import { ollamaChat, OllamaAbortError, type OllamaMessage } from './useOllama'
+
+export type ChatRole = 'user' | 'assistant'
+
+/**
+ * `thinking` renders a single shimmering status line (no bubble) while the
+ * turn cycles through cheeky placeholder phrases. `streaming` appends the
+ * reply word-by-word into the bubble for the live-typing beat. `done` is the
+ * resting state.
+ */
+export type ChatState = 'thinking' | 'streaming' | 'done'
+
+export interface ChatTurn {
+  id: number
+  role: ChatRole
+  text: string
+  state: ChatState
+  /**
+   * Live reasoning trace for thinking-enabled Ollama turns. Accumulates while
+   * the model reasons (state `thinking`) and is kept afterwards so the answer
+   * can show an expandable "thought process". Undefined for normal turns.
+   */
+  thinking?: string
+}
+
+/** A past conversation listed in the left drawer. */
+export interface Conversation {
+  id: number
+  title: string
+  /** Snapshot of the thread, replayed verbatim when reopened. */
+  messages: ChatTurn[]
+}
+
+const PHRASE_INTERVAL_MS = 420
+const WORD_INTERVAL_MS = 38
+
+// Module-level singleton so every section (thread, composer, top bar) reads
+// and writes the SAME conversation without prop-drilling through App.
+let uid = 0
+const messages = ref<ChatTurn[]>([])
+const modelId = ref<string>(DEFAULT_MODEL_ID)
+// User-facing toggle for reasoning models (Ollama only). Off by default: fast,
+// direct replies. On: the model reasons first (slower) — see useOllama.
+const thinking = ref(false)
+
+// Drawer history. Seeded with a few canned threads so the menu looks lived-in
+// on first launch; real conversations get archived in front of these on
+// `newChat` / `openConversation`. No persistence — it's a demo, resets on
+// reload. Seed messages are all `done` so reopening one renders instantly.
+function turn(role: ChatRole, text: string): ChatTurn {
+  return { id: uid++, role, text, state: 'done' }
+}
+
+const conversations = ref<Conversation[]>([
+  {
+    id: uid++,
+    title: 'Haiku about UI components',
+    messages: [
+      turn('user', 'Write a haiku about building UI components.'),
+      turn('assistant', 'Slots align like glass —\na worklet hums on the thread,\nthe island unfolds.'),
+    ],
+  },
+  {
+    id: uid++,
+    title: 'Names for an AI demo',
+    messages: [
+      turn('user', 'Give me three names for a tongue-in-cheek AI demo app.'),
+      turn('assistant', 'Here are three: vyai, Orbit, and Hush.'),
+    ],
+  },
+  {
+    id: uid++,
+    title: 'Two-hour vue-lynx plan',
+    messages: [
+      turn('user', 'Plan a focused two-hour session to learn vue-lynx.'),
+      turn('assistant', 'Start by skimming the docs and running one example end to end…'),
+    ],
+  },
+  {
+    id: uid++,
+    title: 'What is a main-thread worklet',
+    messages: [
+      turn('user', 'Explain what a Lynx main-thread worklet is and why it matters.'),
+      turn('assistant', 'A main-thread worklet is a small function that Lynx runs on the UI thread…'),
+    ],
+  },
+])
+// The thread currently on screen, if it came from history — lets us update its
+// snapshot in place instead of forking a duplicate when archived again.
+const activeConversationId = ref<number | null>(null)
+// True from the moment a prompt is sent until the reply finishes streaming —
+// drives the composer's send→stop swap and disables double-sends.
+const isResponding = ref(false)
+
+// In-flight Ollama request (so `stop` can cancel it) and the thinking-phrase
+// rotator (so we can stop cycling once the reply lands or the user bails).
+let abortController: AbortController | null = null
+let thinkingTimer: ReturnType<typeof setInterval> | null = null
+
+function clearThinking() {
+  if (thinkingTimer) {
+    clearInterval(thinkingTimer)
+    thinkingTimer = null
+  }
+}
+
+const activeModel = computed(() => MODELS.find(m => m.id === modelId.value) ?? MODELS[1])
+const isEmpty = computed(() => messages.value.length === 0)
+
+function setModel(id: string) {
+  modelId.value = id
+}
+
+function setThinking(on: boolean) {
+  thinking.value = on
+}
+
+// Derive a drawer title from the first user line, trimmed to a tidy length.
+function titleFor(turns: ChatTurn[]): string {
+  const first = turns.find(t => t.role === 'user')?.text?.trim()
+  if (!first) return 'New chat'
+  return first.length > 40 ? `${first.slice(0, 40)}…` : first
+}
+
+// Fold the on-screen thread back into the drawer list (front of stack) so it
+// survives a New Chat / switch. Reuses the slot if this thread was opened from
+// history; otherwise prepends a fresh entry. No-ops on an empty thread.
+function archiveCurrent() {
+  if (messages.value.length === 0) return
+  const snapshot = messages.value.map(t => ({ ...t }))
+  const existing = conversations.value.find(c => c.id === activeConversationId.value)
+  if (existing) {
+    existing.title = titleFor(snapshot)
+    existing.messages = snapshot
+    // Bubble it to the top — most-recent-first ordering.
+    conversations.value = [existing, ...conversations.value.filter(c => c !== existing)]
+  }
+  else {
+    conversations.value = [
+      { id: uid++, title: titleFor(snapshot), messages: snapshot },
+      ...conversations.value,
+    ]
+  }
+}
+
+function newChat() {
+  stop()
+  archiveCurrent()
+  messages.value = []
+  activeConversationId.value = null
+  isResponding.value = false
+}
+
+// Open a past thread from the drawer: park the current one, then replay the
+// selected snapshot. Cloning keeps the live thread from mutating the archive.
+function openConversation(id: number) {
+  const conv = conversations.value.find(c => c.id === id)
+  if (!conv) return
+  if (conv.id === activeConversationId.value) return
+  stop()
+  archiveCurrent()
+  messages.value = conv.messages.map(t => ({ ...t }))
+  activeConversationId.value = conv.id
+  isResponding.value = false
+}
+
+// Halt the in-flight turn. The scheduled timeouts bail once `isResponding` is
+// false (thinking-phase guard) or the turn leaves the `streaming` state (the
+// word-tick guard), so flipping both here is enough to stop cleanly.
+function stop() {
+  if (!isResponding.value) return
+  isResponding.value = false
+  abortController?.abort()
+  abortController = null
+  clearThinking()
+  const last = messages.value[messages.value.length - 1]
+  if (last && last.role === 'assistant' && last.state !== 'done') {
+    if (last.state === 'thinking') last.text = 'Stopped.'
+    last.state = 'done'
+  }
+}
+
+// Cycle the cheeky thinking copy until the reply lands. Mutations go through
+// `messages.value[idx]` so they hit Vue's reactive proxy (mutating a captured
+// object ref skips it). Indefinite (loops the phrases) because a real model can
+// take longer than the canned list; the caller clears it via `clearThinking`.
+function startThinking(idx: number, phrases: string[]) {
+  let i = 0
+  thinkingTimer = setInterval(() => {
+    const t = messages.value[idx]
+    if (!t || t.state !== 'thinking') return clearThinking()
+    i = (i + 1) % phrases.length
+    t.text = phrases[i]
+  }, PHRASE_INTERVAL_MS)
+}
+
+// Type the finished reply into the bubble word-by-word for the live feel.
+function streamReply(idx: number, reply: string) {
+  const t = messages.value[idx]
+  if (!t || !isResponding.value) return
+  t.text = ''
+  t.state = 'streaming'
+
+  const words = (reply ?? '').split(/(\s+)/) // keep whitespace tokens so spacing survives
+  let w = 0
+  const tick = () => {
+    const cur = messages.value[idx]
+    if (!cur || cur.state !== 'streaming') return
+    cur.text += words[w]
+    w++
+    if (w < words.length) {
+      setTimeout(tick, WORD_INTERVAL_MS)
+    }
+    else {
+      cur.state = 'done'
+      isResponding.value = false
+    }
+  }
+  tick()
+}
+
+function send(raw: string) {
+  const text = raw.trim()
+  if (!text || isResponding.value) return
+
+  messages.value.push({ id: uid++, role: 'user', text, state: 'done' })
+
+  // Snapshot the conversation for a real model before we add the placeholder.
+  const history: OllamaMessage[] = messages.value
+    .filter(t => t.state === 'done')
+    .map(t => ({ role: t.role, content: t.text }))
+
+  const phrases = sampleThinking(4)
+  const idx = messages.value.length
+  messages.value.push({ id: uid++, role: 'assistant', text: phrases[0], state: 'thinking' })
+  isResponding.value = true
+  startThinking(idx, phrases)
+
+  const ollamaModel = activeModel.value.ollamaModel
+  if (ollamaModel) {
+    // Real local model. The cheeky phrase rotator spins until the reply lands
+    // (Lynx's native fetch can't stream, so the whole reply arrives at once),
+    // then we animate it word-by-word for the live feel. Any reasoning trace is
+    // kept on the turn and shown via the collapsible "thought process".
+    abortController = new AbortController()
+    ollamaChat({ model: ollamaModel, messages: history, think: thinking.value, signal: abortController.signal })
+      .then(({ content, thinking: trace }) => {
+        clearThinking()
+        if (!isResponding.value) return // stopped mid-flight
+        const t = messages.value[idx]
+        if (!t) return
+        if (trace) t.thinking = trace
+        streamReply(idx, content || '(no response — is the model loaded?)')
+      })
+      .catch((err: unknown) => {
+        clearThinking()
+        if (err instanceof OllamaAbortError || !isResponding.value) return
+        const t = messages.value[idx]
+        if (t) {
+          t.text = err instanceof Error ? err.message : 'Something went wrong talking to Ollama.'
+          t.thinking = undefined
+          t.state = 'done'
+        }
+        isResponding.value = false
+      })
+      .finally(() => {
+        abortController = null
+      })
+    return
+  }
+
+  // Mock tiers: fake a think delay, then stream a canned reply.
+  const reply = replyFor(text)
+  setTimeout(() => {
+    clearThinking()
+    streamReply(idx, reply)
+  }, phrases.length * PHRASE_INTERVAL_MS)
+}
+
+export function useChat() {
+  return {
+    messages,
+    modelId,
+    activeModel,
+    thinking,
+    isResponding,
+    isEmpty,
+    conversations,
+    activeConversationId,
+    setModel,
+    setThinking,
+    newChat,
+    openConversation,
+    send,
+    stop,
+  }
+}

--- a/apps/examples/vyai/src/composables/useDrawer.ts
+++ b/apps/examples/vyai/src/composables/useDrawer.ts
@@ -1,0 +1,14 @@
+import { ref } from 'vue'
+
+// Module-level singleton so the burger (TopBar), the under-sheet panel
+// (ConversationsDrawer) and the sliding shell (App) all read/write the same
+// open flag without prop-drilling. Mirrors the useChat pattern.
+const open = ref(false)
+
+export function useDrawer() {
+  return {
+    open,
+    toggle: () => { open.value = !open.value },
+    close: () => { open.value = false },
+  }
+}

--- a/apps/examples/vyai/src/composables/useOllama.ts
+++ b/apps/examples/vyai/src/composables/useOllama.ts
@@ -1,0 +1,147 @@
+// Tiny client for a locally-running Ollama server (https://ollama.com).
+//
+// It hits the /api/chat endpoint with streaming OFF, so the whole reply comes
+// back in one JSON response — the demo then reuses its own word-by-word typing
+// animation to make it feel live (see useChat.ts). Keeping it non-streaming
+// means no ReadableStream parsing, which is the brittle part across the web and
+// Lynx runtimes.
+//
+// To hand this to someone else: the only thing to configure is the base URL.
+//   • Web build on the same machine as Ollama → the default just works.
+//   • Phone / simulator → localhost is the *device*, not your laptop. Set the
+//     URL to your machine's LAN IP (e.g. http://192.168.1.20:11434) and start
+//     the server with `OLLAMA_HOST=0.0.0.0 ollama serve` so it accepts remote
+//     connections. You can also override via a VITE_OLLAMA_URL env var.
+
+const ENV_URL
+  = typeof import.meta !== 'undefined'
+    ? (import.meta as { env?: Record<string, string | undefined> }).env?.VITE_OLLAMA_URL
+    : undefined
+
+export const OLLAMA_BASE_URL = ENV_URL ?? 'http://localhost:11434'
+
+// Bubbles render as raw Lynx <text> — no markdown, no emoji glyphs — so steer
+// the model to plain prose. Override per call via OllamaChatOptions.system.
+export const OLLAMA_SYSTEM
+  = 'You are a concise, helpful assistant inside a mobile chat app. '
+    + 'Reply in plain text only: no markdown, no headings, no bullet syntax '
+    + '(*, -, #, backticks) and no emoji. Use short paragraphs separated by '
+    + 'blank lines. Keep answers brief unless asked for detail.'
+
+export interface OllamaMessage {
+  role: 'system' | 'user' | 'assistant'
+  content: string
+}
+
+export interface OllamaChatOptions {
+  /** Ollama model name, e.g. `qwen3.5:9b`. */
+  model: string
+  /** Full conversation so far, oldest first. */
+  messages: OllamaMessage[]
+  /** Override the server URL for this call. */
+  baseUrl?: string
+  /** System prompt prepended to the conversation. Defaults to {@link OLLAMA_SYSTEM}; pass null to omit. */
+  system?: string | null
+  /**
+   * Reasoning models (e.g. qwen3.5) otherwise burn the whole token budget in a
+   * hidden `thinking` field and never emit an answer. Off by default so replies
+   * are fast and land in `content`; set true if you want the model to reason.
+   */
+  think?: boolean
+  /** Abort signal so an in-flight turn can be stopped. */
+  signal?: AbortSignal
+}
+
+interface OllamaChatResponse {
+  message?: { role: string, content?: string, thinking?: string }
+  error?: string
+  done_reason?: string
+}
+
+/** A finished reply: the answer plus any reasoning trace (empty if none). */
+export interface OllamaChatResult {
+  content: string
+  thinking: string
+}
+
+/** Thrown when the user aborts a turn — callers should swallow this silently. */
+export class OllamaAbortError extends Error {}
+
+/**
+ * Send a chat completion to Ollama and resolve with the finished reply.
+ *
+ * Deliberately NON-streaming (`stream: false`): we ask for the whole reply in
+ * one JSON object and read it with `res.json()`. Lynx's native fetch has no
+ * readable body stream and its `res.text()` can resolve to undefined, so
+ * streaming/NDJSON parsing is unreliable on device — `res.json()` is the one
+ * body reader native runtimes implement consistently. Callers animate the
+ * returned text themselves for the live-typing feel.
+ *
+ * Throws a human-readable Error on failure (server down, model not pulled, …)
+ * and an {@link OllamaAbortError} if the request was aborted.
+ */
+export async function ollamaChat(opts: OllamaChatOptions): Promise<OllamaChatResult> {
+  const { model, messages, baseUrl = OLLAMA_BASE_URL, system = OLLAMA_SYSTEM, think = false, signal } = opts
+
+  if (typeof fetch !== 'function') {
+    throw new TypeError('fetch is unavailable in this runtime — run the web build to chat with Ollama.')
+  }
+
+  const payload: OllamaMessage[] = system
+    ? [{ role: 'system', content: system }, ...messages]
+    : messages
+
+  // With thinking ON, reasoning models need headroom or they fill the default
+  // 4k window with reasoning and never reach the answer (done_reason "length").
+  // With it OFF, no extra budget needed — the reply lands straight in content.
+  const body: Record<string, unknown> = { model, messages: payload, stream: false, think }
+  if (think) body.options = { num_ctx: 8192, num_predict: 2048 }
+
+  let res: Response
+  try {
+    res = await fetch(`${baseUrl}/api/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal,
+    })
+  }
+  catch (err) {
+    if ((err as Error)?.name === 'AbortError') throw new OllamaAbortError()
+    throw new Error(`Couldn't reach Ollama at ${baseUrl}. Is \`ollama serve\` running?`)
+  }
+
+  if (!res.ok) {
+    throw new Error(`Ollama returned ${res.status}. Is "${model}" pulled? Try \`ollama pull ${model}\`.`)
+  }
+
+  let data: OllamaChatResponse | undefined
+  try {
+    data = await res.json() as OllamaChatResponse
+  }
+  catch (err) {
+    if ((err as Error)?.name === 'AbortError') throw new OllamaAbortError()
+    throw new Error('Ollama sent a response this runtime could not read. Try the web build, or update LynxExplorer.')
+  }
+
+  if (data?.error) throw new Error(data.error)
+
+  const content = (data?.message?.content ?? '').trim()
+  const thinking = (data?.message?.thinking ?? '').trim()
+
+  // Reasoning ran past the budget before answering. Tell the user how to fix it
+  // rather than showing a blank bubble.
+  if (!content && thinking) {
+    throw new Error('The model ran out of room while reasoning. Turn Reasoning off for a faster, direct reply.')
+  }
+
+  return { content, thinking }
+}
+
+/** Convenience composable wrapper — returns the configured base URL + chat fn. */
+export function useOllama(baseUrl: string = OLLAMA_BASE_URL) {
+  return {
+    baseUrl,
+    chat: (opts: Omit<OllamaChatOptions, 'baseUrl'>) => ollamaChat({ ...opts, baseUrl }),
+  }
+}

--- a/apps/examples/vyai/src/data/chat.ts
+++ b/apps/examples/vyai/src/data/chat.ts
@@ -1,0 +1,143 @@
+// Mock "AI" backend for the vyai demo. Nothing here calls a real model — it's
+// a deterministic-ish canned-reply engine so the chat *feels* alive without a
+// network. The composer drives the staging (thinking → streaming → done); this
+// file just supplies the content.
+
+export interface Model {
+  id: string
+  /** Short display name shown in the top island + model picker. */
+  name: string
+  /** One-line capability blurb under the name in the picker. */
+  blurb: string
+  icon: string
+  /**
+   * When set, replies are streamed from a local Ollama server using this model
+   * name (e.g. `qwen3.5:9b`) instead of the canned mock engine below. See
+   * `composables/useOllama.ts`.
+   */
+  ollamaModel?: string
+}
+
+// Three tongue-in-cheek "vyui" tiers, aping the usual mini / standard / pro
+// model ladder, plus a real local model served by Ollama. `vyai` is the
+// default middle tier; pick "qwen3.5 (local)" to chat with your own machine.
+export const MODELS: Model[] = [
+  { id: 'vyai-mini', name: 'vyai mini', blurb: 'Fastest — great for quick taps', icon: 'i-tabler-bolt' },
+  { id: 'vyai', name: 'vyai', blurb: 'Smart, balanced, the daily driver', icon: 'i-tabler-sparkles' },
+  { id: 'vyai-max', name: 'vyai max', blurb: 'Deepest reasoning, slower replies', icon: 'i-tabler-brain' },
+  { id: 'ollama-qwen', name: 'qwen3.5 (local)', blurb: 'Runs on your machine via Ollama', icon: 'i-tabler-cpu', ollamaModel: 'qwen3.5:9b' },
+]
+
+export const DEFAULT_MODEL_ID = 'vyai'
+
+// Empty-state prompt chips. Tapping one drops its `prompt` into the composer
+// and sends it — the classic ChatGPT "Get started" grid.
+export interface Suggestion {
+  icon: string
+  label: string
+  prompt: string
+}
+
+/** Quick-tool entry in the composer's "+" tray. */
+export interface Tool {
+  icon: string
+  label: string
+}
+
+export const TOOLS: Tool[] = [
+  { icon: 'i-tabler-camera', label: 'Camera' },
+  { icon: 'i-tabler-photo', label: 'Photos' },
+  { icon: 'i-tabler-paperclip', label: 'Files' },
+  { icon: 'i-tabler-world-search', label: 'Search the web' },
+]
+
+export const SUGGESTIONS: Suggestion[] = [
+  { icon: 'i-tabler-code', label: 'Explain this code', prompt: 'Explain what a Lynx main-thread worklet is and why it matters.' },
+  { icon: 'i-tabler-bulb', label: 'Brainstorm', prompt: 'Give me three names for a tongue-in-cheek AI demo app.' },
+  { icon: 'i-tabler-pencil', label: 'Write a haiku', prompt: 'Write a haiku about building UI components.' },
+  { icon: 'i-tabler-map', label: 'Plan something', prompt: 'Plan a focused two-hour session to learn vue-lynx.' },
+]
+
+// Claude-Code-style status copy. The thinking turn cycles through a few of
+// these before the real reply streams in.
+export const THINKING_PHRASES: ReadonlyArray<string> = [
+  'Thinking…',
+  'Pondering…',
+  'Cogitating…',
+  'Consulting the orb…',
+  'Crunching tokens…',
+  'Aligning the vibes…',
+  'Untangling the prompt…',
+  'Channeling the muse…',
+  'Warming the GPUs…',
+  'Sharpening the pencil…',
+]
+
+export function sampleThinking(count: number): string[] {
+  const pool = [...THINKING_PHRASES]
+  const out: string[] = []
+  for (let i = 0; i < count && pool.length; i++) {
+    const idx = Math.floor(Math.random() * pool.length)
+    out.push(pool.splice(idx, 1)[0])
+  }
+  return out
+}
+
+// Keyword-matched canned replies. First matching rule wins; otherwise the
+// generic fallback. Replies are plain multi-paragraph strings (Lynx <text>
+// has no markdown) — split on \n\n at render time.
+interface Rule {
+  match: RegExp
+  reply: string
+}
+
+const RULES: Rule[] = [
+  {
+    match: /\bhaiku\b/i,
+    reply:
+      'Slots align like glass —\n'
+      + 'a worklet hums on the thread,\n'
+      + 'the island unfolds.',
+  },
+  {
+    match: /worklet|main.?thread/i,
+    reply:
+      'A main-thread worklet is a small function that Lynx runs on the UI thread instead of the background JS thread.\n\n'
+      + 'That matters for gestures and animation: reading touch positions and writing styles on the same frame avoids the round-trip lag you get when the work hops back to the JS thread.\n\n'
+      + 'The catch is they only see what gets bundled onto that thread — bare package imports can be skipped, so worklets sometimes have to live right next to where they are used.',
+  },
+  {
+    match: /\bname(s)?\b/i,
+    reply:
+      'Here are three, leaning into the tongue-in-cheek angle:\n\n'
+      + '1. vyai — you are already using it.\n'
+      + '2. Orbit — for the little floating island that follows you around.\n'
+      + '3. Hush — a quiet assistant that only speaks when spoken to.',
+  },
+  {
+    match: /plan|learn|study/i,
+    reply:
+      'Here is a tight two-hour block:\n\n'
+      + '0:00–0:20 — Skim the vue-lynx docs and run one example end to end.\n'
+      + '0:20–1:10 — Rebuild a single component from scratch; break it on purpose.\n'
+      + '1:10–1:45 — Wire a gesture or a worklet and watch it run on the simulator.\n'
+      + '1:45–2:00 — Write down the three things that surprised you.',
+  },
+  {
+    match: /\bhi\b|hello|hey|yo\b/i,
+    reply: 'Hey! I am vyai — a pretend assistant built entirely from vyui components. Ask me anything and I will improvise something convincing.',
+  },
+]
+
+const FALLBACKS: ReadonlyArray<string> = [
+  'Good question. In a shipped build this is where a real model would answer — for now I am a handful of vyui components doing an impression of one.\n\nTry a suggestion chip to see me play along.',
+  'I love the confidence of that prompt. I do not actually have a model behind me yet, but the typing animation is real and so is the island composer you used to send it.',
+  'Here is my honest answer: I am a demo. Everything you see — the streaming text, the morphing island, the keyboard lift — is vyui. The intelligence is, regrettably, still on the roadmap.',
+]
+
+export function replyFor(prompt: string): string {
+  for (const rule of RULES) {
+    if (rule.match.test(prompt)) return rule.reply
+  }
+  return FALLBACKS[Math.floor(Math.random() * FALLBACKS.length)]
+}

--- a/apps/examples/vyai/src/index.css
+++ b/apps/examples/vyai/src/index.css
@@ -1,0 +1,85 @@
+/*
+ * Tailwind entry. `@lynx-js/tailwind-preset` is utility-only for Lynx,
+ * so we only load `base` and `utilities`.
+ */
+@tailwind base;
+@tailwind utilities;
+
+/* @vyui/kit default theme tokens. */
+@import '@vyui/kit/style.css';
+
+/* `animate-spin` isn't in the Lynx tailwind preset, so define the keyframe
+   here (Lynx supports CSS transform keyframes). Used by the thinking dot. */
+@keyframes vyui-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.vyui-spin {
+  animation: vyui-spin 0.8s linear infinite;
+}
+
+/* Soft breathing pulse for the assistant's "listening" / streaming states.
+   Opacity-only so it composites on the main thread. */
+@keyframes vyai-breathe {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
+  }
+}
+
+.vyai-breathe {
+  animation: vyai-breathe 1.4s ease-in-out infinite;
+}
+
+/* Under-sheet conversation drawer. Rather than floating over the page (which
+   meant a full-screen backdrop swallowing taps), the menu is parked BEHIND the
+   app: `.vyai-undersheet` is pinned to the left at z-0, and `.vyai-shell`
+   (which holds the whole app, opaque) covers it. Tapping the burger slides the
+   shell right to reveal the sheet underneath. Lynx animates the transform via
+   the `transition` rule when the `--open` class toggles. */
+.vyai-undersheet {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 300px;
+  z-index: 0;
+  background-color: #f1f0ef; /* a touch darker than parchment — reads as the surface beneath */
+}
+
+.vyai-shell {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1;
+  background-color: #fdfcfc; /* Parchment White — opaque so the under-sheet stays hidden when closed */
+  transform: translateX(0);
+  transition: transform 300ms ease;
+}
+
+/* Floating-island lift. The kit's `bg-white/80` islands now sit parchment-on-
+   parchment, so they blend in. 1px hairlines / inset box-shadows vanish on
+   hi-DPI native (and inset shadows are unreliable in vue-lynx), so the
+   definition leans on a real, visible border — 2px ash — with just a whisper
+   of drop shadow to lift it. Applied to the island row surface via `:ui`. */
+.vyai-float {
+  border: 1.5px solid #ececec;
+  box-shadow: 0 2px 8px rgba(28, 25, 23, 0.06);
+}
+
+.vyai-shell--open {
+  /* Reveal exactly the under-sheet's width. */
+  transform: translateX(300px);
+  /* Soft edge where the shell now overhangs the revealed sheet. */
+  box-shadow: -8px 0 40px rgba(15, 23, 42, 0.18);
+}

--- a/apps/examples/vyai/src/index.ts
+++ b/apps/examples/vyai/src/index.ts
@@ -1,0 +1,29 @@
+// MT-worklet propagation: vue-lynx's `worklet-loader-mt` only walks RELATIVE
+// imports into the main-thread graph; bare specifiers like `@vyui/core` are
+// silently skipped, so the MT bundle never registers any of our worklets and
+// every touch crashes with `bind of undefined`. Drop a single side-effect
+// relative import here so the walker can descend through core.
+// @ts-expect-error — path resolves at build time via rspack; out of the
+// demo's TS project file list. See `packages/core/src/index.ts`.
+import '../../../../packages/core/src'
+
+import { installIntlPolyfill, registerIconSet } from '@vyui/core'
+import { createApp } from 'vue-lynx'
+import { VyUI } from '@vyui/kit'
+import iconParkOutline from '@iconify-json/icon-park-outline/icons.json'
+import iconParkSolid from '@iconify-json/icon-park-solid/icons.json'
+import lucide from '@iconify-json/lucide/icons.json'
+import tabler from '@iconify-json/tabler/icons.json'
+import App from './App.vue'
+import './index.css'
+
+installIntlPolyfill()
+
+registerIconSet('lucide', lucide)
+registerIconSet('icon-park-outline', iconParkOutline)
+registerIconSet('icon-park-solid', iconParkSolid)
+registerIconSet('tabler', tabler)
+
+const app = createApp(App)
+app.use(VyUI)
+app.mount()

--- a/apps/examples/vyai/src/lynx-env.d.ts
+++ b/apps/examples/vyai/src/lynx-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference path="../../_shared/vue-shim.d.ts" />
+import 'vue-lynx/types'
+
+export {}

--- a/apps/examples/vyai/src/rspeedy-env.d.ts
+++ b/apps/examples/vyai/src/rspeedy-env.d.ts
@@ -1,0 +1,13 @@
+/// <reference types="@lynx-js/rspeedy/client" />
+
+declare module '@lynx-js/types' {
+  interface GlobalProps {}
+}
+
+declare module '@iconify-json/*/icons.json' {
+  import type { IconifyJSON } from '@iconify/types'
+  const data: IconifyJSON
+  export default data
+}
+
+export {}

--- a/apps/examples/vyai/src/sections/ChatThread.vue
+++ b/apps/examples/vyai/src/sections/ChatThread.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import { SUGGESTIONS } from '../data/chat'
+import { useChat } from '../composables/useChat'
+import EmptyState from '../components/EmptyState.vue'
+import MessageList from '../components/MessageList.vue'
+
+const { messages, isEmpty, activeModel, send } = useChat()
+</script>
+
+<template>
+  <scroll-view class="w-full flex-1 min-h-0" scroll-orientation="vertical">
+    <!-- Top padding clears the fixed top island; bottom padding clears the
+         fixed composer so the last turn is never hidden behind it. -->
+    <view class="flex flex-col px-4 pt-24 pb-44">
+      <EmptyState
+        v-if="isEmpty"
+        :model-name="activeModel.name"
+        :suggestions="SUGGESTIONS"
+        @pick="send"
+      />
+      <MessageList v-else :messages="messages" />
+    </view>
+  </scroll-view>
+</template>

--- a/apps/examples/vyai/src/sections/Composer.vue
+++ b/apps/examples/vyai/src/sections/Composer.vue
@@ -1,0 +1,177 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { VyIcon, VyInput, VyIsland, VyIslandButton } from '@vyui/kit'
+import { MODELS, TOOLS } from '../data/chat'
+import { useChat } from '../composables/useChat'
+import ComposerActions from '../components/ComposerActions.vue'
+import ModelPill from '../components/ModelPill.vue'
+import ModelMenu from '../components/ModelMenu.vue'
+import ToolsTray from '../components/ToolsTray.vue'
+
+const { isResponding, modelId, activeModel, thinking, setModel, setThinking, send, stop } = useChat()
+
+const input = ref('')
+
+// Island row mode: 'default' = compose, 'voice' = the listening takeover.
+const mode = ref<string>('default')
+// Panel expansion + which content fills it. The "+" button and the model
+// pill share the single island panel, so `panel` tracks who opened it.
+const open = ref(false)
+const panel = ref<'tools' | 'models'>('tools')
+
+// Toggle the shared panel to a given content. Re-tapping the active opener
+// closes it; tapping the other opener swaps the content without closing.
+function togglePanel(which: 'tools' | 'models') {
+  if (open.value && panel.value === which) {
+    open.value = false
+    return
+  }
+  panel.value = which
+  open.value = true
+}
+
+function pickModel(id: string) {
+  setModel(id)
+  open.value = false
+}
+
+const hasText = computed(() => input.value.trim().length > 0)
+
+function onSend() {
+  if (!hasText.value || isResponding.value) return
+  send(input.value)
+  input.value = ''
+}
+
+// --- Keyboard lift -------------------------------------------------------
+// The composer sits in normal flow at the bottom of a flex column (see
+// App.vue). When the keyboard opens we grow a spacer BELOW the bar by the
+// keyboard height; the flex column then pushes the bar up by that much.
+//
+// Height comes from VyInput's normalized `@keyboard` event — the reliable
+// keyboard signal under vue-lynx (the global `keyboardstatuschanged` event is
+// not delivered to the runtime). See docs/upstream/vue-lynx-keyboard.md.
+const kbHeight = ref(0)
+
+function onKeyboard(info: { visible: boolean, height: number }) {
+  kbHeight.value = info?.visible ? info.height : 0
+}
+
+// Fake voice flow: morph the row to a listening pill, then "transcribe" a
+// canned prompt and send it after a beat. The X cancels early.
+const VOICE_PROMPT = 'What would a tongue-in-cheek AI assistant say about itself?'
+let voiceTimer: ReturnType<typeof setTimeout> | null = null
+
+function startVoice() {
+  open.value = false
+  mode.value = 'voice'
+  voiceTimer = setTimeout(() => {
+    if (mode.value !== 'voice') return
+    mode.value = 'default'
+    send(VOICE_PROMPT)
+  }, 2600)
+}
+
+function cancelVoice() {
+  if (voiceTimer) clearTimeout(voiceTimer)
+  voiceTimer = null
+  mode.value = 'default'
+}
+</script>
+
+<template>
+  <!-- Composer in normal flow at the bottom of App's flex column. The spacer
+       below grows to the keyboard height, pushing this bar up. -->
+  <view class="shrink-0">
+    <view class="px-3 pb-6 pt-2">
+      <!-- Float treatment rides the ROOT (not the row) so it wraps the whole
+           island as one continuous edge — including the panel when it pops out
+           in attached mode. `border-0` on the row drops the kit's own hairline
+           so there's no double edge inside the root border. -->
+      <VyIsland
+        layer="inline"
+        size="lg"
+        expand-style="attached"
+        v-model:open="open"
+        v-model:mode="mode"
+        :ui="{
+          root: 'w-full rounded-3xl vyai-float',
+          row: 'w-full flex-col items-stretch gap-2 rounded-3xl border-0',
+        }"
+      >
+        <!-- Compose row: [+ tools] [input] [send / stop / mic] -->
+        <view class="flex flex-row items-center gap-1.5 w-full">
+          <VyIslandButton icon="i-tabler-plus" @tap="togglePanel('tools')" />
+
+          <view class="flex-1">
+            <VyInput
+              v-model="input"
+              variant="none"
+              placeholder="Message vyai"
+              confirm-type="send"
+              class="w-full bg-transparent"
+              :ui="{ root: 'px-2 gap-1' }"
+              @confirm="onSend"
+              @keyboard="onKeyboard"
+            />
+          </view>
+
+          <ComposerActions
+            :is-responding="isResponding"
+            :has-text="hasText"
+            @send="onSend"
+            @stop="stop"
+            @voice="startVoice"
+          />
+        </view>
+
+        <!-- Model pill, parked under the compose row. Tap opens the shared
+             island panel filled with the model picker. -->
+        <ModelPill
+          :model="activeModel"
+          :open="open && panel === 'models'"
+          :can-think="!!activeModel.ollamaModel"
+          :thinking="thinking"
+          @tap="togglePanel('models')"
+          @toggle-think="setThinking"
+        />
+
+        <!-- Voice takeover row. -->
+        <template #voice>
+          <view class="flex flex-row items-center gap-3 flex-1 px-2">
+            <view class="size-9 rounded-full bg-red-500 flex items-center justify-center vyai-breathe">
+              <VyIcon name="i-tabler-microphone" :size="20" color="#ffffff" />
+            </view>
+            <text class="flex-1 text-slate-500 text-[15px] vyai-breathe">Listening…</text>
+          </view>
+          <view
+            class="size-9 rounded-full bg-slate-100 flex items-center justify-center"
+            @tap="cancelVoice"
+          >
+            <VyIcon name="i-tabler-x" :size="20" color="#334155" />
+          </view>
+        </template>
+
+        <!-- Shared panel — grows above the composer. Content swaps with
+             `panel`: the "+" tools tray, or the model picker. -->
+        <template #expanded>
+          <ModelMenu
+            v-if="panel === 'models'"
+            :models="MODELS"
+            :selected-id="modelId"
+            @select="pickModel"
+          />
+          <ToolsTray
+            v-else
+            :tools="TOOLS"
+            @select="open = false"
+            @voice="startVoice"
+          />
+        </template>
+      </VyIsland>
+    </view>
+
+    <!-- Keyboard spacer — grows to the keyboard height, pushing the bar up. -->
+    <view :style="{ height: `${kbHeight}px` }" />
+  </view>
+</template>

--- a/apps/examples/vyai/src/sections/TopBar.vue
+++ b/apps/examples/vyai/src/sections/TopBar.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { VyIsland, VyIslandButton } from '@vyui/kit'
+import { useChat } from '../composables/useChat'
+import { useDrawer } from '../composables/useDrawer'
+
+const { newChat } = useChat()
+const { toggle: toggleDrawer } = useDrawer()
+</script>
+
+<template>
+  <!-- Burger pill, pinned top-left — slides the app over to reveal the
+       under-sheet menu (see App.vue). These islands are fixed inside the
+       sliding shell, so they travel with it when it opens. -->
+  <VyIsland
+    layer="inline"
+    size="sm"
+    :ui="{ row: 'vyai-float' }"
+    :style="{ position: 'fixed', top: '40px', left: '12px', zIndex: 50 }"
+  >
+    <VyIslandButton icon="i-tabler-menu-2" @tap="toggleDrawer" />
+  </VyIsland>
+
+  <!-- New-chat pill, pinned top-right. -->
+  <VyIsland
+    layer="inline"
+    size="sm"
+    :ui="{ row: 'vyai-float' }"
+    :style="{ position: 'fixed', top: '40px', right: '12px', zIndex: 50 }"
+  >
+    <VyIslandButton icon="i-tabler-edit" @tap="newChat" />
+  </VyIsland>
+</template>

--- a/apps/examples/vyai/src/tsconfig.json
+++ b/apps/examples/vyai/src/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "strict": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "jsx": "preserve",
+    "lib": ["ESNext"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@vyui/core": ["../../../../packages/core/src/index.ts"],
+      "@vyui/core/internal": ["../../../../packages/core/src/internal.ts"],
+      "@vyui/core/date": ["../../../../packages/core/src/date/index.ts"],
+      "@vyui/core/shared": ["../../../../packages/core/src/shared/index.ts"],
+      "@vyui/kit": ["../../../../packages/kit/src/index.ts"]
+    }
+  },
+  "vueCompilerOptions": {
+    "plugins": ["vue-lynx/types/volar-plugin"]
+  },
+  "include": [
+    "./**/*",
+    "../../../../packages/core/src/**/*",
+    "../../../../packages/kit/src/**/*"
+  ],
+  "exclude": ["../node_modules", "../../../../packages/core/src/**/*.story.vue", "../../../../packages/core/src/**/*.test.ts", "../../../../packages/core/src/**/*.bench.ts"]
+}

--- a/apps/examples/vyai/tailwind.config.ts
+++ b/apps/examples/vyai/tailwind.config.ts
@@ -1,0 +1,40 @@
+import type { Config } from 'tailwindcss'
+import lynxPreset from '@lynx-js/tailwind-preset'
+// Import directly from source so jiti (used by rsbuild-plugin-tailwindcss to
+// evaluate this config file) resolves the file without requiring @vyui/kit to
+// be pre-built. rspack itself never sees this import — jiti executes the config
+// before rspack starts. Mirrors the content path pointing at `packages/kit/src/**`.
+import vyuiPreset from '../../../packages/kit/src/tailwind.js'
+
+const config: Config = {
+  content: [
+    './src/**/*.{vue,js,ts}',
+    '../../../packages/kit/src/**/*.{vue,js,ts}',
+    '../../../packages/core/src/**/*.{vue,js,ts}',
+  ],
+  presets: [lynxPreset, vyuiPreset as Config],
+  theme: {
+    extend: {
+      // Brand palette. Remapping the stock Tailwind tokens (rather than adding
+      // new classes) re-skins the whole demo in place AND flows through the
+      // kit's neutral scale: `@vyui/kit/style.css` defines
+      // `--ui-color-neutral-*: theme('colors.slate.*')`, so overriding `slate`
+      // here recolors every kit component that paints `neutral` too.
+      colors: {
+        // Parchment White — every `bg-white`, plus the island's `bg-white/80`.
+        'white': '#fdfcfc',
+        'parchment-white': '#fdfcfc',
+        // Ash Border — the borders + hairline dividers (slate-200 = neutral-200).
+        'ash-border': '#e5e5e5',
+        // Sunken surface — the under-sheet sidebar + the model pill sit on this
+        // so they read as one tone (also `.vyai-undersheet` in index.css).
+        'parchment-sunken': '#f1f0ef',
+        slate: {
+          200: '#e5e5e5',
+        },
+      },
+    },
+  },
+}
+
+export default config

--- a/apps/examples/vyai/tsconfig.json
+++ b/apps/examples/vyai/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "references": [
+    { "path": "./tsconfig.node.json" },
+    { "path": "./src" }
+  ],
+  "files": []
+}

--- a/apps/examples/vyai/tsconfig.node.json
+++ b/apps/examples/vyai/tsconfig.node.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "strict": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["lynx.config.ts", "tailwind.config.ts", "postcss.config.js", "../_shared/**/*.ts"]
+}

--- a/docs/upstream/vue-lynx-keyboard.md
+++ b/docs/upstream/vue-lynx-keyboard.md
@@ -1,0 +1,89 @@
+# Keyboard awareness under vue-lynx
+
+How to react to the on-screen keyboard (e.g. lift a docked composer above it) in
+a vue-lynx app. The short version: **listen to the `<input>`/`<textarea>`
+element's own `keyboard` event, not the global `keyboardstatuschanged`.**
+
+## The trap: `GlobalEventEmitter` is not delivered
+
+The documented Lynx pattern (used by `lynx-ui`'s `KeyboardAwareRoot` and ported
+into vyui's `KeyboardAware*` family via `useGlobalKeyboard`) subscribes to a
+global event:
+
+```ts
+lynx.getJSModule('GlobalEventEmitter')
+  .addListener('keyboardstatuschanged', (status, height) => { … })
+```
+
+On the iOS simulator the native side **does** emit this — the unified log shows:
+
+```
+[I:LynxKeyboardEventDispatcher.m] keyboard status is on / keyboard height is 336
+call jsmodule:GlobalEventEmitter.emit.keyboardstatuschanged 0x…   ← the vue bg context
+```
+
+…but the listener registered from a vue-lynx component (`onMounted`) **never
+fires**. The emit reaches the right background JS context, yet the vue-lynx-side
+`GlobalEventEmitter` listener does not receive it. So vyui's `KeyboardAware*`
+components are effectively inert on device under vue-lynx. (Upstream item — see
+"Open questions" below.)
+
+## What works: the element `keyboard` event
+
+Lynx also dispatches keyboard show/hide **directly to the focused input
+element**. Element events do reach the vue-lynx runtime (the input's
+`focus`/`input`/`selection` events fire normally). The raw payload is:
+
+```
+{ show: 0 | 1, keyBoardHeight: number, safeAreaBottom: number }
+```
+
+Note the capital **B** in `keyBoardHeight`. Verified on the iOS simulator
+(force the software keyboard with **Cmd+K**); Android field names may differ.
+
+`@vyui/core`'s `Input`/`Textarea` (and `@vyui/kit`'s `VyInput`/`VyTextarea`)
+surface this as a normalized **`keyboard`** event:
+
+```ts
+'keyboard': [info: { visible: boolean, height: number, safeAreaBottom: number }]
+```
+
+```vue
+<VyInput @keyboard="onKb" />
+<script setup>
+function onKb({ visible, height }) {
+  kbHeight.value = visible ? height : 0
+}
+</script>
+```
+
+## Applying the lift: flex spacer, not fixed-transform
+
+Reactive `transform` / `bottom` on a `position: fixed` element did **not**
+visibly repaint on the Lynx runtime in testing. The reliable approach is plain
+reactive layout:
+
+- Put the page in a `flex flex-col`; the scroll area is `flex-1 min-h-0`.
+- The composer sits in normal flow at the bottom.
+- Render a spacer **below** it whose height tracks the keyboard:
+  `<view :style="{ height: kbHeight + 'px' }" />`.
+
+Lynx overlays the keyboard (the page does not resize — layout stays full
+height), so growing the spacer pushes the composer up by exactly the keyboard
+height. Reset to `0` on `blur`.
+
+Reference implementation: `apps/examples/vyai/src/sections/Composer.vue`.
+
+## Open questions / upstream
+
+- **Why is `GlobalEventEmitter` `keyboardstatuschanged` not delivered to the
+  vue-lynx background listener?** Confirm whether vue-lynx wires
+  `lynx.getJSModule('GlobalEventEmitter')` to the same registry the native emit
+  targets, or whether listeners must be registered through a different binding /
+  thread. This is the root blocker for a global (input-agnostic) keyboard hook.
+- **`KeyboardAware*` rework:** re-point `KeyboardAwareRoot` away from
+  `useGlobalKeyboard` and onto the input's `keyboard` event relayed through
+  `KeyboardAwareTrigger` (the Trigger already wraps the input and holds the root
+  context). Consider switching the lift mechanism from the responder's
+  `setNativeProps` transform to the flex-spacer model above.
+- **Android:** verify the `keyboard` event payload field names and units.

--- a/packages/core/src/components/FeedList/FeedList.vue
+++ b/packages/core/src/components/FeedList/FeedList.vue
@@ -91,6 +91,13 @@ export interface FeedListProps<T = unknown> {
   /** Initial loading-more state when uncontrolled. */
   defaultLoadingMore?: boolean
   /**
+   * No more data to load. Shows the `noMoreDataFooter` slot (end-of-list). Until
+   * this is `true` — and while not `loadingMore` — no footer renders, so a list
+   * with more pages to fetch never displays an "end of list" message.
+   * @defaultValue `false`
+   */
+  noMoreData?: boolean
+  /**
    * Items from the bottom that triggers `load-more`.
    * @defaultValue `2`
    */
@@ -144,6 +151,7 @@ const props = withDefaults(defineProps<FeedListProps<T>>(), {
   enableBounce: false,
   enableLoadMore: false,
   defaultLoadingMore: false,
+  noMoreData: false,
   loadMoreThresholdItemCount: 2,
   upperThresholdItemCount: 0,
 })
@@ -503,7 +511,10 @@ const itemSnapValue = computed(() => {
 })
 
 const isEmpty = computed(() => props.items.length === 0)
-const hasFooter = computed(() => props.enableLoadMore)
+// Footer row only exists when there's something to show: the load-more spinner
+// while fetching, or the end-of-list footer once `noMoreData`. Otherwise no
+// footer renders, so "No more items" never shows while more pages remain.
+const hasFooter = computed(() => props.enableLoadMore && (loadingMore.value || props.noMoreData))
 
 defineExpose({ scrollToIndex, refreshState })
 </script>

--- a/packages/core/src/components/Input/Input.vue
+++ b/packages/core/src/components/Input/Input.vue
@@ -18,6 +18,7 @@
     `bindblur`              → `@blur`
     `bindconfirm`           → `@confirm`
     `bindselection`         → `@selection`
+    `bindkeyboard`          → `@keyboard`
   The main-thread `bindinput` variant from the React port is dropped here —
   vue-lynx doesn't surface `main-thread:` event bindings in templates, so we
   use the equivalent background-thread `@input` (same `event.detail` payload).
@@ -93,6 +94,20 @@ export type InputEmits = {
   'confirm': [value: string]
   /** Fires when the user moves the selection caret / changes the selection. */
   'selectionChange': [selectionStart: number, selectionEnd: number]
+  /**
+   * Fires when the software keyboard shows/hides while this input is focused.
+   * Lynx delivers this as an element event on the native `<input>` with the
+   * raw shape `{ show: 0|1, keyBoardHeight, safeAreaBottom }` (note the capital
+   * B in `keyBoardHeight`); it is normalized here to `{ visible, height,
+   * safeAreaBottom }`.
+   *
+   * This is the reliable way to react to the keyboard under vue-lynx: the
+   * global `GlobalEventEmitter` `keyboardstatuschanged` event is emitted by the
+   * native side but is NOT delivered to the vue-lynx background runtime, so
+   * this per-element event is what consumers (and keyboard-aware lifts) should
+   * use. Verified on the iOS simulator; Android payload fields may differ.
+   */
+  'keyboard': [info: { visible: boolean, height: number, safeAreaBottom: number }]
 }
 </script>
 
@@ -326,6 +341,18 @@ function handleSelection(event: any) {
   emit('selectionChange', detail.selectionStart ?? 0, detail.selectionEnd ?? 0)
 }
 
+// Normalize Lynx's raw `{ show, keyBoardHeight, safeAreaBottom }` keyboard
+// payload. See the `keyboard` entry in `InputEmits` for why this element event
+// (not the global emitter) is the keyboard signal under vue-lynx.
+function handleKeyboard(event: any) {
+  const d = event?.detail ?? {}
+  emit('keyboard', {
+    visible: d.show === 1 || d.show === true,
+    height: Number(d.keyBoardHeight ?? d.keyboardHeight ?? d.height ?? 0) || 0,
+    safeAreaBottom: Number(d.safeAreaBottom ?? 0) || 0,
+  })
+}
+
 defineExpose<InputExposed>({
   focus,
   blur,
@@ -360,6 +387,7 @@ defineExpose<InputExposed>({
     @blur="handleBlur"
     @confirm="handleConfirm"
     @selection="handleSelection"
+    @keyboard="handleKeyboard"
   >
     <slot />
   </Primitive>

--- a/packages/core/src/components/Input/Textarea.vue
+++ b/packages/core/src/components/Input/Textarea.vue
@@ -63,6 +63,13 @@ export type TextareaEmits = {
   'blur': [value: string]
   'confirm': [value: string]
   'selectionChange': [selectionStart: number, selectionEnd: number]
+  /**
+   * Software-keyboard show/hide while focused. Normalized from Lynx's raw
+   * `{ show, keyBoardHeight, safeAreaBottom }` element event — see `Input.vue`
+   * for why this element event (not the global emitter) is the keyboard signal
+   * under vue-lynx.
+   */
+  'keyboard': [info: { visible: boolean, height: number, safeAreaBottom: number }]
 }
 </script>
 
@@ -235,6 +242,17 @@ function handleSelection(event: any) {
   emit('selectionChange', detail.selectionStart ?? 0, detail.selectionEnd ?? 0)
 }
 
+// Normalize Lynx's raw `{ show, keyBoardHeight, safeAreaBottom }` keyboard
+// payload — see `Input.vue`'s `keyboard` emit for the rationale.
+function handleKeyboard(event: any) {
+  const d = event?.detail ?? {}
+  emit('keyboard', {
+    visible: d.show === 1 || d.show === true,
+    height: Number(d.keyBoardHeight ?? d.keyboardHeight ?? d.height ?? 0) || 0,
+    safeAreaBottom: Number(d.safeAreaBottom ?? 0) || 0,
+  })
+}
+
 defineExpose<TextareaExposed>({
   focus,
   blur,
@@ -272,6 +290,7 @@ defineExpose<TextareaExposed>({
     @blur="handleBlur"
     @confirm="handleConfirm"
     @selection="handleSelection"
+    @keyboard="handleKeyboard"
   >
     <slot />
   </Primitive>

--- a/packages/core/src/components/Sortable/SortableItem.vue
+++ b/packages/core/src/components/Sortable/SortableItem.vue
@@ -15,7 +15,7 @@ export interface SortableItemProps {
 </script>
 
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, watch } from 'vue'
+import { onBeforeUnmount, watch } from 'vue'
 import { runOnBackground, runOnMainThread, useMainThreadRef } from 'vue-lynx'
 
 import type { SortableItemHandle } from './sortableContext'
@@ -41,12 +41,13 @@ const indexRef = useMainThreadRef<number>(props.index)
 const itemDisabledRef = useMainThreadRef<boolean>(props.disabled)
 const lastTargetRef = useMainThreadRef<number>(-1)
 const liftedDyRef = useMainThreadRef<number>(0)
-// Long-press timer id, MT-local. The activation delay is timed on the main
-// thread (via the worklet `setTimeout`) so a touch never has to round-trip
-// MT→BG→setTimeout→MT before the row can lift — that cross-channel hop is the
-// documented-fragile path (see useDragGesture onMounted) and on-device it was
-// dropping the activation entirely, so drag never started. 0 = no timer.
-const activationTimerRef = useMainThreadRef<number>(0)
+// Long-press activation is timed on the main thread by polling
+// `requestAnimationFrame`, NOT `setTimeout`. The MT worklet runtime does not
+// expose `setTimeout`/`clearTimeout` — they're commented out as internal in
+// @lynx-js/types (main-thread/lynx.d.ts) — so the old timer threw inside the
+// worklet and the row never lifted (iOS + web). The rAF poller (`_activationTick`)
+// checks elapsed time against `longPressMs` each frame and is cancelled
+// implicitly when `armedRef` clears (move-disarm / touchend / unmount).
 
 // Velocity tracker (Y) — drives the velocity-aware drop: a fast toss lands one
 // row further in the flick direction than the raw pointer offset (mirrors
@@ -54,37 +55,66 @@ const activationTimerRef = useMainThreadRef<number>(0)
 const posQueueRef = useMainThreadRef<number[]>([])
 const timeQueueRef = useMainThreadRef<number[]>([])
 
-watch(() => props.index, (v) => { indexRef.current = v })
-watch(() => props.disabled, (v) => { itemDisabledRef.current = v })
+// Index / disabled live on the MT and gate the touch worklets. BG writes to a
+// MainThreadRef.current are no-ops in vue-lynx 0.4.0, so push updates through a
+// setter worklet rather than assigning `.current` from this (BG) thread.
+watch(() => props.index, (v) => { runOnMainThread(_syncIndexMT as any)(v) })
+watch(() => props.disabled, (v) => { runOnMainThread(_syncDisabledMT as any)(v) })
 
-// ── Registry handle (BG side; .current populated at mount) ─────────────────
-const elementRef: SortableItemHandle['elementRef'] = { current: null }
-let handle: SortableItemHandle | null = null
-let unregister: (() => void) | null = null
-
-onMounted(() => {
-  elementRef.current = (containerRef as unknown as {
-    current: { setStyleProperty?(k: string, v: string): void } | null
-  }).current
-  handle = { index: props.index, elementRef }
-  unregister = ctx.register(handle)
-})
-
-watch(() => props.index, (v) => {
-  if (handle) handle.index = v
-})
+// ── Registry handle (MT side) ──────────────────────────────────────────────
+// The handle (element + logical index) MUST be appended ON the main thread:
+// `ctx.itemHandlesMT` is a MainThreadRef and BG writes to it are dropped by
+// vue-lynx 0.4.0. The previous `onMounted` registration ran on the BG thread,
+// so the registry stayed empty — the lifted row never moved, siblings never
+// shifted, and the drop saw `count === 0`, so no reorder ever committed.
+// Registration now happens in `_registerMT` (bound to `main-thread-binduiappear`,
+// where this item's MT element ref is populated) and teardown in `_unregisterMT`.
+const handleRef = useMainThreadRef<SortableItemHandle | null>(null)
 
 onBeforeUnmount(() => {
-  // Cancel a pending long-press on the MT (BG `.current` writes are dropped).
+  // All teardown runs on the MT (BG `.current` writes are dropped): cancel any
+  // pending long-press and drop this item from the registry.
   runOnMainThread(_cancelActivation as any)()
-  if (unregister) {
-    unregister()
-    unregister = null
-  }
-  handle = null
+  runOnMainThread(_unregisterMT as any)()
 })
 
 // ── Worklets ────────────────────────────────────────────────────────────────
+
+/**
+ * Append this item to the MT registry. Bound to `main-thread-binduiappear` so
+ * the element ref is guaranteed populated. Guarded against the repeat appears
+ * Lynx fires when a row scrolls back into view.
+ */
+function _registerMT() {
+  'main thread'
+  if (handleRef.current) return
+  const el = (containerRef as unknown as { current: any }).current
+  const handle: SortableItemHandle = { index: indexRef.current, elementRef: { current: el } }
+  handleRef.current = handle
+  ctx.itemHandlesMT.current = [...ctx.itemHandlesMT.current, handle]
+}
+
+/** Remove this item from the MT registry on unmount. */
+function _unregisterMT() {
+  'main thread'
+  const h = handleRef.current
+  if (!h) return
+  ctx.itemHandlesMT.current = ctx.itemHandlesMT.current.filter(x => x !== h)
+  handleRef.current = null
+}
+
+/** Push a new logical index to the MT (ref + registry handle). */
+function _syncIndexMT(v: number) {
+  'main thread'
+  indexRef.current = v
+  if (handleRef.current) handleRef.current.index = v
+}
+
+/** Push the per-row disabled flag to the MT. */
+function _syncDisabledMT(v: boolean) {
+  'main thread'
+  itemDisabledRef.current = v
+}
 
 function _setTransform(
   el: { setStyleProperty?(k: string, v: string): void } | null,
@@ -189,8 +219,27 @@ function _activate() {
   ctx.draggingIndexMT.current = indexRef.current
   lastTargetRef.current = indexRef.current
   // Paint a small lift so the user sees the row engage even before they move.
-  _setTransform(elementRef.current, 0)
+  _setTransform((containerRef as unknown as { current: any }).current, 0)
   runOnBackground(_emitDragStart as any)(indexRef.current)
+}
+
+/**
+ * Main-thread long-press poller. Scheduled via `requestAnimationFrame` from
+ * touchstart; lifts the row once the press outlives `longPressMs`. Bails (and
+ * stops rescheduling) as soon as the gesture disarms, the row is already
+ * dragging, or another item has claimed the gesture. Uses rAF because the MT
+ * worklet runtime has no `setTimeout`.
+ */
+function _activationTick() {
+  'main thread'
+  if (!armedRef.current || draggingRef.current) return
+  if (ctx.draggingIndexMT.current !== -1) return
+  if (Date.now() - touchStartTimeRef.current >= ctx.longPressMsMT.current) {
+    _activate()
+    return
+  }
+  if (typeof requestAnimationFrame === 'function') requestAnimationFrame(_activationTick)
+  else (lynx as any).requestAnimationFrame(_activationTick)
 }
 
 function _onTouchStart(e: { touches: Array<{ clientY: number }> }) {
@@ -206,23 +255,18 @@ function _onTouchStart(e: { touches: Array<{ clientY: number }> }) {
   posQueueRef.current = [e.touches[0].clientY]
   timeQueueRef.current = [Date.now()]
   // Defer activation by `longPressMs` so a tap or vertical scroll doesn't lift.
-  // Timed entirely on the main thread — `_onTouchMove` disarms it if the finger
-  // travels before it fires, and `_onTouchEnd` clears it on release. Keeping it
-  // MT-local avoids the MT→BG→setTimeout→MT round-trip that was dropping the
-  // activation on-device.
-  if (activationTimerRef.current) {
-    clearTimeout(activationTimerRef.current)
-    activationTimerRef.current = 0
-  }
+  // Timed entirely on the main thread via an rAF poller — `_onTouchMove` disarms
+  // it if the finger travels before it fires, and `_onTouchEnd` clears it on
+  // release. rAF (not setTimeout) because the MT worklet runtime lacks timers.
   const delay = ctx.longPressMsMT.current
   if (delay <= 0) {
     _activate()
   }
+  else if (typeof requestAnimationFrame === 'function') {
+    requestAnimationFrame(_activationTick)
+  }
   else {
-    activationTimerRef.current = setTimeout(() => {
-      activationTimerRef.current = 0
-      _activate()
-    }, delay) as unknown as number
+    (lynx as any).requestAnimationFrame(_activationTick)
   }
 }
 
@@ -236,11 +280,8 @@ function _onTouchMove(e: { touches: Array<{ clientY: number }> }) {
   // Disarm + cancel the pending long-press so the row never lifts mid-scroll.
   if (!draggingRef.current) {
     if (Math.abs(dy) > 6) {
+      // Disarm: the rAF activation poller bails on its next frame once armed clears.
       armedRef.current = false
-      if (activationTimerRef.current) {
-        clearTimeout(activationTimerRef.current)
-        activationTimerRef.current = 0
-      }
     }
     return
   }
@@ -250,7 +291,7 @@ function _onTouchMove(e: { touches: Array<{ clientY: number }> }) {
   const count = ctx.itemHandlesMT.current.length
 
   liftedDyRef.current = dy
-  _setTransform(elementRef.current, dy)
+  _setTransform((containerRef as unknown as { current: any }).current, dy)
 
   // Velocity sampling — last 50ms window, keep >=2 so a release always has a
   // pair to differentiate.
@@ -283,12 +324,9 @@ function _onTouchEnd() {
   if (!armedRef.current && !draggingRef.current) return
   armedRef.current = false
 
-  // Cancel a still-pending long-press: a quick tap/release must not lift the
-  // row after the finger is already gone.
-  if (activationTimerRef.current) {
-    clearTimeout(activationTimerRef.current)
-    activationTimerRef.current = 0
-  }
+  // A still-pending long-press is cancelled implicitly: `armedRef` is now false,
+  // so the rAF activation poller bails on its next frame — a quick tap/release
+  // never lifts the row after the finger is already gone.
 
   if (!draggingRef.current) {
     // Long-press never confirmed — nothing to do.
@@ -339,14 +377,12 @@ function _emitDragEnd(from: number, to: number) {
   ctx.notifyDragEnd()
 }
 
-// MT teardown — cancel a pending long-press timer when the row unmounts. BG
-// writes to `.current` are dropped, so the clear must happen ON the MT.
+// MT teardown — disarm a pending long-press when the row unmounts. BG writes to
+// `.current` are dropped, so this must happen ON the MT. The rAF poller reads
+// `armedRef` each frame and stops once it's false.
 function _cancelActivation() {
   'main thread'
-  if (activationTimerRef.current) {
-    clearTimeout(activationTimerRef.current)
-    activationTimerRef.current = 0
-  }
+  armedRef.current = false
 }
 </script>
 
@@ -355,6 +391,7 @@ function _cancelActivation() {
     class="vyui-sortable__item"
     data-vyui-sortable-item
     :main-thread-ref="containerRef"
+    :main-thread-binduiappear="_registerMT"
     :main-thread-bindtouchstart="_onTouchStart"
     :main-thread-bindtouchmove="_onTouchMove"
     :main-thread-bindtouchend="_onTouchEnd"

--- a/packages/core/src/components/Sortable/SortableRoot.vue
+++ b/packages/core/src/components/Sortable/SortableRoot.vue
@@ -123,12 +123,9 @@ function _bindScroll() {
   viewportHeightMT.current = el.clientHeight ?? 0
 }
 
-function register(handle: SortableItemHandle) {
-  itemHandlesMT.current = [...itemHandlesMT.current, handle]
-  return () => {
-    itemHandlesMT.current = itemHandlesMT.current.filter(h => h !== handle)
-  }
-}
+// Item registration lives in SortableItem and runs on the MAIN thread: the
+// registry is a MainThreadRef and BG writes to `.current` are dropped by
+// vue-lynx 0.4.0, so a BG-side `register()` here left the registry empty.
 
 function commitReorder(from: number, to: number) {
   if (from === to || from < 0 || to < 0) return
@@ -165,7 +162,6 @@ provideSortableRootContext({
   viewportHeightMT,
   autoScrollEdgeMT,
   autoScrollSpeedMT,
-  register,
   commitReorder,
   notifyDragStart,
   notifyDragEnd,

--- a/packages/core/src/components/Sortable/sortableContext.ts
+++ b/packages/core/src/components/Sortable/sortableContext.ts
@@ -55,8 +55,6 @@ export interface SortableRootContext<T = unknown> {
   autoScrollSpeedMT: MainThreadRef<number>
 
   // ── BG callbacks invoked from MT worklets ────────────────────────────────
-  /** Register a freshly mounted item; returns an unregister fn for onBeforeUnmount. */
-  register: (handle: SortableItemHandle) => () => void
   /** Commit a reorder from `from` → `to`. Emits `update:modelValue` + `reorder`. */
   commitReorder: (from: number, to: number) => void
   /** Mark drag started (sets `draggingIndex` for slot reactivity). */

--- a/packages/kit/src/components/Input.vue
+++ b/packages/kit/src/components/Input.vue
@@ -96,7 +96,7 @@ const props = withDefaults(defineProps<InputProps>(), {
   autocomplete: 'off',
   autofocusDelay: 0,
 })
-defineEmits(['update:modelValue', 'confirm'])
+defineEmits(['update:modelValue', 'confirm', 'focus', 'blur', 'keyboard'])
 defineSlots<InputSlots>()
 
 const slots = useSlots()
@@ -198,6 +198,9 @@ defineExpose({ inputRef })
         :class="ui.base({ class: ['w-full', props.ui?.base] })"
         @update:model-value="$emit('update:modelValue', $event)"
         @confirm="$emit('confirm', $event)"
+        @focus="$emit('focus', $event)"
+        @blur="$emit('blur', $event)"
+        @keyboard="$emit('keyboard', $event)"
       />
     </view>
     <view

--- a/packages/kit/src/components/IslandButton.vue
+++ b/packages/kit/src/components/IslandButton.vue
@@ -86,6 +86,8 @@ export interface IslandButtonSlots {
 import { computed, useSlots } from 'vue'
 import { Button as CoreButton, Icon as VyIcon } from '@vyui/core'
 import { useStyledComponent } from '../composables/useStyledComponent'
+import { useAppConfig } from '../composables/useAppConfig'
+import { resolveColorHex } from '../utils/resolveColor'
 import { injectIslandContext, type IslandSize } from './islandContext'
 
 const props = withDefaults(defineProps<IslandButtonProps>(), {
@@ -134,6 +136,24 @@ const { ui } = useStyledComponent('islandButton', theme, () => ({
   iconOnly: iconOnly.value,
 }))
 
+const appConfig = useAppConfig()
+
+// Lynx's `<svg>` rasterizes the XML and can't inherit `currentColor`, so the
+// `text-*` utility the theme puts on the `leadingIcon` slot never reaches the
+// glyph (unlike the `<text>` label, which it colors fine). Mirror the
+// Button/Input/Alert pattern: read the foreground utility back off the
+// resolved slot class — including any consumer `ui.leadingIcon` override and
+// the active-state shade — and bake it into the icon `:color`. Returns
+// `undefined` for non-palette colors (e.g. arbitrary `text-[#abc]`) so the
+// icon keeps its `currentColor` default rather than guessing.
+const iconColor = computed(() => {
+  const cls = String(ui.value.leadingIcon({ class: props.ui?.leadingIcon }))
+  if (/\btext-white\b/.test(cls)) return 'white'
+  if (/\btext-black\b/.test(cls)) return 'black'
+  const match = cls.match(/\btext-([a-z]+)-(\d+)\b/)
+  return match ? resolveColorHex(appConfig, match[1], Number(match[2])) : undefined
+})
+
 function onTap() {
   if (props.disabled) return
   if (island) {
@@ -158,6 +178,7 @@ function onTap() {
         v-if="icon"
         :name="icon"
         :size="iconPx"
+        :color="iconColor"
         :class="ui.leadingIcon({ class: props.ui?.leadingIcon })"
       />
     </slot>

--- a/packages/kit/src/components/Textarea.vue
+++ b/packages/kit/src/components/Textarea.vue
@@ -83,7 +83,7 @@ const props = withDefaults(defineProps<TextareaProps>(), {
   rows: 3,
   autofocusDelay: 0,
 })
-defineEmits(['update:modelValue'])
+defineEmits(['update:modelValue', 'confirm', 'focus', 'blur', 'keyboard'])
 defineSlots<TextareaSlots>()
 
 const slots = useSlots()
@@ -174,6 +174,10 @@ defineExpose({ textareaRef })
       :max-length="maxLength"
       :class="ui.base({ class: props.ui?.base })"
       @update:model-value="$emit('update:modelValue', $event)"
+      @confirm="$emit('confirm', $event)"
+      @focus="$emit('focus', $event)"
+      @blur="$emit('blur', $event)"
+      @keyboard="$emit('keyboard', $event)"
     />
     <view
       v-if="hasTrailing"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,6 +248,61 @@ importers:
         specifier: 3.5.17
         version: 3.5.17(typescript@5.9.3)
 
+  apps/examples/vyai:
+    dependencies:
+      '@vyui/core':
+        specifier: workspace:*
+        version: link:../../../packages/core
+      '@vyui/kit':
+        specifier: workspace:*
+        version: link:../../../packages/kit
+      vue-lynx:
+        specifier: ^0.4.0
+        version: 0.4.0(patch_hash=69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.14))
+    devDependencies:
+      '@iconify-json/icon-park-outline':
+        specifier: ^1.2.0
+        version: 1.2.4
+      '@iconify-json/icon-park-solid':
+        specifier: ^1.2.4
+        version: 1.2.4
+      '@iconify-json/lucide':
+        specifier: ^1.2.108
+        version: 1.2.108
+      '@iconify-json/tabler':
+        specifier: ^1.2.35
+        version: 1.2.35
+      '@lynx-js/rspeedy':
+        specifier: ^0.13.5
+        version: 0.13.6(@rspack/core@1.7.11(@swc/helpers@0.5.21))(typescript@5.9.3)(webpack@5.106.2(postcss@8.5.14))
+      '@lynx-js/tailwind-preset':
+        specifier: ^0.4.0
+        version: 0.4.0(tailwindcss@3.4.19(tsx@4.22.3)(yaml@2.9.0))
+      '@lynx-js/types':
+        specifier: ^3.8.0
+        version: 3.8.0
+      '@rsbuild/plugin-vue':
+        specifier: ^1.2.6
+        version: 1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(vue@3.5.17(typescript@5.9.3))
+      autoprefixer:
+        specifier: ^10.4.20
+        version: 10.5.0(postcss@8.5.14)
+      postcss:
+        specifier: ^8.4.49
+        version: 8.5.14
+      rsbuild-plugin-tailwindcss:
+        specifier: ^0.2.4
+        version: 0.2.4(@rsbuild/core@1.7.3)(tailwindcss@3.4.19(tsx@4.22.3)(yaml@2.9.0))
+      tailwindcss:
+        specifier: ^3.4.17
+        version: 3.4.19(tsx@4.22.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vue:
+        specifier: 3.5.17
+        version: 3.5.17(typescript@5.9.3)
+
   fixtures/fixture-consumer:
     devDependencies:
       '@lynx-js/types':


### PR DESCRIPTION
Bundles the vyai Ollama demo together with the input/island-button/gesture fixes that were in flight.

**vyai example app (with local Ollama)**
- New `apps/examples/vyai`: island composer, model picker, streaming bubbles, conversations drawer, keyboard lift.
- `useOllama` composable — configurable client for a local Ollama server (`/api/chat`); base URL via `VITE_OLLAMA_URL`.
- Ollama-backed model in the picker (`qwen3.5:9b`); replies animate word-by-word; "Thinking" switch toggles reasoning per turn, shown in a collapsible "thought process".
- Non-streaming on purpose (`stream:false` + `res.json()`): Lynx's native fetch has no readable body stream and its `res.text()` can resolve to undefined, so this is the reliable path on device.

**Input (`@vyui/core` + `@vyui/kit`)**
- `Input`/`Textarea` emit a normalized `keyboard` event (`{ visible, height, safeAreaBottom }`) — the reliable keyboard signal under vue-lynx (global `keyboardstatuschanged` isn't delivered to the BG runtime).
- `VyInput`/`VyTextarea` forward `@focus`/`@blur` (and `VyTextarea` now `@confirm`).
- Adds `docs/upstream/vue-lynx-keyboard.md`.

**IslandButton (`@vyui/kit`)**
- Bake the icon color so the theme/active foreground actually applies (Lynx `<svg>` can't inherit `currentColor`), matching Button/Input/Alert/Combobox.

**Gesture fixes (`@vyui/core`)**
- `fix(sortable)`: register items on the main thread so drag-to-reorder works.
- `fix(feedlist)`: gate the end-of-list footer on a `noMoreData` prop.