### PR TITLE
fix(patches): follow VyUI packages in vue-lynx MT loader

### DIFF
--- a/docs/upstream/vue-lynx-mt-worklet-import-issue.md
+++ b/docs/upstream/vue-lynx-mt-worklet-import-issue.md
@@ -45,7 +45,7 @@
 ## Impact
 
 - **Breaks aliased imports (near-universal pattern):** Any shared composable or module that defines `'main thread'` worklets and is consumed via `@/`/tsconfig path aliases — the standard project convention — silently fails at runtime with a confusing low-level error that is far from the root cause.
-- **Blocks published component libraries entirely:** A package consumed via a bare specifier (e.g. `@vyui/core`) cannot ship MT worklets to consumers, because the consumer's MT loader skips all imports into that package. There is no viable workaround for real consumers; a relative side-effect import pointing into `node_modules` is not a publishable solution.
+- **Blocks published component libraries entirely:** A package consumed via a bare specifier (e.g. `@vyui/core`) cannot ship MT worklets to consumers, because the consumer's MT loader skips all imports into that package. A fully general solution needs upstream package traversal / allowlisting. VyUI currently carries a narrow local patch that follows only `@/…` plus `@vyui/core` / `@vyui/kit` imports; it is a stopgap for VyUI consumers, not a general npm-package traversal policy.
 
 ---
 

--- a/patches/README.md
+++ b/patches/README.md
@@ -3,9 +3,9 @@
 pnpm-native patches applied via `pnpm.patchedDependencies` (declared in the root
 `pnpm-workspace.yaml`, since pnpm 11 reads that key from the workspace file).
 
-## `vue-lynx@0.4.0.patch` — follow `@/…` alias imports in the MT worklet loader
+## `vue-lynx@0.4.0.patch` — follow VyUI worklet imports in the MT loader
 
-**Status:** Tier-1 stopgap. Remove when the upstream fix lands.
+**Status:** Local stopgap. Remove when the upstream fix lands.
 
 **Upstream issue:** `docs/upstream/vue-lynx-mt-worklet-import-issue.md`
 
@@ -20,28 +20,37 @@ const fromRe = /from\s+['"](\.[^'"]+)['"]/g;
 const bareRe = /import\s+['"](\.[^'"]+)['"]/g;
 ```
 
-So worklets imported through an `@/…` path alias were never re-emitted into the
-MT graph and never registered (runtime `TypeError: cannot read property 'bind'
-of undefined`). The patch broadens **both** regexes to also follow `@/…` (and
-nothing else — broadening to all bare specifiers would pull npm deps into the MT
-graph):
+So worklets imported through an `@/…` path alias, or through published
+`@vyui/core` / `@vyui/kit` package imports, were never re-emitted into the MT
+graph and never registered (runtime `TypeError: cannot read property 'bind'
+of undefined`). The patch broadens **both** regexes to also follow:
+
+- relative imports (`./…` / `../…`) — unchanged upstream behavior
+- project aliases under `@/…`
+- the known worklet-bearing VyUI packages: `@vyui/core`, `@vyui/kit`, and their
+  subpaths
+
+It deliberately does **not** follow every bare npm specifier. Pulling arbitrary
+dependencies into the MT graph is the upstream Tier-2 policy question; this
+local patch only unblocks VyUI packages.
 
 ```js
