### PR TITLE
feat(kit): paint input focus ring while focused

### DIFF
--- a/.changeset/input-focus-ring.md
+++ b/.changeset/input-focus-ring.md
@@ -1,0 +1,5 @@
+---
+"@vyui/kit": patch
+---
+
+`VyInput` now paints its colored border plus a shadow-ring while focused (tracked in JS — Lynx has no `:focus-within`), instead of only via the static `highlight` prop. The ring is a flat arbitrary `box-shadow` (`0 0 0 2px var(--ui-color-{color}-200)`) because the Lynx preset has no `ring*`/`boxShadowColor` plugins; the per-color classes are safelisted in the Tailwind preset. `highlight` still forces the same treatment on permanently.

--- a/apps/docs/content/3.components/input.md
+++ b/apps/docs/content/3.components/input.md
@@ -69,7 +69,7 @@ Icon names only resolve after their Iconify set has been registered. See [`Icon`
 
 ### Variants and validation emphasis
 
-Use `highlight` to paint a static semantic border regardless of focus.
+The semantic border and shadow ring paint automatically while the input is focused. Use `highlight` to force them on permanently, for example for validation emphasis.
 
 ::component-code
 ---
@@ -266,7 +266,7 @@ The core instance provides `focus()`, `blur()`, `clear()`, `setValue(value)`, `g
 | `color` | `Color` | `'primary'` | Semantic border, highlight, and icon color. |
 | `variant` | `'outline' \| 'soft' \| 'subtle' \| 'ghost' \| 'none'` | `'outline'` | Surface treatment. |
 | `size` | `'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` | Padding, text, gap, and icon scale. |
-| `highlight` | `boolean` | `false` | Always paints a semantic border. |
+| `highlight` | `boolean` | `false` | Forces the semantic border and focus ring on permanently. |
 | `id` | `string` | `undefined` | Native identifier. |
 | `name` | `string` | `undefined` | Native field name. |
 | `required` | `boolean` | `false` | Native required marker. |
@@ -344,7 +344,7 @@ createApp(App)
 | `trailing` | Trailing adornment wrapper. |
 | `trailingIcon` | Trailing icon. |
 
-The theme combines `size`, `variant`, `color`, `highlight`, and internal leading, trailing, and loading states. `outline` and `subtle` use semantic borders, while `soft`, `ghost`, and `none` reduce or remove the border treatment.
+The theme combines `size`, `variant`, `color`, `highlight`, and internal leading, trailing, and loading states. `outline` and `subtle` use semantic borders, while `soft`, `ghost`, and `none` reduce or remove the border treatment. While focused, or when `highlight` is set, the root paints a semantic border plus a shadow ring in the active `color`.
 
 Because CSS inheritance is disabled in the Lynx build, typed-text and placeholder colors belong on `base`, while surface and border classes belong on `root`. The loading icon defaults to `appConfig.ui.icons.loading`; override that semantic icon globally or use `loadingIcon` per input.
 
@@ -362,6 +362,7 @@ Use `type="password"` for secret text, but do not assume the keyboard type valid
 - The normalized `keyboard` event comes from the focused native element and reports both keyboard height and safe-area bottom inset.
 - Use [`KeyboardAware`](/components/keyboard-aware) wrappers when the software keyboard may cover the field.
 - Software-keyboard layouts, autocomplete behavior, password masking, and return-key labels can differ across iOS, Android, and web.
+- Focus is tracked in JS because Lynx has no `:focus-within` and the border and ring live on the root wrapper, not the native input; the ring itself is a flat `box-shadow`.
 - Leading and trailing elements are flex siblings rather than absolute overlays because Lynx does not reliably layer them over a native text input.
 - Lynx SVG does not inherit `currentColor`, so built-in and custom icon slots receive an explicit resolved hex color.
 - The default theme is light-mode-only.

--- a/apps/examples/kit-demo/src/sections/FormSection.vue
+++ b/apps/examples/kit-demo/src/sections/FormSection.vue
@@ -19,6 +19,9 @@ import {
 } from '@vyui/kit'
 
 const name = ref('')
+const ringDefault = ref('')
+const ringError = ref('')
+const ringSoft = ref('')
 const bio = ref('')
 const wifiOn = ref(true)
 const bluetoothOn = ref(false)
@@ -142,6 +145,16 @@ function onFormSubmit(values: Record<string, unknown>) {
         leading-icon="icon-park-outline:user"
       />
       <text v-if="name" class="text-slate-500 text-xs pt-1">Hello, {{ name }}!</text>
+    </view>
+
+    <!-- Input focus ring -->
+    <view class="bg-white border border-slate-200 rounded-lg p-4 flex flex-col gap-2">
+      <text class="text-slate-900 text-base font-semibold">Input focus ring</text>
+      <text class="text-slate-500 text-xs">Tap an input — colored border + shadow ring should follow focus, and drop on blur.</text>
+      <VyInput v-model="ringDefault" placeholder="color=primary (default)" />
+      <VyInput v-model="ringError" color="error" placeholder="color=error" />
+      <VyInput v-model="ringSoft" variant="soft" placeholder="variant=soft (borderless at rest)" />
+      <VyInput highlight placeholder="highlight (static ring, no focus needed)" />
     </view>
 
     <!-- Textarea -->

--- a/packages/kit/src/components/Input.vue
+++ b/packages/kit/src/components/Input.vue
@@ -56,7 +56,7 @@ export interface InputProps {
   color?: InputVariants['color']
   variant?: InputVariants['variant']
   size?: InputVariants['size']
-  /** Paints a static ring matching `color`, ignoring focus state. */
+  /** Forces the colored ring on permanently; by default it paints while focused. */
   highlight?: boolean
   /** Forwarded to the underlying `<input>`. */
   id?: string
@@ -100,7 +100,7 @@ const props = withDefaults(defineProps<InputProps>(), {
   autocomplete: 'off',
   autofocusDelay: 0,
 })
-defineEmits(['update:modelValue', 'confirm', 'focus', 'blur', 'keyboard'])
+const emit = defineEmits(['update:modelValue', 'confirm', 'focus', 'blur', 'keyboard'])
 defineSlots<InputSlots>()
 
 const slots = useSlots()
@@ -127,12 +127,25 @@ const resolvedTrailingIcon = computed(() => {
 const hasLeading = computed(() => !!slots.leading || !!resolvedLeadingIcon.value || !!props.avatar || !!props.loading)
 const hasTrailing = computed(() => !!slots.trailing || !!resolvedTrailingIcon.value)
 
+// Lynx has no `:focus-within`, and the border/ring chrome lives on the root
+// <view>, not the <input> — track focus in JS and drive the `highlight`
+// variant so the colored border + shadow ring follows focus.
+const isFocused = ref(false)
+function onFocus(event: unknown) {
+  isFocused.value = true
+  emit('focus', event)
+}
+function onBlur(event: unknown) {
+  isFocused.value = false
+  emit('blur', event)
+}
+
 const ui = computed(() => buildInput(appConfig)({
   color: props.color,
   variant: props.variant,
   size: props.size,
   loading: props.loading,
-  highlight: props.highlight,
+  highlight: props.highlight || isFocused.value,
   leading: hasLeading.value,
   trailing: hasTrailing.value,
 }))
@@ -207,8 +220,8 @@ defineExpose({ inputRef })
         :class="ui.base({ class: ['w-full', props.ui?.base] })"
         @update:model-value="$emit('update:modelValue', $event)"
         @confirm="$emit('confirm', $event)"
-        @focus="$emit('focus', $event)"
-        @blur="$emit('blur', $event)"
+        @focus="onFocus"
+        @blur="onBlur"
         @keyboard="$emit('keyboard', $event)"
       />
     </view>

--- a/packages/kit/src/tailwind.js
+++ b/packages/kit/src/tailwind.js
@@ -185,6 +185,10 @@ export function createVyuiPreset(options = {}) {
           'group-data-[state=checked]',
         ],
       },
+      // Focus/highlight ring — generated as a template literal in
+      // `theme/input.ts`; arbitrary values can't be expressed in the regex
+      // pattern above, so safelist the exact strings (keep in sync).
+      ...allColors.map((c) => `shadow-[0_0_0_2px_var(--ui-color-${c}-200)]`),
       'text-white',
     ],
   }

--- a/packages/kit/src/theme/input.ts
+++ b/packages/kit/src/theme/input.ts
@@ -2,8 +2,9 @@
 // (`border-primary-500`) which Tailwind resolves via CSS variables defined in
 // the consuming app — see `apps/examples/kit-demo/src/index.css`.
 //
-// Lynx adaptation: `ring-*` → `border-*` (no ringWidth plugin in
-// `@lynx-js/tailwind-preset`), `inline-flex` → `flex` (Lynx strips
+// Lynx adaptation: `ring-*` → `border-*` + a flat arbitrary `box-shadow`
+// focus ring (no ringWidth plugin in `@lynx-js/tailwind-preset` — see
+// compoundVariants), `inline-flex` → `flex` (Lynx strips
 // inline-flex), and — most importantly — leading / trailing slots are
 // **inline siblings** of the underlying `<input>` rather than absolutely-
 // positioned overlays. Lynx's layout engine doesn't reliably overlay
@@ -76,12 +77,19 @@ export default (colors: Color[]) => ({
     highlight: { true: '' }
   },
   compoundVariants: [
-    // Resting border is neutral; the colored border is opt-in via `highlight`
-    // (no focus state on Lynx).
+    // Resting border is neutral; the colored border + shadow ring paints while
+    // focused (tracked in JS by `Input.vue` — Lynx has no `:focus-within` and
+    // the chrome lives on `root`, not the `<input>`) or statically via
+    // `highlight`. The ring is a flat arbitrary box-shadow: the Lynx preset
+    // has no `ring*` / `boxShadowColor` plugins, but its `shadow-*` emits a
+    // plain `box-shadow` (no `--tw-shadow` var composition), and
+    // `--ui-color-*-200` holds a concrete value, so the single var() level
+    // survives Lynx's one-level var() resolution. Template-literal class —
+    // safelisted in `../tailwind.js` (keep the two in sync).
     ...colors.map(c => ({
       color: c,
       highlight: true,
-      class: { root: `border border-${c}-500` }
+      class: { root: `border border-${c}-500 shadow-[0_0_0_2px_var(--ui-color-${c}-200)]` }
     })),
     // Icons default to neutral (dimmed), decoupled from `color`; override via
     // the `leading` / `trailing` slots. Loading spinner animates the icon slot.


### PR DESCRIPTION
`VyInput` now paints its colored border + a shadow ring while focused, matching nuxt/ui's focus treatment within Lynx constraints.

- Ring is a flat arbitrary box-shadow (`0 0 0 2px var(--ui-color-{c}-200)`) — the Lynx preset has no `ring*`/`boxShadowColor` plugins, so the color is baked into the shadow value
- Focus is tracked in JS via `@focus`/`@blur` (no `:focus-within` on Lynx; the chrome lives on the root `<view>`); `highlight` still forces the ring on statically
- Per-color shadow classes safelisted in the kit Tailwind preset (template literals are invisible to the scanner)
- kit-demo: "Input focus ring" card in FormSection covering default/error/soft/highlight
- Docs updated (highlight prop, theming, platform notes) + patch changeset

Verified on web and native device — spread-only box-shadow with a single-level var() color renders correctly on both.
