### PR TITLE
fix(core,kit): drag only the sortable item pill, expose ui-dragging s…

### DIFF
--- a/.changeset/sortable-dragging-divider.md
+++ b/.changeset/sortable-dragging-divider.md
@@ -1,0 +1,6 @@
+---
+"@vyui/core": patch
+"@vyui/kit": patch
+---
+
+Sortable rows no longer drag list chrome along with the finger. The kit theme now renders each row as a transparent shell (the element core transforms) around a new `itemContent` pill slot, so only the pill visibly moves — the old `border-b` divider look is gone. `SortableItem` flips a `ui-dragging` class (+ `data-state="dragging"`) on the lifted row, and `VYUI_UI_STATES` gains `dragging` so themes can restyle the lifted pill (default: stronger pill border via `group-ui-dragging:`).

--- a/apps/docs/app/generated/api/Sortable.json
+++ b/apps/docs/app/generated/api/Sortable.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "ui",
-      "type": "Partial<Record<\"root\" | \"item\" | \"handle\", any>> | undefined",
+      "type": "Partial<Record<\"root\" | \"item\" | \"handle\" | \"itemContent\", any>> | undefined",
       "required": false
     }
   ],

--- a/apps/examples/cli-demo/src/lib/vyui/vyui-preset.js
+++ b/apps/examples/cli-demo/src/lib/vyui/vyui-preset.js
@@ -56,7 +56,7 @@ export { COLORS, NEUTRAL } from './theme/color-constants.js'
  * })
  * ```
  */
-export const VYUI_UI_STATES = ['on', 'off', 'completed', 'highlighted', 'inactive']
+export const VYUI_UI_STATES = ['on', 'off', 'completed', 'highlighted', 'inactive', 'dragging']
 
 const buildScale = (name, neutral, shades) =>
   Object.fromEntries([

--- a/apps/examples/docs-playground/tailwind.config.ts
+++ b/apps/examples/docs-playground/tailwind.config.ts
@@ -1,6 +1,20 @@
 import type { Config } from 'tailwindcss'
-import lynxPreset from '@lynx-js/tailwind-preset'
-import vyuiPreset from '../../../packages/kit/src/tailwind.js'
+import { createLynxPreset } from '@lynx-js/tailwind-preset'
+import vyuiPreset, { VYUI_UI_STATES } from '../../../packages/kit/src/tailwind.js'
+
+// Extend the lynx preset's `uiVariants` with the extra `ui-*` state markers the
+// kit themes use (`ui-on:`, `ui-dragging:`, …) — the class-based replacements
+// for Lynx-incompatible `data-[state=…]` selectors (issue #9).
+const lynxPreset = createLynxPreset({
+  lynxUIPlugins: {
+    uiVariants: {
+      prefixes: defaults => ({
+        ...defaults,
+        ui: [...defaults.ui, ...VYUI_UI_STATES],
+      }),
+    },
+  },
+})
 
 const config: Config = {
   content: [

--- a/apps/examples/kit-demo/src/sections/gestures/SortableCard.vue
+++ b/apps/examples/kit-demo/src/sections/gestures/SortableCard.vue
@@ -6,7 +6,8 @@ import { VySortable } from '@vyui/kit'
 // `long-press-ms="0"` lifts immediately on press so a simulator mouse click-drag
 // works without holding. The Gestures tab disables the outer page scroll (see
 // App.vue) so instant drag won't fight page scrolling. Edge autoscroll +
-// clamping come from core.
+// clamping come from core. Row pills come from the theme's `itemContent` slot —
+// the slot only supplies the content inside the pill.
 const tags = ref(['Design', 'Engineering', 'Product', 'Research'])
 </script>
 
@@ -14,12 +15,10 @@ const tags = ref(['Design', 'Engineering', 'Product', 'Research'])
   <view class="bg-white border border-slate-200 rounded-lg p-3 flex flex-col flex-1 min-w-[280px] gap-2">
     <text class="text-slate-900 text-base font-semibold">Sortable</text>
     <text class="text-slate-500 text-xs">Press a row and drag to reorder. Current: {{ tags.join(' · ') }}</text>
-    <VySortable v-model="tags" :long-press-ms="0">
+    <VySortable v-model="tags" :long-press-ms="0" size="sm">
       <template #item="{ item }">
-        <view class="bg-slate-50 border border-slate-200 rounded-md h-10 flex flex-row items-center px-3 mb-1.5">
-          <text class="text-slate-400 text-base mr-3">⠿</text>
-          <text class="text-slate-900 text-sm">{{ item }}</text>
-        </view>
+        <text class="text-slate-400 text-base">⠿</text>
+        <text class="text-slate-900 text-sm">{{ item }}</text>
       </template>
     </VySortable>
   </view>

--- a/docs/data-attributes.md
+++ b/docs/data-attributes.md
@@ -20,7 +20,7 @@ e.g. `[data-state="open"]` / `[data-disabled]`.
 
 | Attribute | Values | Where |
 | --- | --- | --- |
-| `data-state` | `open` / `closed`, `checked` / `unchecked`, `active` / `inactive`, `on` / `off` (component-dependent) | Accordion, Button, Checkbox, Collapsible, Combobox, Dialog, DropdownMenu, Popover, Progress, RadioGroup, Rating, Select, Sheet, Stepper, Switch, Tabs, Toast, Toggle, Navigation |
+| `data-state` | `open` / `closed`, `checked` / `unchecked`, `active` / `inactive`, `on` / `off`, `dragging` / `idle` (component-dependent) | Accordion, Button, Checkbox, Collapsible, Combobox, Dialog, DropdownMenu, Popover, Progress, RadioGroup, Rating, Select, Sheet, Sortable, Stepper, Switch, Tabs, Toast, Toggle, Navigation |
 | `data-disabled` | present when disabled | All interactive components |
 | `data-orientation` | `horizontal` / `vertical` | Accordion, RadioGroup, Rating, Separator, Slider, Stepper, Tabs |
 | `data-readonly` | present when read-only | Input, Textarea, NumberField |

--- a/packages/core/src/components/Sortable/SortableItem.vue
+++ b/packages/core/src/components/Sortable/SortableItem.vue
@@ -15,7 +15,7 @@ export interface SortableItemProps {
 </script>
 
 <script setup lang="ts">
-import { onBeforeUnmount, watch } from 'vue'
+import { computed, onBeforeUnmount, watch } from 'vue'
 import { runOnBackground, runOnMainThread, useMainThreadRef } from 'vue-lynx'
 
 import type { SortableItemHandle } from './sortableContext'
@@ -30,6 +30,11 @@ defineSlots<{
 }>()
 
 const ctx = injectSortableRootContext()
+
+// BG-side dragging state — drives the `ui-dragging` class so themes can
+// restyle the lifted row (e.g. hide its divider, which is painted on this
+// element and would otherwise travel with the drag transform).
+const isDragging = computed(() => ctx.draggingIndex.value === props.index)
 
 const containerRef = useMainThreadRef<any>(null)
 const touchStartYRef = useMainThreadRef<number>(0)
@@ -383,7 +388,9 @@ function _cancelActivation() {
 <template>
   <view
     class="vyui-sortable__item"
+    :class="{ 'ui-dragging': isDragging }"
     data-vyui-sortable-item
+    :data-state="isDragging ? 'dragging' : 'idle'"
     :main-thread-ref="containerRef"
     :main-thread-binduiappear="_registerMT"
     :main-thread-bindtouchstart="_onTouchStart"
@@ -395,6 +402,6 @@ function _cancelActivation() {
       flexShrink: 0,
     }"
   >
-    <slot :dragging="ctx.draggingIndex.value === props.index" :index="props.index" />
+    <slot :dragging="isDragging" :index="props.index" />
   </view>
 </template>

--- a/packages/kit/src/components/Sortable.vue
+++ b/packages/kit/src/components/Sortable.vue
@@ -80,7 +80,11 @@ const itemHeight = computed(() => ITEM_HEIGHTS[(props.size ?? 'md') as keyof typ
       :index="index"
       :class="ui.item({ class: props.ui?.item })"
     >
-      <slot name="item" :item="it" :index="index" />
+      <!-- The pill is a child of the transformed shell so the shell can stay
+           transparent — paint on the shell itself travels with the drag. -->
+      <view :class="ui.itemContent({ class: props.ui?.itemContent })">
+        <slot name="item" :item="it" :index="index" />
+      </view>
     </SortableItem>
   </SortableRoot>
 </template>

--- a/packages/kit/src/tailwind.d.ts
+++ b/packages/kit/src/tailwind.d.ts
@@ -29,7 +29,7 @@ export declare const NEUTRAL: 'neutral'
 
 /** Extra `ui-*` state markers (beyond the lynx preset's built-ins) the kit
  *  themes rely on for class-based state variants — feed into `uiVariants`. */
-export declare const VYUI_UI_STATES: readonly ['on', 'off', 'completed', 'highlighted', 'inactive']
+export declare const VYUI_UI_STATES: readonly ['on', 'off', 'completed', 'highlighted', 'inactive', 'dragging']
 
 /** Default preset built with the standard color set. */
 declare const preset: Partial<Config>

--- a/packages/kit/src/tailwind.js
+++ b/packages/kit/src/tailwind.js
@@ -56,7 +56,7 @@ export { COLORS, NEUTRAL } from './theme/color-constants.js'
  * })
  * ```
  */
