### PR TITLE
chore: add native, mobile keywords for discoverability

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,6 +18,8 @@
     "vue",
     "lynx",
     "vue-lynx",
+    "native",
+    "mobile",
     "ui",
     "components",
     "cli",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,8 @@
     "vue",
     "lynx",
     "vue-lynx",
+    "native",
+    "mobile",
     "headless",
     "ui",
     "components",

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -18,6 +18,8 @@
     "vue",
     "lynx",
     "vue-lynx",
+    "native",
+    "mobile",
     "ui",
     "components",
     "design-system",


### PR DESCRIPTION
Adds `native` and `mobile` to the npm `keywords` of all three published packages to widen discoverability on npmjs.com.

- `@vyui/core`, `@vyui/kit`, `@vyui/cli` keywords gain `native`, `mobile`.

Mirrors the matching GitHub repo topics, which were added separately.