### PR TITLE
fix: textarea border, switch thumb, toast preview, select height

### DIFF
--- a/apps/docs/content/3.components/select.md
+++ b/apps/docs/content/3.components/select.md
@@ -18,7 +18,7 @@ links:
 ::component-code
 ---
 name: select-example
-height: 120px
+height: 240px
 ---
 ::
 

--- a/apps/examples/docs-playground/src/App.vue
+++ b/apps/examples/docs-playground/src/App.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, shallowRef } from 'vue'
+import { OverlayRoot } from '@vyui/core'
 import { examples } from './examples'
 
 // The docs host selects which example to mount via `global-props`. On the
@@ -15,7 +16,12 @@ const current = computed(() => examples[requested.value])
 </script>
 
 <template>
-  <view class="flex items-center justify-center w-full min-h-screen p-6 bg-transparent">
+  <view class="relative flex items-center justify-center w-full min-h-screen p-6 bg-transparent">
+    <!-- Paints overlay-portal components (Toast, Modal, Popover, ActionSheet);
+         their ToastViewport / *Content register into the overlayStore and only
+         render through an OverlayRoot mounted at the app root. -->
+    <OverlayRoot />
+
     <component :is="current" v-if="current" />
     <text v-else class="text-sm text-red-500">Unknown example: {{ requested }}</text>
   </view>

--- a/packages/kit/src/theme/switch.ts
+++ b/packages/kit/src/theme/switch.ts
@@ -12,8 +12,15 @@ export default (colors: Color[]) => ({
     root: 'flex flex-row items-center min-w-0 max-w-full gap-2',
     // `items-center` centers the thumb vertically — without it, the thumb
     // (`h-4` < rail's `h-5`) pins to the cross-axis start (top edge) on Lynx.
-    base: 'relative flex flex-row items-center shrink-0 rounded-full transition-colors',
-    thumb: 'pointer-events-none flex flex-row items-center justify-center rounded-full bg-white shadow transform transition-transform',
+    //
+    // Thumb position is driven by flexbox justification (`justify-start` /
+    // `justify-end` via the `checked` variant), NOT `translate-x-*`. The Lynx
+    // tailwind preset compiles `translate-x-*` to `transform: translate3d(var(…))`,
+    // and `transform`/`var()` positioning silently fails to paint on Lynx —
+    // see the canonical write-up in `core/src/components/Slider/SliderThumbImpl.vue`.
+    // `px-0.5` keeps the thumb off the rail edges at both ends.
+    base: 'relative flex flex-row items-center justify-start shrink-0 px-0.5 rounded-full transition-colors',
+    thumb: 'pointer-events-none flex flex-row items-center justify-center rounded-full bg-white shadow',
     wrapper: 'flex-1 min-w-0 flex flex-col',
     label: 'text-sm font-medium text-neutral-900',
     description: 'text-xs text-neutral-500',
@@ -28,8 +35,8 @@ export default (colors: Color[]) => ({
       xl: { base: 'w-14 h-8', thumb: 'w-7 h-7', icon: 'size-5' },
     },
     checked: {
-      true: '',
-      false: { base: 'bg-neutral-200', thumb: 'translate-x-0.5' },
+      true: { base: 'justify-end' },
+      false: { base: 'bg-neutral-200' },
     },
     disabled: {
       true: { base: 'opacity-50 cursor-not-allowed' },
@@ -44,10 +51,6 @@ export default (colors: Color[]) => ({
   compoundVariants: [
     ...colors.map(c => ({ color: c, checked: true, class: { base: `bg-${c}-500` } })),
     ...colors.map(c => ({ color: c, highlight: true, class: { base: `border-2 border-${c}-500` } })),
-    { size: 'sm' as const, checked: true, class: { thumb: 'translate-x-4' } },
-    { size: 'md' as const, checked: true, class: { thumb: 'translate-x-5' } },
-    { size: 'lg' as const, checked: true, class: { thumb: 'translate-x-5' } },
-    { size: 'xl' as const, checked: true, class: { thumb: 'translate-x-6' } },
   ],
   defaultVariants: {
     color: 'primary' as const,

--- a/packages/kit/src/theme/textarea.ts
+++ b/packages/kit/src/theme/textarea.ts
@@ -18,7 +18,10 @@ export default (colors: Color[]) => ({
     // Typed-text color sits on `base` (the <textarea>), not `root`: CSS
     // inheritance is OFF in the Lynx build (`enableCSSInheritance: false`), so a
     // `text-*` on the root <view> never reaches the textarea element.
-    base: 'flex-1 min-w-0 min-h-0 max-w-full bg-transparent text-neutral-900 placeholder:text-neutral-400 focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 align-top',
+    // `border-0` resets the native <textarea>'s user-agent border (visible as a
+    // black inset border on the web Lynx build); the themed border lives on
+    // `root`.
+    base: 'flex-1 min-w-0 min-h-0 max-w-full bg-transparent border-0 text-neutral-900 placeholder:text-neutral-400 focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 align-top',
     leading: 'flex flex-row items-center shrink-0',
     leadingIcon: 'shrink-0 text-neutral-400',
     leadingAvatar: 'shrink-0',


### PR DESCRIPTION
- textarea: reset native <textarea> user-agent border with border-0
- switch: position thumb via flexbox justify (translate-x doesn't paint on Lynx)
- docs-playground: mount OverlayRoot so Toast/Modal/Popover render
- docs: double Select preview height to 240px