-export const VYUI_UI_STATES = ['on', 'off', 'completed', 'highlighted', 'inactive']
+export const VYUI_UI_STATES = ['on', 'off', 'completed', 'highlighted', 'inactive', 'dragging']
 
 const buildScale = (name, neutral, shades) =>
   Object.fromEntries([

--- a/packages/kit/src/theme/sortable.ts
+++ b/packages/kit/src/theme/sortable.ts
@@ -1,28 +1,39 @@
 /**
  * Sortable theme — light-mode Vue-Lynx defaults for a drag-to-reorder list.
  *
- * Size variant drives item padding plus the optional drag handle size. The
- * `itemHeight` prop on `SortableRoot` is set in pixels by the wrapper based on
- * this same size token so the swap math stays aligned with the visual row.
+ * Two-layer row: `item` is the transparent shell core transforms during a drag
+ * (any paint on it would travel with the finger — that's how the old divider
+ * look smeared); `itemContent` is the visible pill, so only the pill appears
+ * to move. The shell's bottom padding is the row gap and lives INSIDE the
+ * fixed row pitch (`itemHeight` on `SortableRoot`), keeping the main-thread
+ * swap math aligned with the rendered geometry.
+ *
+ * Size variant drives the gap, pill padding, and the optional drag handle
+ * size. The `itemHeight` prop is set in pixels by the wrapper from this same
+ * size token.
  */
 export default {
   slots: {
     root: 'w-full min-w-0 max-w-full overflow-hidden flex flex-col',
-    item: 'flex flex-row items-center min-w-0 max-w-full overflow-hidden gap-2 bg-white border-b border-neutral-200 last:border-b-0',
+    item: 'group flex flex-col min-w-0 max-w-full',
+    itemContent: 'flex-1 flex flex-row items-center min-w-0 overflow-hidden gap-2 bg-white border border-neutral-200 rounded-md group-ui-dragging:border-neutral-300',
     handle: 'shrink-0 text-neutral-400',
   },
   variants: {
     size: {
       sm: {
-        item: 'px-4 py-3 text-base',
+        item: 'pb-1.5',
+        itemContent: 'px-4 text-base',
         handle: 'size-5',
       },
       md: {
-        item: 'px-5 py-4 text-lg',
+        item: 'pb-2',
+        itemContent: 'px-5 text-lg',
         handle: 'size-6',
       },
       lg: {
-        item: 'px-6 py-5 text-xl',
+        item: 'pb-2',
+        itemContent: 'px-6 text-xl',
         handle: 'size-7',
       },
     },


### PR DESCRIPTION
…tate

Sortable rows dragged their full-row chrome (divider included) with the finger. The kit theme now renders each row as a transparent shell around a new itemContent pill slot so only the pill moves; SortableItem flips a ui-dragging class + data-state="dragging" on the lifted row, and VYUI_UI_STATES gains 'dragging' so themes can restyle the lifted pill.