### PR TITLE
fix(kit): resolve theme barrel under jiti in src-plane tailwind preset

### DIFF
--- a/.changeset/tailwind-theme-barrel-jiti.md
+++ b/.changeset/tailwind-theme-barrel-jiti.md
@@ -1,0 +1,5 @@
+---
+"@vyui/kit": patch
+---
+
+Fix tailwind preset failing to load from source under jiti (`Cannot find module './theme/index.js'`) — import the theme barrel with an explicit `.ts` extension; Vite still emits `./theme/index.js` in dist.

--- a/packages/kit/src/tailwind.js
+++ b/packages/kit/src/tailwind.js
@@ -33,7 +33,10 @@
  */
 
 import { COLORS, NEUTRAL, SHADES } from './theme/color-constants.js'
-import * as themeExports from './theme/index.js'
+// Explicit `.ts` so the source plane resolves under jiti (the example apps'
+// tailwind configs import `src/tailwind.js` directly, and jiti's CJS resolver
+// won't remap `.js` → `.ts`). Vite rewrites this to `./theme/index.js` in dist.
+import * as themeExports from './theme/index.ts'
 
 // Re-exported so a Tailwind config can extend the default set without pulling in
 // the component barrel (`@vyui/kit`) through jiti:


### PR DESCRIPTION
Fixes the Release build failure introduced by #134 (`Cannot find module './theme/index.js'` in the docs-playground tailwind config).

- The exact-safelist walk imports the theme barrel, but the barrel is `index.ts` and jiti won't remap `.js` → `.ts` for literal specifiers
- Only the src plane broke: docs-playground/tiktok-demo/vyai import `packages/kit/src/tailwind.js` directly; packaged consumers were fine (dist has a compiled `theme/index.js`)
- Fix: import `./theme/index.ts` explicitly — jiti transpiles it, Vite rewrites the specifier to `.js` in dist, and `tailwind.js` isn't in tsc's include
- Verified: jiti src load (601-class safelist intact), kit `build-only` + dist-plane load, and the exact failing step `pnpm --filter @vyui/docs-playground build`