### PR TITLE
fix(release): avoid GitHub changelog API failures

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,11 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.2/schema.json",
-  "changelog": [
-    "@svitejs/changesets-changelog-github-compact",
-    {
-      "repo": "KealanAU/vyui"
-    }
-  ],
+  "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
   "linked": [],


### PR DESCRIPTION
## Summary
- switch Changesets from the GitHub GraphQL-backed changelog plugin to the built-in Changesets changelog
- prevents `changeset version` from failing when GitHub's GraphQL response closes early during the Release workflow

## Context
Release #27 reached the Changesets step, then failed with `ERR_STREAM_PREMATURE_CLOSE` while fetching `https://api.github.com/graphql` from the changelog plugin.

## Verification
- parsed `.changeset/config.json` and confirmed `changelog` is `@changesets/cli/changelog`
- push hook completed `vue-tsc --noEmit` with the existing vue-lynx Volar compatibility warning
