### PR TITLE
docs: preview loading skeleton + expanded CLI guide

### DIFF
--- a/apps/docs/app/components/content/ComponentCode.vue
+++ b/apps/docs/app/components/content/ComponentCode.vue
@@ -55,8 +55,12 @@ const { copy, copied } = useClipboard({ source })
         </div>
       </div>
       <template #fallback>
-        <div class="flex items-center justify-center text-sm text-muted" :style="{ height }">
-          Loading Lynx preview…
+        <div class="preview-canvas">
+          <div class="relative z-[1] flex flex-col items-center justify-center gap-3" :style="{ height }" aria-hidden="true">
+            <div class="preview-skeleton h-9 w-40 rounded-full" />
+            <div class="preview-skeleton h-3 w-52 rounded-full" />
+            <div class="preview-skeleton h-3 w-36 rounded-full" />
+          </div>
         </div>
       </template>
     </ClientOnly>
@@ -103,5 +107,31 @@ const { copy, copied } = useClipboard({ source })
   margin: 0;
   padding: 1rem;
   white-space: pre;
+}
+
+/* Skeleton shown during hydration, mirroring LynxPreview's own boot skeleton. */
+.preview-skeleton {
+  position: relative;
+  overflow: hidden;
+  background: color-mix(in srgb, var(--ui-bg-elevated) 70%, var(--ui-bg));
+}
+.preview-skeleton::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    color-mix(in srgb, var(--ui-bg-elevated) 40%, transparent),
+    transparent
+  );
+  animation: preview-shimmer 1.4s ease-in-out infinite;
+}
+@keyframes preview-shimmer {
+  100% { transform: translateX(100%); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .preview-skeleton::after { animation: none; }
 }
 </style>

--- a/apps/docs/app/components/content/LynxPreview.vue
+++ b/apps/docs/app/components/content/LynxPreview.vue
@@ -14,10 +14,14 @@ const props = withDefaults(defineProps<{
 })
 
 const host = ref<HTMLElement>()
+const loading = ref(true)
 const failed = ref(false)
 const errorMessage = ref('')
 let lynxView: LynxViewElement | undefined
 let observer: IntersectionObserver | undefined
+// Safety net: if the card neither fires `load` nor `error` (e.g. an older
+// bundle), reveal it anyway so the skeleton can't linger forever.
+let revealTimer: ReturnType<typeof setTimeout> | undefined
 
 // Each <lynx-view> boots its own Web Worker + WASM runtime, so mounting every
 // preview on page load is expensive (a page can embed 6+). Defer the boot until
@@ -52,15 +56,23 @@ async function mountPreview() {
     }
     el.style.width = '100%'
     el.style.height = props.height
+    // web-core dispatches `load` once the card's first screen is painted — that's
+    // the cue to drop the skeleton and reveal the live preview.
+    el.addEventListener('load', () => {
+      loading.value = false
+    })
     el.addEventListener('error', (event) => {
       failed.value = true
+      loading.value = false
       const detail = (event as unknown as CustomEvent<{ error?: Error }>).detail
       errorMessage.value = detail?.error?.message || 'The Lynx web runtime could not load this example.'
     })
     host.value.appendChild(el)
+    revealTimer = setTimeout(() => { loading.value = false }, 8000)
   }
   catch (error) {
     failed.value = true
+    loading.value = false
     errorMessage.value = error instanceof Error ? error.message : 'The Lynx web runtime could not start.'
   }
 }