-const fromRe = /from\s+['"]((?:\.|@\/)[^'"]+)['"]/g;
-const bareRe = /import\s+['"]((?:\.|@\/)[^'"]+)['"]/g;
+const fromRe = /from\s+['"](\.[^'"]+|@\/[^'"]+|@vyui\/(?:core|kit)(?:\/[^'"]*)?)['"]/g;
+const bareRe = /import\s+['"](\.[^'"]+|@\/[^'"]+|@vyui\/(?:core|kit)(?:\/[^'"]*)?)['"]/g;
 ```
 
-The re-emitted `import '@/…';` is resolved by the project's existing `@` alias,
-so the module enters the MT graph and its `registerWorkletInternal` calls land.
+The re-emitted imports are resolved by the consumer bundler. For `@/…`, that
+uses the project's existing alias. For `@vyui/core` / `@vyui/kit`, it pulls the
+published package module into the MT bundle so the precompiled
+`registerWorkletInternal` calls in `@vyui/core/dist` can run.
 
 The patched file also carries a `[vyui local patch — REMOVE WHEN UPSTREAM FIXED]`
 banner comment at the top, so the change is self-documenting in the diff.
 
 ### Verifying it works
 
-1. Ensure a worklet composable is imported via the alias, e.g. in
-   `packages/core/src/components/Swiper/SwiperRoot.vue`:
-   `import { useDragGesture } from '@/shared/gesture/useDragGesture'`
+1. Ensure a worklet-bearing path is imported through either the source alias
+   (`@/…`) or published package imports (`@vyui/kit` / `@vyui/core`).
 2. `pnpm --filter @vyui/kit-demo build`
 3. Audit the MT bundle for referenced-but-unregistered worklets, from
    `apps/examples/kit-demo/dist`:
@@ -55,8 +64,7 @@ banner comment at the top, so the change is self-documenting in the diff.
    console.log("registered:",reg.size,"referenced:",refs.size,"UNRESOLVED:",un.length,un.slice(0,20));
    '
    ```
-   PASS = `UNRESOLVED: 0`. Without the patch this build reports 7 unresolved
-   (the gesture worklets); with the patch + alias import it is 0.
+   PASS = `UNRESOLVED: 0`.
 
 ### Undo (when upstream is fixed)
 

--- a/patches/vue-lynx@0.4.0.patch
+++ b/patches/vue-lynx@0.4.0.patch
@@ -2,28 +2,29 @@ diff --git a/plugin/dist/loaders/worklet-loader-mt.js b/plugin/dist/loaders/work
 index 2201679cff292214a49d6db18cc00627f31431a6..049a6456f82a9c0c1b39006528926a1ea8b6454f 100644
 --- a/plugin/dist/loaders/worklet-loader-mt.js
 +++ b/plugin/dist/loaders/worklet-loader-mt.js
-@@ -1,7 +1,14 @@
+@@ -1,7 +1,15 @@
 +// [vyui local patch — REMOVE WHEN UPSTREAM FIXED]
 +// vue-lynx's MT worklet loader only followed relative imports, so '@/…'
-+// alias-imported worklets never registered on MT (TypeError: cannot read
-+// property 'bind' of undefined). This widens extractLocalImports to also
-+// follow '@/…'. Track: docs/upstream/vue-lynx-mt-worklet-import-issue.md.
++// alias-imported worklets and published @vyui/core/@vyui/kit package imports
++// never reached the MT graph (TypeError: cannot read property 'bind' of
++// undefined). This widens extractLocalImports to follow those known-safe
++// edges. Track: docs/upstream/vue-lynx-mt-worklet-import-issue.md.
 +// To undo: delete patches/vue-lynx@0.4.0.patch + its pnpm.patchedDependencies
 +// entry in the root package.json, then `pnpm install`.
  import * as __WEBPACK_EXTERNAL_MODULE__lynx_js_react_transform_7b1e07c1__ from "@lynx-js/react/transform";
  function extractLocalImports(source) {
      const specifiers = new Set();
 -    const fromRe = /from\s+['"](\.[^'"]+)['"]/g;
-+    const fromRe = /from\s+['"]((?:\.|@\/)[^'"]+)['"]/g;
++    const fromRe = /from\s+['"](\.[^'"]+|@\/[^'"]+|@vyui\/(?:core|kit)(?:\/[^'"]*)?)['"]/g;
      let match;
      while(null !== (match = fromRe.exec(source))){
          const lineStart = source.lastIndexOf('\n', match.index) + 1;
-@@ -10,7 +17,7 @@ function extractLocalImports(source) {
+@@ -10,7 +18,7 @@ function extractLocalImports(source) {
          if (/with\s*\{/.test(line)) continue;
          specifiers.add(match[1]);
      }
 -    const bareRe = /import\s+['"](\.[^'"]+)['"]/g;
-+    const bareRe = /import\s+['"]((?:\.|@\/)[^'"]+)['"]/g;
++    const bareRe = /import\s+['"](\.[^'"]+|@\/[^'"]+|@vyui\/(?:core|kit)(?:\/[^'"]*)?)['"]/g;
      while(null !== (match = bareRe.exec(source)))specifiers.add(match[1]);
      if (0 === specifiers.size) return '';
      return [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  vue-lynx@0.4.0: 69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993
+  vue-lynx@0.4.0: 0d09250f7c1381bb9ec8c228d2ebb0bbb240546f41260c000bb9b5cb59df477b
 
 importers:
 
@@ -134,7 +134,7 @@ importers:
         version: 0.3.1(tailwindcss@3.4.19(tsx@4.22.3)(yaml@2.9.0))
       vue-lynx:
         specifier: ^0.4.0
-        version: 0.4.0(patch_hash=69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15))
+        version: 0.4.0(patch_hash=0d09250f7c1381bb9ec8c228d2ebb0bbb240546f41260c000bb9b5cb59df477b)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15))
     devDependencies:
       '@iconify-json/lucide':
         specifier: ^1.2.108
@@ -180,7 +180,7 @@ importers:
         version: link:../../../packages/kit
       vue-lynx:
         specifier: ^0.4.0
-        version: 0.4.0(patch_hash=69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.14))
+        version: 0.4.0(patch_hash=0d09250f7c1381bb9ec8c228d2ebb0bbb240546f41260c000bb9b5cb59df477b)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.14))
     devDependencies:
       '@iconify-json/lucide':
         specifier: ^1.2.108
@@ -226,7 +226,7 @@ importers:
         version: link:../../../packages/kit
       vue-lynx:
         specifier: ^0.4.0
-        version: 0.4.0(patch_hash=69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.14))
+        version: 0.4.0(patch_hash=0d09250f7c1381bb9ec8c228d2ebb0bbb240546f41260c000bb9b5cb59df477b)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.14))
     devDependencies:
       '@iconify-json/icon-park-outline':
         specifier: ^1.2.0
@@ -275,7 +275,7 @@ importers:
         version: link:../../../packages/kit
       vue-lynx:
         specifier: ^0.4.0
-        version: 0.4.0(patch_hash=69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.14))
+        version: 0.4.0(patch_hash=0d09250f7c1381bb9ec8c228d2ebb0bbb240546f41260c000bb9b5cb59df477b)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.14))
     devDependencies:
       '@iconify-json/icon-park-outline':
         specifier: ^1.2.0
@@ -324,7 +324,7 @@ importers:
         version: link:../../../packages/core
       vue-lynx:
         specifier: ^0.4.0
-        version: 0.4.0(patch_hash=69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2)
+        version: 0.4.0(patch_hash=0d09250f7c1381bb9ec8c228d2ebb0bbb240546f41260c000bb9b5cb59df477b)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2)
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
@@ -352,7 +352,7 @@ importers:
         version: link:../../../packages/kit
       vue-lynx:
         specifier: ^0.4.0
