### PR TITLE
fix(kit): layer sheet content above backdrop

### DIFF
--- a/.changeset/fix-kit-sheet-content-z-index.md
+++ b/.changeset/fix-kit-sheet-content-z-index.md
@@ -1,0 +1,6 @@
+---
+"@vyui/core": patch
+"@vyui/kit": patch
+---
+
+Ensure tray, drawer, and action sheet content renders above the sheet backdrop by default, and disable automatic capitalization and correction for kit email and password inputs.

--- a/packages/core/src/components/Input/Input.test.ts
+++ b/packages/core/src/components/Input/Input.test.ts
@@ -34,6 +34,17 @@ describe('Input — default render', () => {
     expect(el.getAttribute('maxlength')).toBe('32')
   })
 
+  it('forwards input capitalization and correction hints', () => {
+    const { container } = render(Input, {
+      autocapitalize: 'none',
+      autocorrect: 'off',
+      'data-testid': 'input',
+    })
+    const el = input(container)
+    expect(el.getAttribute('autocapitalize')).toBe('none')
+    expect(el.getAttribute('autocorrect')).toBe('off')
+  })
+
   it('renders disabled / readonly attrs and data-* mirrors', () => {
     const { container } = render(_Input, { disabled: true, readonly: true })
     const el = input(container)

--- a/packages/core/src/components/Input/Input.vue
+++ b/packages/core/src/components/Input/Input.vue
@@ -61,6 +61,10 @@ export interface InputProps extends PrimitiveProps {
   inputFilter?: string
   /** On-screen return-key label — see `InputConfirmType`. */
   confirmType?: InputConfirmType
+  /** Browser/native capitalization hint forwarded to the underlying input. */
+  autocapitalize?: string
+  /** Browser/native correction hint forwarded to the underlying input. */
+  autocorrect?: string
   /** When `false`, focus will not raise the software keyboard. */
   showSoftInputOnFocus?: boolean
 }
@@ -377,6 +381,8 @@ defineExpose<InputExposed>({
     :type="type"
     :input-filter="inputFilter"
     :confirm-type="confirmType"
+    :autocapitalize="autocapitalize"
+    :autocorrect="autocorrect"
     :show-soft-input-on-focus="showSoftInputOnFocus"
     ignore-focus
     accessibility-traits="keyboard"

--- a/packages/kit/src/components/Input.vue
+++ b/packages/kit/src/components/Input.vue
@@ -66,6 +66,10 @@ export interface InputProps {
   required?: boolean
   /** Forwarded to the underlying `<input>`. Defaults to `'off'`. */
   autocomplete?: string
+  /** Forwarded to the underlying `<input>`. Defaults to `'none'` for email and password inputs. */
+  autocapitalize?: string
+  /** Forwarded to the underlying `<input>`. Defaults to `'off'` for email and password inputs. */
+  autocorrect?: string
   /** Focus the input on mount (after `autofocusDelay` ms). */
   autofocus?: boolean
   /** Delay before applying `autofocus`, in milliseconds. */
@@ -137,6 +141,10 @@ const ui = computed(() => buildInput(appConfig)({
 // neutral (dimmed); override via the `leading` / `trailing` slots' `iconColor`.
 const iconColor = computed(() => resolveColorHex(appConfig, 'neutral', 400))
 
+const isAuthField = computed(() => props.type === 'email' || props.type === 'password')
+const resolvedAutocapitalize = computed(() => props.autocapitalize ?? (isAuthField.value ? 'none' : undefined))
+const resolvedAutocorrect = computed(() => props.autocorrect ?? (isAuthField.value ? 'off' : undefined))
+
 onMounted(() => {
   if (!props.autofocus) return
   if (props.autofocusDelay > 0) {
@@ -194,6 +202,8 @@ defineExpose({ inputRef })
         :name="name"
         :required="required"
         :autocomplete="autocomplete"
+        :autocapitalize="resolvedAutocapitalize"
+        :autocorrect="resolvedAutocorrect"
         :class="ui.base({ class: ['w-full', props.ui?.base] })"
         @update:model-value="$emit('update:modelValue', $event)"
         @confirm="$emit('confirm', $event)"

--- a/packages/kit/src/theme/actionSheet.ts
+++ b/packages/kit/src/theme/actionSheet.ts
@@ -25,7 +25,7 @@ const fgClass = (fg: { semantic: string, shade: number }) => `text-${fg.semantic
 export default (colors: Color[]) => ({
   slots: {
     overlay: 'fixed inset-0 bg-neutral-900/40',
-    content: 'flex flex-col max-h-[100vh] overflow-hidden',
+    content: 'z-[1001] flex flex-col max-h-[100vh] overflow-hidden',
     handle: 'self-center w-9 h-1 rounded-full bg-neutral-300 mt-1.5 mb-1',
     header: 'flex flex-col gap-0.5 px-4 py-2',
     title: 'text-neutral-500 text-xs font-semibold uppercase tracking-wider',

--- a/packages/kit/src/theme/drawer.ts
+++ b/packages/kit/src/theme/drawer.ts
@@ -16,7 +16,7 @@
 export default {
   slots: {
     overlay: 'fixed inset-0 bg-neutral-900/50',
-    content: 'fixed bg-white border border-neutral-200 flex overflow-hidden max-h-[100vh]',
+    content: 'fixed z-[1001] bg-white border border-neutral-200 flex overflow-hidden max-h-[100vh]',
     handle: 'self-center w-9 h-1 rounded-full bg-neutral-300 mt-1.5 mb-1',
     scaffold: 'flex flex-col flex-1 min-h-0',
     header: 'flex flex-row items-center gap-1.5 px-4 py-3 min-h-12',

--- a/packages/kit/src/theme/tray.ts
+++ b/packages/kit/src/theme/tray.ts
@@ -27,7 +27,7 @@ export default {
     // The sheet panel. `fitContent` on core SheetContent means no explicit
     // height — it hugs handle + morph + footer. `variant` supplies the
     // edge/inset + border + radius chrome below.
-    content: 'fixed flex flex-col overflow-hidden bg-white',
+    content: 'fixed z-[1001] flex flex-col overflow-hidden bg-white',
     // Drag pill (SheetContent's first child; core flex-direction pins it top).
     handle: 'self-center w-9 h-1 rounded-full bg-neutral-300 mt-1.5 mb-1',
     // Height-animated container. `overflow-hidden` clips the outgoing/incoming


### PR DESCRIPTION
## Summary
- add explicit z-[1001] to tray, drawer, and action sheet content slots
- ensure kit sheet panels render above the core SheetBackdrop zIndex: 1000
- forward autocapitalize/autocorrect through core Input
- default VyInput type="email" and type="password" to autocapitalize="none" and autocorrect="off" while leaving text inputs unchanged
- add a patch changeset for @vyui/core and @vyui/kit

## Verification
- pnpm --filter @vyui/core test -- src/components/Input/Input.test.ts
- pnpm --filter @vyui/core typecheck
- pnpm --filter @vyui/kit typecheck
- pnpm --filter @vyui/core lint
- pnpm --filter @vyui/kit lint