### PR TITLE
chore: drop reductive section-divider and label comments

### DIFF
--- a/apps/docs/app/composables/useNavigation.ts
+++ b/apps/docs/app/composables/useNavigation.ts
@@ -4,7 +4,6 @@ import type { ContentNavigationItem } from '@nuxt/content'
 // frontmatter, no edits to the fleet-authored .md files). Unmapped slugs fall
 // into "Other" — add them here as new components are documented.
 const COMPONENT_CATEGORY: Record<string, string> = {
-  // Form
   input: 'Form',
   textarea: 'Form',
   select: 'Form',
@@ -20,14 +19,12 @@ const COMPONENT_CATEGORY: Record<string, string> = {
   label: 'Form',
   rating: 'Form',
   form: 'Form',
-  // Navigation & Disclosure
   tabs: 'Navigation',
   accordion: 'Navigation',
   stepper: 'Navigation',
   collapsible: 'Navigation',
   pagination: 'Navigation',
   navigation: 'Navigation',
-  // Overlay
   modal: 'Overlay',
   dialog: 'Overlay',
   'alert-dialog': 'Overlay',
@@ -38,7 +35,6 @@ const COMPONENT_CATEGORY: Record<string, string> = {
   tooltip: 'Overlay',
   'dropdown-menu': 'Overlay',
   toast: 'Overlay',
-  // Data Display
   avatar: 'Data Display',
   'avatar-group': 'Data Display',
   alert: 'Data Display',
@@ -46,21 +42,18 @@ const COMPONENT_CATEGORY: Record<string, string> = {
   chip: 'Data Display',
   progress: 'Data Display',
   icon: 'Data Display',
-  // Layout
   'aspect-ratio': 'Layout',
   'scroll-view': 'Layout',
   separator: 'Layout',
   card: 'Layout',
   placeholder: 'Layout',
   skeleton: 'Layout',
-  // Gestures & Lists
   'swipe-action': 'Gestures & Lists',
   swiper: 'Gestures & Lists',
   sortable: 'Gestures & Lists',
   draggable: 'Gestures & Lists',
   feedlist: 'Gestures & Lists',
   'feed-list': 'Gestures & Lists',
-  // Dynamic Island
   island: 'Dynamic Island',
   'island-button': 'Dynamic Island',
   'island-group': 'Dynamic Island',

--- a/packages/cli/src/write-files.ts
+++ b/packages/cli/src/write-files.ts
@@ -35,7 +35,7 @@ export function destFor(file: RegistryFile, config: VyuiConfig, projectRoot: str
         case 'composables': return safeDestination(projectRoot, config.paths.composables, tail)
         case 'utils': return safeDestination(projectRoot, config.paths.utils, tail)
         case 'theme': return safeDestination(projectRoot, config.paths.theme, tail)
-        default: return safeDestination(projectRoot, config.paths.lib, target) // types.ts, plugin.ts
+        default: return safeDestination(projectRoot, config.paths.lib, target)
       }
     }
   }

--- a/packages/core/src/components/FeedList/FeedList.vue
+++ b/packages/core/src/components/FeedList/FeedList.vue
@@ -58,7 +58,6 @@ export interface FeedListProps<T = unknown> {
   /** Disable scrolling and refresh interactions. */
   disabled?: boolean
 
-  // Pull-to-refresh
   /**
    * Enable the rubber-band pull-to-refresh. Off → a bare `<list>`, no touch
    * handlers.
@@ -83,7 +82,6 @@ export interface FeedListProps<T = unknown> {
    */
   enableBounce?: boolean
 
-  // Load-more
   /** Enable load-more on scroll-to-lower. */
   enableLoadMore?: boolean
   /** Controlled loading-more state. Bind with `v-model:loadingMore`. */
@@ -424,8 +422,6 @@ function _onTouchEnd() {
   }
 }
 
-// BG callbacks.
-
 function _onPull(progress: number, releaseReady: boolean) {
   pullProgress.value = progress
   if (refreshing.value) return
@@ -450,8 +446,6 @@ function _onClosed() {
   setRefreshState('done')
   setRefreshState('idle')
 }
-
-// Helpers / public API.
 
 function keyFor(item: T, index: number): string {
   if (typeof props.itemKey === 'function') return props.itemKey(item, index)

--- a/packages/core/src/components/Pagination/utils.ts
+++ b/packages/core/src/components/Pagination/utils.ts
@@ -39,7 +39,6 @@ export function getRange(currentPage: number, pageCount: number, siblingCount: n
     const itemCount = totalPageNumbers - 2 // 2 stands for one ellipsis and either first or last page
 
     const showLeftEllipsis
-      // default condition
       = leftSiblingIndex > firstPageIndex + 2
       // if the current page is towards the end of the list
         && Math.abs(lastPageIndex - itemCount - firstPageIndex + 1) > 2
@@ -47,7 +46,6 @@ export function getRange(currentPage: number, pageCount: number, siblingCount: n
         && Math.abs(leftSiblingIndex - firstPageIndex) > 2
 
     const showRightEllipsis
-      // default condition
       = rightSiblingIndex < lastPageIndex - 2
       // if the current page is towards the start of the list
         && Math.abs(lastPageIndex - itemCount) > 2

--- a/packages/core/src/components/ScrollView/ScrollView.vue
+++ b/packages/core/src/components/ScrollView/ScrollView.vue
@@ -219,14 +219,12 @@ const containerIdRef = useMainThreadRef<string>(containerId.value)
 const upperWrapperIdRef = useMainThreadRef<string>(upperWrapperId.value)
 const lowerWrapperIdRef = useMainThreadRef<string>(lowerWrapperId.value)
 
-// Touch bookkeeping.
 const startTouch = useMainThreadRef<any>(null)
 const prevTouch = useMainThreadRef<any>(null)
 const startBouncingTouch = useMainThreadRef<any>(null)
 const startTouchBouncingDelta = useMainThreadRef<any>(0)
 const bouncingTouchStartPosition = useMainThreadRef<any>(0)
 
-// Scroll velocity tracking.
 const scrollVelocity = useMainThreadRef<number>(0)
 const prevScroll = useMainThreadRef<any>(null)
 
@@ -527,8 +525,6 @@ function _mtFlingBounce() {
   flingEndWithBouncingEnableFlag.current = true
 }
 
-// ── Public handler worklets (bound in the template) ──
-
 function _mtTouchStart(event: any) {
   'main thread'
   startTouch.current = event.touches
@@ -665,8 +661,6 @@ function _mtLowerDisexposure() {
   'main thread'
   toLower.current = false
 }
-
-// ── Native BG event forwards ──
 
 function onScrollToLower(event: unknown): void {
   emits('scrollToLower', event)

--- a/packages/core/src/components/Sheet/SheetContentImpl.vue
+++ b/packages/core/src/components/Sheet/SheetContentImpl.vue
@@ -132,7 +132,6 @@ const isDragEnabled = computed(() =>
   && (ctx.enableDragToClose.value || ctx.snapPoints.value.length > 1),
 )
 
-// ---- MT refs for drag state -------------------------------------------
 // All read/written only inside `'main thread'` worklets that fire on user
 // input. By that time, the `INIT_MT_REF` ops below have been flushed.
 const containerRef = useMainThreadRef<any>(null)
@@ -195,7 +194,6 @@ const posRef = useMainThreadRef<number>(0)
 // Position the active drag started from (drags can begin at any snap).
 const touchStartPosRef = useMainThreadRef<number>(0)
 
-// ---- Config sync BG → MT ----------------------------------------------
 // vue-lynx@0.4.0 silently drops BG-thread writes to `MainThreadRef.current`
 // (only the constructor's INIT_MT_REF transfers a value BG → MT), so these
 // syncs have to hop through `runOnMainThread`. That's safe here: watch
@@ -232,8 +230,6 @@ watch(ctx.dismissVelocity, (v) => { void runOnMainThread(_setDismissVelocity as 
 watch(ctx.duration, (v) => { void runOnMainThread(_setDurationMs as any)(v) })
 watch(snapPositionsPx, (v) => { void runOnMainThread(_setSnapPositions as any)(v) })
 watch(ctx.enableDragToClose, (v) => { void runOnMainThread(_setEnableDragToClose as any)(v) })
-
-// ---- Touch worklets ---------------------------------------------------
 
 function _setStyle(decl: Record<string, string>) {
   'main thread'

--- a/packages/core/src/components/Slider/SliderImplMTS.vue
+++ b/packages/core/src/components/Slider/SliderImplMTS.vue
@@ -41,7 +41,6 @@ const props = withDefaults(defineProps<SliderImplMTSProps>(), {
 const root = injectSliderRootContext()
 const orientation = injectSliderOrientationContext()
 
-// --- Track MT refs ----------------------------------------------------------
 const trackRef = useMainThreadRef<any>(null)
 
 // Track rect, refreshed on `layoutchange` and on first `touchstart`. Stored as
@@ -52,7 +51,6 @@ const rectYRef = useMainThreadRef<number>(0)
 const rectWRef = useMainThreadRef<number>(0)
 const rectHRef = useMainThreadRef<number>(0)
 
-// --- Orientation MT mirrors -------------------------------------------------
 // 0 = horizontal (read clientX, paint translateX), 1 = vertical.
 const axisRef = useMainThreadRef<0 | 1>(orientation.size === 'width' ? 0 : 1)
 const startEdgeRef = useMainThreadRef<StartEdgeCode>(encodeStartEdge(orientation.startEdge.value))
@@ -61,15 +59,10 @@ watch(() => orientation.startEdge.value, (v) => {
   startEdgeRef.current = encodeStartEdge(v)
 })
 
-// --- Drag state -------------------------------------------------------------
 const activeIndexRef = useMainThreadRef<number>(-1)
 // Snapshot of all thumb values at touchstart — used to compute each thumb's
 // stable BG-anchor position so paint deltas are relative to it.
 const startValuesRef = useMainThreadRef<number[]>([])
-
-// ---------------------------------------------------------------------------
-// Worklets
-// ---------------------------------------------------------------------------
 
 function _measureRect() {
   'main thread'

--- a/packages/core/src/components/Sortable/SortableItem.vue
+++ b/packages/core/src/components/Sortable/SortableItem.vue
@@ -31,7 +31,6 @@ defineSlots<{
 
 const ctx = injectSortableRootContext()
 
-// ── MT refs ────────────────────────────────────────────────────────────────
 const containerRef = useMainThreadRef<any>(null)
 const touchStartYRef = useMainThreadRef<number>(0)
 const touchStartTimeRef = useMainThreadRef<number>(0)
@@ -61,7 +60,6 @@ const timeQueueRef = useMainThreadRef<number[]>([])
 watch(() => props.index, (v) => { runOnMainThread(_syncIndexMT as any)(v) })
 watch(() => props.disabled, (v) => { runOnMainThread(_syncDisabledMT as any)(v) })
 
-// ── Registry handle (MT side) ──────────────────────────────────────────────
 // The handle (element + logical index) MUST be appended ON the main thread:
 // `ctx.itemHandlesMT` is a MainThreadRef and BG writes to it are dropped by
 // vue-lynx 0.4.0. The previous `onMounted` registration ran on the BG thread,
@@ -77,8 +75,6 @@ onBeforeUnmount(() => {
   runOnMainThread(_cancelActivation as any)()
   runOnMainThread(_unregisterMT as any)()
 })
-
-// ── Worklets ────────────────────────────────────────────────────────────────
 
 /**
  * Append this item to the MT registry. Bound to `main-thread-binduiappear` so
@@ -365,8 +361,6 @@ function _onTouchEnd() {
   ctx.draggingIndexMT.current = -1
   runOnBackground(_emitDragEnd as any)(startIdx, target)
 }
-
-// ── BG callbacks ───────────────────────────────────────────────────────────
 
 function _emitDragStart(idx: number) {
   ctx.notifyDragStart(idx)

--- a/packages/core/src/components/Sortable/SortableRoot.vue
+++ b/packages/core/src/components/Sortable/SortableRoot.vue
@@ -74,14 +74,12 @@ const itemHeight = computed(() => props.itemHeight)
 const disabled = computed(() => props.disabled)
 const draggingIndex = ref(-1)
 
-// ── MT-shared state ─────────────────────────────────────────────────────────
 const itemHandlesMT = useMainThreadRef<SortableItemHandle[]>([])
 const itemHeightMT = useMainThreadRef<number>(props.itemHeight)
 const disabledMT = useMainThreadRef<boolean>(props.disabled)
 const draggingIndexMT = useMainThreadRef<number>(-1)
 const longPressMsMT = useMainThreadRef<number>(props.longPressMs)
 
-// ── Autoscroll (MT) ─────────────────────────────────────────────────────────
 const rootRef = useMainThreadRef<any>(null)
 const scrollRefMT = useMainThreadRef<any>(null)
 const viewportTopMT = useMainThreadRef<number>(0)

--- a/packages/core/src/components/Sortable/sortableContext.ts
+++ b/packages/core/src/components/Sortable/sortableContext.ts
@@ -30,7 +30,6 @@ export interface SortableRootContext<T = unknown> {
   /** Currently lifted index (BG-side, drives slot `dragging` flag). -1 if none. */
   draggingIndex: Ref<number>
 
-  // ── MT-shared state ──────────────────────────────────────────────────────
   /** MT-shared registry of every mounted item's handle. */
   itemHandlesMT: MainThreadRef<SortableItemHandle[]>
   /** MT mirror of `itemHeight`. */
@@ -42,7 +41,6 @@ export interface SortableRootContext<T = unknown> {
   /** Long-press activation delay in ms. */
   longPressMsMT: MainThreadRef<number>
 
-  // ── Autoscroll (MT) ──────────────────────────────────────────────────────
   /** Scroll container element (the root view). null when not yet mounted. */
   scrollRefMT: MainThreadRef<{ scrollTop?: number, scrollHeight?: number, clientHeight?: number, scrollTo?(o: { top?: number, behavior?: string }): void } | null>
   /** Viewport top in page coords, px. Measured on mount. */

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -224,7 +224,6 @@ export const components = {
     'ToggleGroupItem',
   ] as const,
 
-  // Utility components
   configProvider: [
     'ConfigProvider',
   ] as const,

--- a/packages/core/src/date/calendar.ts
+++ b/packages/core/src/date/calendar.ts
@@ -229,7 +229,6 @@ export function createYearRange({ start, end }: DateRange): DateValue[] {
 
   while (current.compare(end) <= 0) {
     years.push(current)
-    // Move to the first day of the next year
     current = startOfYear(current.add({ years: 1 }))
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,7 +4,6 @@
 // Swiper, SwipeAction, Draggable, Sortable, ScrollView, FeedList,
 // LazyComponent).
 
-// Overlay infrastructure
 export * from './components/OverlayRoot'
 
 // Overlays + menus (tap-driven; work on Lynx native)
@@ -15,7 +14,6 @@ export * from './components/Popover'
 export * from './components/Select'
 export * from './components/Sheet'
 
-// Form controls
 export * from './components/Combobox'
 
 // vyui originals
@@ -52,7 +50,6 @@ export * from './components/ToggleGroup'
 // Screen-stack navigation (push/pop pages, iOS / Material style)
 export * from './components/Navigation'
 
-// MT-worklet-driven touch/drag family
 export * from './components/Draggable'
 export * from './components/FeedList'
 export * from './components/LazyComponent'
@@ -62,7 +59,6 @@ export * from './components/Sortable'
 export * from './components/SwipeAction'
 export * from './components/Swiper'
 
-// Component / utility registry
 export {
   type Components,
   components,
@@ -79,7 +75,6 @@ export * from './shared/composables'
 // component formats dates / numbers.
 export { installIntlPolyfill } from './shared/intl'
 
-// Shared utilities
 export {
   createContext,
   isNullish,

--- a/packages/core/src/shared/color/index.ts
+++ b/packages/core/src/shared/color/index.ts
@@ -1,7 +1,5 @@
-// Channel operations
 export { getChannelName, getChannelRange, getChannelValue, setChannelValue, setChannelValues } from './channel'
 
-// Conversion
 export {
   colorToHex,
   colorToHsb,
@@ -13,13 +11,10 @@ export {
   convertToRgb,
 } from './convert'
 
-// Gradients
 export { getAreaBackgroundStyle, getAreaGradient, getSliderBackgroundStyle, getSliderGradient } from './gradient'
 
-// Parsing
 export { isValidColor, normalizeColor, parseColor } from './parse'
 
-// Types
 export type {
   ChannelRange,
   Color,

--- a/packages/core/src/shared/useForwardExpose.ts
+++ b/packages/core/src/shared/useForwardExpose.ts
@@ -35,7 +35,6 @@ export function useForwardExpose<T extends ComponentPublicInstance>() {
   const localExpose: Record<string, any> | null = Object.assign({}, instance.exposed)
   const ret: Record<string, any> = {}
 
-  // retrieve props for current instance
   for (const key in instance.props) {
     Object.defineProperty(ret, key, {
       enumerable: true,
@@ -44,7 +43,6 @@ export function useForwardExpose<T extends ComponentPublicInstance>() {
     })
   }
 
-  // retrieve default exposed value
   if (Object.keys(localExpose).length > 0) {
     for (const key in localExpose) {
       Object.defineProperty(ret, key, {
@@ -55,7 +53,6 @@ export function useForwardExpose<T extends ComponentPublicInstance>() {
     }
   }
 
-  // retrieve original first root element
   Object.defineProperty(ret, '$el', {
     enumerable: true,
     configurable: true,
@@ -69,7 +66,6 @@ export function useForwardExpose<T extends ComponentPublicInstance>() {
     if (!ref)
       return
 
-    // retrieve the forwarded element
     Object.defineProperty(ret, '$el', {
       enumerable: true,
       configurable: true,

--- a/packages/core/src/shared/useForwardProps.ts
+++ b/packages/core/src/shared/useForwardProps.ts
@@ -26,7 +26,6 @@ type WithOptionalBooleans<T> = {
  */
 export function useForwardProps<T extends Record<string, any>>(props: MaybeRefOrGetter<T>) {
   const vm = getCurrentInstance()
-  // Default value for declared props
   const defaultProps = Object.keys(vm?.type.props ?? {}).reduce((prev, curr) => {
     const defaultValue = (vm?.type.props[curr] as PropOptions).default
     if (defaultValue !== undefined)
@@ -43,7 +42,6 @@ export function useForwardProps<T extends Record<string, any>>(props: MaybeRefOr
       preservedProps[camelize(key) as keyof T] = assignedProps[key]
     })
 
-    // Only return value from the props parameter
     return Object.keys({ ...defaultProps, ...preservedProps }).reduce((prev, curr) => {
       if (refProps.value[curr] !== undefined)
         (prev as Record<string, any>)[curr] = refProps.value[curr]

--- a/packages/core/src/shared/useSelectionBehavior.ts
+++ b/packages/core/src/shared/useSelectionBehavior.ts
@@ -10,7 +10,6 @@ export function useSelectionBehavior<T>(
   const firstValue = ref()
 
   const onSelectItem = (val: T, condition: (existingValue: T) => boolean) => {
-    // multiple select
     if (props.multiple && Array.isArray(modelValue.value)) {
       if (props.selectionBehavior === 'replace') {
         modelValue.value = [val]
@@ -24,7 +23,6 @@ export function useSelectionBehavior<T>(
           modelValue.value = [...modelValue.value, val]
       }
     }
-    // single select
     else {
       if (props.selectionBehavior === 'replace') {
         modelValue.value = { ...val }

--- a/packages/core/src/shared/useSingleOrMultipleValue.ts
+++ b/packages/core/src/shared/useSingleOrMultipleValue.ts
@@ -22,7 +22,7 @@ function validateProps({ type, defaultValue, modelValue }: SingleOrMultipleProps
   if (canTypeBeInferred)
     return Array.isArray(value) ? 'multiple' : 'single'
   else
-    return type ?? 'single' // always fallback to `single`
+    return type ?? 'single'
 }
 
 function getDefaultType({ type, defaultValue, modelValue }: SingleOrMultipleProps) {

--- a/packages/core/src/shared/utils/interpolation.ts
+++ b/packages/core/src/shared/utils/interpolation.ts
@@ -68,7 +68,6 @@ function isExtrapolate(value: string): value is Extrapolation {
 // if type is correct, converts it to ExtrapolationConfig
 function validateType(type: ExtrapolationType): RequiredExtrapolationConfig {
   'main thread'
-  // initialize extrapolationConfig with default extrapolation
   const extrapolationConfig: RequiredExtrapolationConfig = {
     extrapolateLeft: Extrapolation.EXTEND,
     extrapolateRight: Extrapolation.EXTEND,
@@ -90,7 +89,6 @@ function validateType(type: ExtrapolationType): RequiredExtrapolationConfig {
     return extrapolationConfig
   }
 
-  // otherwise type is extrapolation config object
   if (
     (type.extrapolateLeft && !isExtrapolate(type.extrapolateLeft))
     || (type.extrapolateRight && !isExtrapolate(type.extrapolateRight))

--- a/packages/core/src/shared/utils/interpolationJS.ts
+++ b/packages/core/src/shared/utils/interpolationJS.ts
@@ -77,7 +77,6 @@ function isExtrapolate(value: string): value is Extrapolation {
 // validates extrapolations type
 // if type is correct, converts it to ExtrapolationConfig
 function validateType(type: ExtrapolationType): RequiredExtrapolationConfig {
-  // initialize extrapolationConfig with default extrapolation
   const extrapolationConfig: RequiredExtrapolationConfig = {
     extrapolateLeft: Extrapolation.EXTEND,
     extrapolateRight: Extrapolation.EXTEND,
@@ -99,7 +98,6 @@ function validateType(type: ExtrapolationType): RequiredExtrapolationConfig {
     return extrapolationConfig
   }
 
-  // otherwise type is extrapolation config object
   if (
     (type.extrapolateLeft && !isExtrapolate(type.extrapolateLeft))
     || (type.extrapolateRight && !isExtrapolate(type.extrapolateRight))

--- a/packages/kit/src/index.ts
+++ b/packages/kit/src/index.ts
@@ -27,7 +27,6 @@ export {
   type VyuiColorRegistry,
 } from './theme/colors'
 
-// Component re-exports.
 export { default as Accordion, default as VyAccordion } from './components/Accordion.vue'
 export { default as ActionSheet, default as VyActionSheet } from './components/ActionSheet.vue'
 export { default as Alert, default as VyAlert } from './components/Alert.vue'

--- a/packages/kit/src/theme/index.ts
+++ b/packages/kit/src/theme/index.ts
@@ -1,4 +1,3 @@
-// Theme barrel.
 export { default as icons } from './icons'
 export { ALL_COLORS, COLORS, NEUTRAL, resolveColors, type Color, type VyuiColorRegistry } from './colors'
 

--- a/packages/kit/src/theme/select.ts
+++ b/packages/kit/src/theme/select.ts
@@ -107,7 +107,6 @@ export default (colors: Color[]) => ({
     // Resting border is neutral; the colored border is opt-in via `highlight`
     // (no focus state on Lynx).
     ...colors.map(color => ({ color, highlight: true, class: { base: `border border-${color}-500` } })),
-    // Loading spinner animation on icon slot.
     { loading: true, leading: true, class: { leadingIcon: 'animate-spin' } },
     { loading: true, leading: false, trailing: true, class: { trailingIcon: 'animate-spin' } },
     // Trigger icons default to neutral (dimmed), decoupled from `color`;

--- a/packages/testing-utils/src/setup.ts
+++ b/packages/testing-utils/src/setup.ts
@@ -24,8 +24,6 @@ const jsdom = new JSDOM('<!DOCTYPE html><html><body></body></html>')
 installLynxTestingEnv(globalThis as any, { window: jsdom.window as any })
 const lynxTestingEnv = (globalThis as any).lynxTestingEnv
 
-// --- Capture main-thread runtime fns ---
-
 lynxTestingEnv.switchToMainThread()
 
 // vue-lynx/main-thread references registerWorkletInternal at import time; stub it
@@ -44,8 +42,6 @@ const mainThreadFns = {
   updateGlobalProps: (globalThis as any).updateGlobalProps,
   registerWorkletInternal: (globalThis as any).registerWorkletInternal,
 }
-
-// --- Capture background-thread runtime fns ---
 
 lynxTestingEnv.switchToBackgroundThread()
 

--- a/tools/gen-registry.ts
+++ b/tools/gen-registry.ts
@@ -79,7 +79,6 @@ const STYLES: StyleDef[] = [
   },
 ]
 
-// ── version resolution ─────────────────────────────────────────────────────
 const kitPkg = JSON.parse(readFileSync(resolve(root, 'packages/kit/package.json'), 'utf8'))
 const corePkg = JSON.parse(readFileSync(resolve(root, 'packages/core/package.json'), 'utf8'))
 const VERSIONS: Record<string, string> = {
@@ -106,7 +105,6 @@ function toDep(spec: string): { name: string, range: string } | undefined {
   return { name, range }
 }
 
-// ── import parsing (AST-based) ──────────────────────────────────────────────
 const kebab = (s: string) => s.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
 
 interface FileEntry { path: string, target: string, type: string, content: string }
@@ -473,7 +471,6 @@ function generateStyle(style: StyleDef) {
   console.log(`[gen-registry] style "${style.name}"  components=${catalog.length}  init-files=${initFiles.length}`)
 }
 
-// ── generate ──────────────────────────────────────────────────────────────────
 await initLexer // es-module-lexer's wasm must be ready before parse()
 
 rmSync(outRoot, { recursive: true, force: true })

--- a/tools/make-component.ts
+++ b/tools/make-component.ts
@@ -14,7 +14,6 @@ const REPO_ROOT = path.resolve(__dirname, '..')
 const COMPONENTS_DIR = path.join(REPO_ROOT, 'packages/core/src/components')
 const BARREL_FILE = path.join(REPO_ROOT, 'packages/core/src/index.ts')
 
-// ---------- arg parsing ----------
 const args = process.argv.slice(2)
 const flags = new Set(args.filter(a => a.startsWith('--')))
 const positional = args.filter(a => !a.startsWith('--'))
@@ -37,7 +36,6 @@ if (fs.existsSync(targetDir)) {
   process.exit(1)
 }
 
-// ---------- templates ----------
 function rootSfc(n: string): string {
   return `<script lang="ts">
 import type { PrimitiveProps } from '@/components/Primitive'
@@ -135,7 +133,6 @@ describe('${n}', () => {
 `
 }
 
-// ---------- plan ----------
 const files: Array<{ rel: string; content: string }> = [
   { rel: `${name}/index.ts`, content: indexTs(name) },
   { rel: `${name}/${name}Root.vue`, content: rootSfc(name) },
@@ -145,7 +142,6 @@ const files: Array<{ rel: string; content: string }> = [
 
 const barrelLine = `export * from './components/${name}'\n`
 
-// ---------- execute ----------
 if (dryRun) {
   console.log(`[dry-run] would create:`)
   for (const f of files) console.log(`  ${path.join('packages/core/src/components', f.rel)}`)

--- a/tools/sync-playground.ts
+++ b/tools/sync-playground.ts
@@ -20,7 +20,6 @@ import { codeToHtml } from 'shiki'
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const playground = resolve(root, 'apps/examples/docs-playground')
 
-// 1. Web bundle -> docs public/
 const bundleSrc = resolve(playground, 'dist/main.web.bundle')
 const publicDir = resolve(root, 'apps/docs/public/playground')
 mkdirSync(publicDir, { recursive: true })
@@ -39,7 +38,6 @@ const runtimeDir = resolve(root, 'apps/docs/public/lynx-runtime')
 rmSync(runtimeDir, { recursive: true, force: true })
 cpSync(runtimeSrc, runtimeDir, { recursive: true, force: true })
 
-// 3. Example sources -> generated manifest
 const examplesDir = resolve(playground, 'src/examples')
 
 const toKebab = (name: string) =>


### PR DESCRIPTION
Fans 5 parallel agents across the whole project (code files only) to remove reductive comments.

- Strips pure section-divider/banner comments and block labels that only restate the adjacent code
- Keeps everything load-bearing: JSDoc/TSDoc, why/rationale, Lynx + worklet (`'main thread'`) notes, directives (`@ts-expect-error`, `eslint-disable`), port provenance, magic-value annotations, issue refs, side-effect anchors
- 71 comments across 27 files; **no code, strings, or directives changed** (verified: every deleted line is a comment except two trailing-inline strips that keep their code)

A conservative first pass found only 1 removable comment — the source comments are genuinely deliberate — so this is the moderate tier (section dividers + condition-restating labels).

Note: touches `SheetContentImpl.vue` (banner labels only), which may trivially conflict with in-flight Sheet work.