-        version: 0.4.0(patch_hash=69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15))
+        version: 0.4.0(patch_hash=0d09250f7c1381bb9ec8c228d2ebb0bbb240546f41260c000bb9b5cb59df477b)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15))
     devDependencies:
       '@iconify-json/lucide':
         specifier: ^1.2.108
@@ -398,7 +398,7 @@ importers:
         version: link:../../../packages/kit
       vue-lynx:
         specifier: ^0.4.0
-        version: 0.4.0(patch_hash=69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.14))
+        version: 0.4.0(patch_hash=0d09250f7c1381bb9ec8c228d2ebb0bbb240546f41260c000bb9b5cb59df477b)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.14))
     devDependencies:
       '@iconify-json/icon-park-outline':
         specifier: ^1.2.0
@@ -453,7 +453,7 @@ importers:
         version: link:../../../packages/kit
       vue-lynx:
         specifier: ^0.4.0
-        version: 0.4.0(patch_hash=69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.14))
+        version: 0.4.0(patch_hash=0d09250f7c1381bb9ec8c228d2ebb0bbb240546f41260c000bb9b5cb59df477b)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.14))
     devDependencies:
       '@iconify-json/icon-park-outline':
         specifier: ^1.2.0
@@ -514,7 +514,7 @@ importers:
         version: 3.5.17(typescript@5.9.3)
       vue-lynx:
         specifier: ^0.4.0
-        version: 0.4.0(patch_hash=69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2)
+        version: 0.4.0(patch_hash=0d09250f7c1381bb9ec8c228d2ebb0bbb240546f41260c000bb9b5cb59df477b)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2)
       vue-tsc:
         specifier: 3.2.6
         version: 3.2.6(typescript@5.9.3)
@@ -632,7 +632,7 @@ importers:
         version: 3.5.34(typescript@5.9.3)
       vue-lynx:
         specifier: ^0.4.0
-        version: 0.4.0(patch_hash=69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)(lightningcss@1.32.0))
+        version: 0.4.0(patch_hash=0d09250f7c1381bb9ec8c228d2ebb0bbb240546f41260c000bb9b5cb59df477b)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)(lightningcss@1.32.0))
       vue-tsc:
         specifier: 3.2.6
         version: 3.2.6(typescript@5.9.3)
@@ -678,7 +678,7 @@ importers:
         version: 3.5.17(typescript@5.9.3)
       vue-lynx:
         specifier: ^0.4.0
-        version: 0.4.0(patch_hash=69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2)
+        version: 0.4.0(patch_hash=0d09250f7c1381bb9ec8c228d2ebb0bbb240546f41260c000bb9b5cb59df477b)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2)
       vue-tsc:
         specifier: 3.2.6
         version: 3.2.6(typescript@5.9.3)
@@ -705,7 +705,7 @@ importers:
         version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.4)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)
       vue-lynx:
         specifier: ^0.4.0
