### PR TITLE
chore(release): Tray as patch bump (kit 0.1.1)

### DIFF
--- a/.changeset/morphing-tray.md
+++ b/.changeset/morphing-tray.md
@@ -1,5 +1,5 @@
 ---
-"@vyui/kit": minor
+"@vyui/kit": patch
 "@vyui/core": patch
 ---
 


### PR DESCRIPTION
Flips the merged Tray changeset from `@vyui/kit: minor` to `patch` so the release stays on the 0.1.x line.

- `@vyui/kit`: `minor` → `patch` (0.1.0 → **0.1.1**, was 0.2.0)
- `@vyui/core`: unchanged patch (→ 0.1.1)

Nothing is published yet — the Changesets "Version Packages" PR (#104) will regenerate to 0.1.1 once this merges. Merge this first, then merge #104 to publish.