### PR TITLE
feat(cli): add vue-lynx patch command

### DIFF
--- a/.changeset/tidy-cameras-compete.md
+++ b/.changeset/tidy-cameras-compete.md
@@ -1,0 +1,5 @@
+---
+"@vyui/cli": patch
+---
+
+Add `patch-vue-lynx` to install the explicit pnpm compatibility patch for `vue-lynx@0.4.0` main-thread worklet import propagation.

--- a/apps/docs/content/3.cli/1.index.md
+++ b/apps/docs/content/3.cli/1.index.md
@@ -22,6 +22,7 @@ The CLI is a thin client over a **registry** — a set of JSON files (hosted at 
 2. **`add <name>`** fetches a component from the registry, resolves its registry dependencies (e.g. `select` pulls in the primitives it builds on), installs any npm packages, and writes the source into your project.
 3. **Imports are rewritten** as files are written: registry-internal specifiers like `@@vyui:components/*` become the aliases in your `vyui.config.json`, so the copied code resolves against your own directory layout.
 4. **You own the result** — added components are plain source files. Re-running `add` preserves them by default (pass `--overwrite` to refresh), and the shared library and transitive dependencies are never silently overwritten.
+5. **`patch-vue-lynx`** is an explicit compatibility command for pnpm projects affected by `vue-lynx@0.4.0` dropping aliased or package imports from the main-thread worklet graph.
 
 ## Quick start
 
@@ -161,6 +162,26 @@ List styles available from the configured registry.
 npx @vyui/cli styles
 ```
 
+### `patch-vue-lynx`
+
+Add the temporary `vue-lynx@0.4.0` main-thread worklet loader patch to a pnpm project.
+
+```bash
+pnpm dlx @vyui/cli patch-vue-lynx
+pnpm install
+```
+
+Use this when worklets imported through `@/…` aliases or published Vy UI packages are missing from the main-thread bundle and runtime handlers fail with `cannot read property 'bind' of undefined`. The command writes `patches/vue-lynx@0.4.0.patch` and adds:
+
+```yaml
+patchedDependencies:
+  vue-lynx@0.4.0: patches/vue-lynx@0.4.0.patch
+```
+
+to `pnpm-workspace.yaml`. It does not run install for you, so the follow-up `pnpm install` stays explicit and reviewable. The command is idempotent, supports `--dry-run`, and only replaces a different existing patch file when `--overwrite` is passed.
+
+Remove the patch file and the `patchedDependencies` entry once the upstream `vue-lynx` loader fix is released.
+
 ## Options
 
 | Option | Command | Description |
@@ -169,9 +190,9 @@ npx @vyui/cli styles
 | `--style <name>` | `init`, registry reads | Style name to use. |
 | `--base-color <name>` | `init` | Neutral palette. Supported values are `slate`, `gray`, `zinc`, `neutral`, and `stone`. |
 | `--all` | `add` | Add every component in the registry. |
-| `--overwrite` | `init`, `add` | Replace files that already exist. |
+| `--overwrite` | `init`, `add`, `patch-vue-lynx` | Replace files that already exist. |
 | `--skip-install` | `init`, `add` | Write files without installing npm dependencies. |
-| `--dry-run` | `init`, `add` | Preview files and project updates without writing. |
+| `--dry-run` | `init`, `add`, `patch-vue-lynx` | Preview files and project updates without writing. |
 | `--json` | `info` | Emit machine-readable project information. |
 | `-y`, `--yes` | all | Accept defaults and skip prompts. |
 | `--cwd <dir>` | all | Run against another directory. |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -27,6 +27,10 @@ npx @vyui/cli add toast --dry-run
 
 # List the styles offered by the registry
 npx @vyui/cli styles
+
+# Add the temporary vue-lynx main-thread worklet loader patch
+npx @vyui/cli patch-vue-lynx
+pnpm install
 ```
 
 `init` detects the app entry, Tailwind config, global CSS, import alias, and
@@ -163,3 +167,23 @@ The registry itself is generated from `@vyui/kit` source by
 For a standard Vue-Lynx project, no manual wiring is required. Run
 `npx @vyui/cli info` to see what was detected, then add components with
 `npx @vyui/cli add`.
+
+## Vue-Lynx main-thread worklet patch
+
+`vue-lynx@0.4.0` only follows relative imports while building the main-thread
+worklet graph. That can drop worklets imported through `@/…` aliases or from
+published VyUI packages, causing runtime `bind` errors when a main-thread
+handler is invoked.
+
+Run the explicit patch command in pnpm projects that hit this loader issue:
+
+```bash
+npx @vyui/cli patch-vue-lynx
+pnpm install
+```
+
+The command writes `patches/vue-lynx@0.4.0.patch` and adds the matching
+`patchedDependencies` entry to `pnpm-workspace.yaml`. It is idempotent, supports
+`--dry-run`, and requires `--overwrite` before replacing a different existing
+patch file. Remove the patch file and workspace entry once the upstream
+`vue-lynx` loader fix is available.

--- a/packages/cli/src/commands/patch-vue-lynx.test.ts
+++ b/packages/cli/src/commands/patch-vue-lynx.test.ts
@@ -1,0 +1,100 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { patchVueLynx } from './patch-vue-lynx.js'
+
+function projectDir(): string {
+  const cwd = mkdtempSync(join(tmpdir(), 'vyui-patch-vue-lynx-'))
+  writeFileSync(join(cwd, 'package.json'), JSON.stringify({
+    packageManager: 'pnpm@11.4.0',
+    dependencies: { 'vue-lynx': '^0.4.0' },
+  }))
+  return cwd
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('patchVueLynx', () => {
+  it('writes the vue-lynx patch and adds patchedDependencies to an existing workspace file', () => {
+    const cwd = projectDir()
+    writeFileSync(join(cwd, 'pnpm-workspace.yaml'), "packages:\n  - 'src/*'\n")
+    vi.spyOn(console, 'log').mockImplementation(() => undefined)
+
+    const result = patchVueLynx({ cwd })
+
+    expect(result.wrotePatch).toBe(true)
+    expect(result.wroteWorkspace).toBe(true)
+    expect(readFileSync(join(cwd, 'patches/vue-lynx@0.4.0.patch'), 'utf8')).toContain('worklet-loader-mt.js')
+    expect(readFileSync(join(cwd, 'pnpm-workspace.yaml'), 'utf8')).toBe(
+      "packages:\n  - 'src/*'\npatchedDependencies:\n  vue-lynx@0.4.0: patches/vue-lynx@0.4.0.patch\n",
+    )
+  })
+
+  it('creates a minimal pnpm-workspace.yaml when none exists', () => {
+    const cwd = projectDir()
+    writeFileSync(join(cwd, 'pnpm-lock.yaml'), '')
+    vi.spyOn(console, 'log').mockImplementation(() => undefined)
+
+    patchVueLynx({ cwd })
+
+    expect(readFileSync(join(cwd, 'pnpm-workspace.yaml'), 'utf8')).toBe(
+      "packages:\n  - '.'\npatchedDependencies:\n  vue-lynx@0.4.0: patches/vue-lynx@0.4.0.patch\n",
+    )
+  })
+
+  it('is idempotent once the patch is already configured', () => {
+    const cwd = projectDir()
+    writeFileSync(join(cwd, 'pnpm-workspace.yaml'), "packages:\n  - '.'\n")
+    vi.spyOn(console, 'log').mockImplementation(() => undefined)
+
+    patchVueLynx({ cwd })
+    const result = patchVueLynx({ cwd })
+
+    expect(result.wrotePatch).toBe(false)
+    expect(result.wroteWorkspace).toBe(false)
+  })
+
+  it('previews changes without writing files', () => {
+    const cwd = projectDir()
+    writeFileSync(join(cwd, 'pnpm-lock.yaml'), '')
+    vi.spyOn(console, 'log').mockImplementation(() => undefined)
+
+    const result = patchVueLynx({ cwd, dryRun: true })
+
+    expect(result.wrotePatch).toBe(true)
+    expect(result.wroteWorkspace).toBe(true)
+    expect(existsSync(join(cwd, 'patches/vue-lynx@0.4.0.patch'))).toBe(false)
+    expect(existsSync(join(cwd, 'pnpm-workspace.yaml'))).toBe(false)
+  })
+
+  it('refuses to replace a different patch unless overwrite is passed', () => {
+    const cwd = projectDir()
+    mkdirSync(join(cwd, 'patches'))
+    writeFileSync(join(cwd, 'patches/vue-lynx@0.4.0.patch'), 'local edits')
+    writeFileSync(join(cwd, 'pnpm-workspace.yaml'), "packages:\n  - '.'\n")
+    vi.spyOn(console, 'log').mockImplementation(() => undefined)
+
+    expect(() => patchVueLynx({ cwd })).toThrow(/already exists and differs/)
+
+    patchVueLynx({ cwd, overwrite: true })
+    expect(readFileSync(join(cwd, 'patches/vue-lynx@0.4.0.patch'), 'utf8')).toContain('extractLocalImports')
+  })
+
+  it('uses the pnpm workspace root when run from a package directory', () => {
+    const root = projectDir()
+    writeFileSync(join(root, 'pnpm-workspace.yaml'), "packages:\n  - 'packages/*'\n")
+    const packageDir = join(root, 'packages/app')
+    mkdirSync(packageDir, { recursive: true })
+    writeFileSync(join(packageDir, 'package.json'), JSON.stringify({ dependencies: { 'vue-lynx': '^0.4.0' } }))
+    vi.spyOn(console, 'log').mockImplementation(() => undefined)
+
+    const result = patchVueLynx({ cwd: packageDir })
+
+    expect(result.root).toBe(root)
+    expect(existsSync(join(root, 'patches/vue-lynx@0.4.0.patch'))).toBe(true)
+    expect(existsSync(join(packageDir, 'patches/vue-lynx@0.4.0.patch'))).toBe(false)
+  })
+})

--- a/packages/cli/src/commands/patch-vue-lynx.ts
+++ b/packages/cli/src/commands/patch-vue-lynx.ts
@@ -1,0 +1,139 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { detectPackageManager, log, c } from '../utils.js'
+
+const VUE_LYNX_VERSION = '0.4.0'
+const PATCH_PATH = `patches/vue-lynx@${VUE_LYNX_VERSION}.patch`
+const PATCH_ENTRY = `vue-lynx@${VUE_LYNX_VERSION}: ${PATCH_PATH}`
+
+const VUE_LYNX_PATCH = `diff --git a/plugin/dist/loaders/worklet-loader-mt.js b/plugin/dist/loaders/worklet-loader-mt.js
+index 2201679cff292214a49d6db18cc00627f31431a6..049a6456f82a9c0c1b39006528926a1ea8b6454f 100644
+--- a/plugin/dist/loaders/worklet-loader-mt.js
++++ b/plugin/dist/loaders/worklet-loader-mt.js
+@@ -1,7 +1,15 @@
++// [vyui local patch \u2014 REMOVE WHEN UPSTREAM FIXED]
++// vue-lynx's MT worklet loader only followed relative imports, so '@/\u2026'
++// alias-imported worklets and published @vyui/core/@vyui/kit package imports
++// never reached the MT graph (TypeError: cannot read property 'bind' of
++// undefined). This widens extractLocalImports to follow those known-safe
++// edges. Track: docs/upstream/vue-lynx-mt-worklet-import-issue.md.
++// To undo: delete patches/vue-lynx@0.4.0.patch + its pnpm.patchedDependencies
++// entry in the root package.json, then \`pnpm install\`.
+ import * as __WEBPACK_EXTERNAL_MODULE__lynx_js_react_transform_7b1e07c1__ from "@lynx-js/react/transform";
+ function extractLocalImports(source) {
+     const specifiers = new Set();
+-    const fromRe = /from\\s+['"](\\.[^'"]+)['"]/g;
++    const fromRe = /from\\s+['"](\\.[^'"]+|@\\/[^'"]+|@vyui\\/(?:core|kit)(?:\\/[^'"]*)?)['"]/g;
+     let match;
+     while(null !== (match = fromRe.exec(source))){
+         const lineStart = source.lastIndexOf('\\n', match.index) + 1;
+@@ -10,7 +18,7 @@ function extractLocalImports(source) {
+         if (/with\\s*\\{/.test(line)) continue;
+         specifiers.add(match[1]);
+     }
+-    const bareRe = /import\\s+['"](\\.[^'"]+)['"]/g;
++    const bareRe = /import\\s+['"](\\.[^'"]+|@\\/[^'"]+|@vyui\\/(?:core|kit)(?:\\/[^'"]*)?)['"]/g;
+     while(null !== (match = bareRe.exec(source)))specifiers.add(match[1]);
+     if (0 === specifiers.size) return '';
+     return [
+`
+
+export interface PatchVueLynxOptions {
+  cwd: string
+  dryRun?: boolean
+  overwrite?: boolean
+}
+
+export interface PatchVueLynxResult {
+  root: string
+  patchFile: string
+  workspaceFile: string
+  wrotePatch: boolean
+  wroteWorkspace: boolean
+}
+
+export function patchVueLynx(opts: PatchVueLynxOptions): PatchVueLynxResult {
+  const pm = detectPackageManager(opts.cwd)
+  if (pm !== 'pnpm') {
+    throw new Error(`patch-vue-lynx currently supports pnpm projects only; detected ${pm}.`)
+  }
+
+  const root = findPnpmRoot(opts.cwd)
+  const patchFile = join(root, PATCH_PATH)
+  const workspaceFile = join(root, 'pnpm-workspace.yaml')
+
+  const existingPatch = existsSync(patchFile) ? readFileSync(patchFile, 'utf8') : undefined
+  if (existingPatch !== undefined && existingPatch !== VUE_LYNX_PATCH && !opts.overwrite) {
+    throw new Error(`${PATCH_PATH} already exists and differs from the VyUI patch. Pass --overwrite to replace it.`)
+  }
+
+  const nextWorkspace = updateWorkspaceConfig(
+    existsSync(workspaceFile) ? readFileSync(workspaceFile, 'utf8') : undefined,
+  )
+  const currentWorkspace = existsSync(workspaceFile) ? readFileSync(workspaceFile, 'utf8') : undefined
+
+  const wrotePatch = existingPatch !== VUE_LYNX_PATCH
+  const wroteWorkspace = currentWorkspace !== nextWorkspace
+
+  if (opts.dryRun) {
+    log.step(`${wrotePatch ? 'write' : 'keep'} ${PATCH_PATH}`)
+    log.step(`${wroteWorkspace ? 'update' : 'keep'} pnpm-workspace.yaml`)
+    log.ok('Dry run complete. No files were changed.')
+    return { root, patchFile, workspaceFile, wrotePatch, wroteWorkspace }
+  }
+
+  if (wrotePatch) {
+    mkdirSync(dirname(patchFile), { recursive: true })
+    writeFileSync(patchFile, VUE_LYNX_PATCH)
+    log.ok(`Wrote ${c.cyan(PATCH_PATH)}`)
+  }
+  else {
+    log.ok(`${c.cyan(PATCH_PATH)} is already up to date`)
+  }
+
+  if (wroteWorkspace) {
+    writeFileSync(workspaceFile, nextWorkspace)
+    log.ok(`Updated ${c.cyan('pnpm-workspace.yaml')}`)
+  }
+  else {
+    log.ok(`${c.cyan('pnpm-workspace.yaml')} already contains ${c.cyan(PATCH_ENTRY)}`)
+  }
+
+  console.log(`
+  Apply the patch: ${c.cyan('pnpm install')}
+  Undo later: ${c.cyan(`delete ${PATCH_PATH} and remove ${PATCH_ENTRY} from pnpm-workspace.yaml`)}
+`)
+
+  return { root, patchFile, workspaceFile, wrotePatch, wroteWorkspace }
+}
+
+function findPnpmRoot(cwd: string): string {
+  let dir = cwd
+  for (;;) {
+    if (existsSync(join(dir, 'pnpm-workspace.yaml')) || existsSync(join(dir, 'pnpm-lock.yaml'))) return dir
+    const parent = dirname(dir)
+    if (parent === dir) return cwd
+    dir = parent
+  }
+}
+
+function updateWorkspaceConfig(current: string | undefined): string {
+  if (!current) {
+    return `packages:\n  - '.'\npatchedDependencies:\n  ${PATCH_ENTRY}\n`
+  }
+
+  const normalized = current.endsWith('\n') ? current : `${current}\n`
+  const existingEntry = new RegExp(`(^|\\n)\\s*vue-lynx@${escapeRegExp(VUE_LYNX_VERSION)}:\\s*.+(?:\\n|$)`)
+  if (existingEntry.test(normalized)) return normalized
+
+  const patchedDependencies = /^patchedDependencies:\s*$/m
+  if (patchedDependencies.test(normalized)) {
+    return normalized.replace(patchedDependencies, `patchedDependencies:\n  ${PATCH_ENTRY}`)
+  }
+
+  return `${normalized}patchedDependencies:\n  ${PATCH_ENTRY}\n`
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,7 @@ import { list } from './commands/list.js'
 import { view } from './commands/view.js'
 import { info } from './commands/info.js'
 import { styles } from './commands/styles.js'
+import { patchVueLynx } from './commands/patch-vue-lynx.js'
 import { c, log } from './utils.js'
 
 const HELP = `${c.bold('vyui')} — add @vyui/kit styled components to your project
@@ -18,6 +19,7 @@ ${c.bold('Usage')}
   vyui view <component...> [options]
   vyui info [options]
   vyui styles [options]
+  vyui patch-vue-lynx [options]
 
 ${c.bold('Commands')}
   init                 Set up vyui.config.json + shared library files
@@ -27,6 +29,7 @@ ${c.bold('Commands')}
   view <component...>  Print registry component source before installing
   info                 Show detected project and VyUI configuration
   styles               List the styles available in the registry
+  patch-vue-lynx       Add the temporary vue-lynx MT worklet loader patch
 
 ${c.bold('Options')}
   --registry <url>     Registry base URL (default https://vyui.dev/r)
@@ -101,6 +104,9 @@ async function main(): Promise<void> {
       break
     case 'styles':
       await styles({ cwd, registry: values.registry })
+      break
+    case 'patch-vue-lynx':
+      patchVueLynx({ cwd, overwrite: values.overwrite, dryRun: values['dry-run'] })
       break
     default:
       log.err(`Unknown command: ${command}`)


### PR DESCRIPTION
## Summary
- add `vyui patch-vue-lynx` to write the temporary `vue-lynx@0.4.0` MT worklet loader patch for pnpm projects
- update CLI README and docs with the explicit patch + `pnpm install` workflow
- add command coverage and a changeset for `@vyui/cli`

## Tests
- `./node_modules/.bin/tsc -p packages/cli/tsconfig.json --noEmit`
- `./packages/cli/node_modules/.bin/vitest run packages/cli/src`
- `./packages/cli/node_modules/.bin/tsup`
- `./node_modules/.bin/eslint packages/cli/src/index.ts packages/cli/src/commands/patch-vue-lynx.ts packages/cli/src/commands/patch-vue-lynx.test.ts`

Note: `pnpm --filter @vyui/cli test` and `pnpm --filter @vyui/cli typecheck` attempted an implicit pnpm install/dependency status check and aborted in the non-TTY shell, so I used the existing local package binaries instead.