-        version: 0.4.0(patch_hash=69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(lightningcss@1.32.0))
+        version: 0.4.0(patch_hash=0d09250f7c1381bb9ec8c228d2ebb0bbb240546f41260c000bb9b5cb59df477b)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(lightningcss@1.32.0))
     devDependencies:
       '@types/jsdom':
         specifier: ^28.0.3
@@ -20746,7 +20746,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-lynx@0.4.0(patch_hash=69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.14)):
+  vue-lynx@0.4.0(patch_hash=0d09250f7c1381bb9ec8c228d2ebb0bbb240546f41260c000bb9b5cb59df477b)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.14)):
     dependencies:
       '@lynx-js/css-extract-webpack-plugin': 0.7.1(@lynx-js/template-webpack-plugin@0.10.9(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(webpack@5.106.2(postcss@8.5.14))
       '@lynx-js/react': 0.116.5(@lynx-js/types@3.8.0)(@types/react@18.3.28)
@@ -20763,7 +20763,7 @@ snapshots:
       - tslib
       - webpack
 
-  vue-lynx@0.4.0(patch_hash=69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15)):
+  vue-lynx@0.4.0(patch_hash=0d09250f7c1381bb9ec8c228d2ebb0bbb240546f41260c000bb9b5cb59df477b)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15)):
     dependencies:
       '@lynx-js/css-extract-webpack-plugin': 0.7.1(@lynx-js/template-webpack-plugin@0.10.9(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(webpack@5.106.2(postcss@8.5.15))
       '@lynx-js/react': 0.116.5(@lynx-js/types@3.8.0)(@types/react@18.3.28)
@@ -20780,7 +20780,7 @@ snapshots:
       - tslib
       - webpack
 
-  vue-lynx@0.4.0(patch_hash=69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2):
+  vue-lynx@0.4.0(patch_hash=0d09250f7c1381bb9ec8c228d2ebb0bbb240546f41260c000bb9b5cb59df477b)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2):
     dependencies:
       '@lynx-js/css-extract-webpack-plugin': 0.7.1(@lynx-js/template-webpack-plugin@0.10.9(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(webpack@5.106.2)
       '@lynx-js/react': 0.116.5(@lynx-js/types@3.8.0)(@types/react@18.3.28)
@@ -20797,7 +20797,7 @@ snapshots:
       - tslib
       - webpack
 
-  vue-lynx@0.4.0(patch_hash=69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)(lightningcss@1.32.0)):
+  vue-lynx@0.4.0(patch_hash=0d09250f7c1381bb9ec8c228d2ebb0bbb240546f41260c000bb9b5cb59df477b)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)(lightningcss@1.32.0)):
     dependencies:
       '@lynx-js/css-extract-webpack-plugin': 0.7.1(@lynx-js/template-webpack-plugin@0.10.9(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(webpack@5.106.2(esbuild@0.28.0)(lightningcss@1.32.0))
       '@lynx-js/react': 0.116.5(@lynx-js/types@3.8.0)(@types/react@18.3.28)
@@ -20814,7 +20814,7 @@ snapshots:
       - tslib
       - webpack
 
-  vue-lynx@0.4.0(patch_hash=69428be67bf3493456cf7cc5995604e1a8129500def9961eb23f9998cb371993)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(lightningcss@1.32.0)):
+  vue-lynx@0.4.0(patch_hash=0d09250f7c1381bb9ec8c228d2ebb0bbb240546f41260c000bb9b5cb59df477b)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.17)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(lightningcss@1.32.0)):
     dependencies:
       '@lynx-js/css-extract-webpack-plugin': 0.7.1(@lynx-js/template-webpack-plugin@0.10.9(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(webpack@5.106.2(lightningcss@1.32.0))
       '@lynx-js/react': 0.116.5(@lynx-js/types@3.8.0)(@types/react@18.3.28)


### PR DESCRIPTION
## Summary
- widen the local vue-lynx MT loader patch to follow @vyui/core and @vyui/kit package imports, not just @/ aliases
- refresh the pnpm patch hash
- document that this is a narrow local stopgap while upstream package traversal remains the permanent fix

## Verification
- pnpm install
- git diff --check
- node --input-type=module -e "import loader from './node_modules/.pnpm/node_modules/vue-lynx/plugin/dist/loaders/worklet-loader-mt.js'; const ctx={cacheable(){}, resourceQuery:'', resourcePath:'/tmp/app.ts', emitError(e){throw e}}; const out=loader.call(ctx, \"import { VyButton } from '@vyui/kit'; import { SwipeAction } from '@vyui/core'; import x from 'lodash'; import y from '@/x'; import z from './z'; export const v=1;\"); console.log(out);"