### PR TITLE
fix(docs): unblock release playground build

### DIFF
--- a/apps/examples/docs-playground/tailwind.config.ts
+++ b/apps/examples/docs-playground/tailwind.config.ts
@@ -1,6 +1,6 @@
 import type { Config } from 'tailwindcss'
 import lynxPreset from '@lynx-js/tailwind-preset'
-import vyuiPreset from '@vyui/kit/tailwind'
+import vyuiPreset from '../../../packages/kit/src/tailwind.js'
 
 const config: Config = {
   content: [


### PR DESCRIPTION
## Summary
- point the docs playground Tailwind config at the workspace kit source preset instead of the package export
- avoids resolving @vyui/kit/tailwind to dist/tailwind.js before @vyui/kit has built during the Release workflow

## Verification
- node --input-type=module -e "const mod = await import('./packages/kit/src/tailwind.js'); console.log(typeof mod.default, Array.isArray(mod.VYUI_UI_STATES), mod.VYUI_UI_STATES.join(','))"
- push hook ran vue-tsc --noEmit (existing vue-lynx Volar compatibility warning only)