@@ -68,25 +80,69 @@ async function mountPreview() {
 onBeforeUnmount(() => {
   observer?.disconnect()
   observer = undefined
+  if (revealTimer) clearTimeout(revealTimer)
   lynxView?.remove()
   lynxView = undefined
 })
 </script>
 
 <template>
-  <div class="not-prose flex items-center justify-center w-full overflow-hidden">
+  <div class="not-prose relative flex items-center justify-center w-full overflow-hidden">
+    <div
+      ref="host"
+      class="w-full transition-opacity duration-300"
+      :class="{ 'opacity-0': loading || failed }"
+      :style="{ height }"
+    />
+
+    <!-- Placeholder while the Web Worker + WASM runtime boot and the card paints
+         its first screen. Overlaid on the (still-empty) host so layout is stable. -->
+    <div
+      v-if="loading"
+      class="absolute inset-0 flex flex-col items-center justify-center gap-3 p-6"
+      aria-hidden="true"
+    >
+      <div class="preview-skeleton h-9 w-40 rounded-full" />
+      <div class="preview-skeleton h-3 w-52 rounded-full" />
+      <div class="preview-skeleton h-3 w-36 rounded-full" />
+    </div>
+
     <div
       v-if="failed"
-      class="flex min-h-48 w-full flex-col items-center justify-center gap-2 px-6 py-8 text-center"
+      class="absolute inset-0 flex flex-col items-center justify-center gap-2 px-6 py-8 text-center"
     >
       <UIcon name="i-lucide-triangle-alert" class="size-5 text-warning" />
       <p class="text-sm font-medium text-highlighted">Live preview unavailable</p>
       <p class="max-w-md text-xs text-muted">{{ errorMessage }}</p>
     </div>
-    <div
-      ref="host"
-      class="w-full"
-      :style="{ height }"
-    />
   </div>
 </template>
+
+<style scoped>
+/* Shimmering skeleton bar: a muted surface swept by a soft highlight so the
+   deferred boot reads as "loading" rather than broken. */
+.preview-skeleton {
+  position: relative;
+  overflow: hidden;
+  background: color-mix(in srgb, var(--ui-bg-elevated) 70%, var(--ui-bg));
+}
+.preview-skeleton::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    color-mix(in srgb, var(--ui-bg-elevated) 40%, transparent),
+    transparent
+  );
+  animation: preview-shimmer 1.4s ease-in-out infinite;
+}
+@keyframes preview-shimmer {
+  100% { transform: translateX(100%); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .preview-skeleton::after { animation: none; }
+}
+</style>

--- a/apps/docs/content/3.cli/1.index.md
+++ b/apps/docs/content/3.cli/1.index.md
@@ -7,6 +7,22 @@ navigation:
 
 The Vy UI CLI copies styled component source into your app, installs the shared dependencies it needs, and wires the local Vy UI plugin into your Vue-Lynx entry. Use it when you want shadcn-style ownership of component files instead of importing everything from `@vyui/kit`.
 
+## Two ways to use Vy UI
+
+- **Install `@vyui/kit`** — import `Vy*` components from the package. Upgrades arrive with `npm update`, and the source stays in `node_modules`. See [Installation](/getting-started/installation).
+- **Copy source with the CLI** — the components live in _your_ repo. You own and edit the files directly; there is no `@vyui/kit` runtime dependency for the components you add. This page covers this path.
+
+Both render identically. Reach for the CLI when you expect to restyle or fork components, want to read the source inline, or prefer to vendor UI code rather than track a dependency.
+
+## How it works
+
+The CLI is a thin client over a **registry** — a set of JSON files (hosted at `https://vyui.dev/r` by default) that describe each component: its source files, the npm packages it needs, and the other registry components it depends on.
+
+1. **`init`** detects your project (package manager, app entry, Tailwind config, path aliases), writes `vyui.config.json`, and copies the shared library (`utils`, `theme`, composables) plus the plugin wiring into the paths you choose.
+2. **`add <name>`** fetches a component from the registry, resolves its registry dependencies (e.g. `select` pulls in the primitives it builds on), installs any npm packages, and writes the source into your project.
+3. **Imports are rewritten** as files are written: registry-internal specifiers like `@@vyui:components/*` become the aliases in your `vyui.config.json`, so the copied code resolves against your own directory layout.
+4. **You own the result** — added components are plain source files. Re-running `add` preserves them by default (pass `--overwrite` to refresh), and the shared library and transitive dependencies are never silently overwritten.
+
 ## Quick start
 
 Run `init` from the root of a Vue-Lynx project.
@@ -50,6 +66,30 @@ npx @vyui/cli add accordion
 ::
 
 Each installable component page also shows its CLI command near the top of the page.
+
+## What `init` sets up
+
+`init` copies the shared library into the paths from your config and wires Vy UI into the app. A typical layout:
+
+```
+src/
+├─ components/vyui/     # components you add land here
+└─ lib/vyui/
+   ├─ theme/            # Tailwind Variants theme, colors + icons
+   ├─ composables/      # app config, icons, styled-component helpers
+   ├─ utils/            # resolveColor + tv() helpers
+   ├─ plugin.ts         # the local Vy UI plugin
+   └─ types.ts
+```
+
+Alongside the files, `init` also:
+
+- registers the local Vy UI plugin in your app entry (`src/index.ts` / `src/main.ts`),
+- adds the Vy UI Tailwind preset and `ui-*` state wiring to your Tailwind config,
+- pulls the theme tokens into your global CSS,
+- installs the shared runtime dependencies.
+
+Anything it can't confirm — a non-standard entry, a missing Tailwind config — is printed as a manual step instead of being guessed. Use `--dry-run` to preview every file and edit first, and `info` afterwards to confirm what was detected.
 
 ## Commands
 


### PR DESCRIPTION
Two docs-only improvements to the playground previews and the CLI page.

- LynxPreview: show a shimmering skeleton while the Web Worker/WASM runtime boots, revealed on the `lynx-view` `load` event (with an 8s safety fallback and the existing error path).
- ComponentCode: hydration fallback now uses the same skeleton on the grid canvas instead of the "Loading Lynx preview…" text.
- CLI docs: add "Two ways to use Vy UI", "How it works" (registry model), and "What `init` sets up" (project-structure tree, verified against `init.json`).

No package changes — docs app only, so nothing to version.