### PR TITLE
docs: publishable package READMEs, surface the CLI, fix kit re-export claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ But the Lynx ecosystem currently has no extensive UI component library. There's 
 
 ## Architecture
 
-Two packages today, with more planned (see Roadmap):
+Two runtime layers plus a CLI to distribute them, with more planned (see Roadmap):
 
 ```text
 @vyui/core    →  Runtime primitives, ship in your app bundle
 @vyui/kit      →  Styled components built on top of @vyui/core
+@vyui/cli      →  shadcn-style CLI — copy kit component source into your own project
 ```
 
 ### `@vyui/core` — Primitives
@@ -52,6 +53,17 @@ pnpm add @vyui/core
 ### `@vyui/kit` — Styled components
 
 Opinionated styled components layered on top of `@vyui/core`, published for Vue-Lynx apps that want ready-to-use `Vy*` components and theme defaults.
+
+### `@vyui/cli` — Own the components (shadcn-style)
+
+A CLI that copies styled component source into your own project instead of installing it as a package — you own and edit the `.vue` + theme files, while the headless `@vyui/core` primitives stay an npm dependency (the shadcn/Radix model).
+
+```sh
+npx @vyui/cli init             # detect the Vue-Lynx project and wire up tokens + preset
+npx @vyui/cli add button       # copy a component (and its dependencies) into your app
+```
+
+Components come from a versioned, style-namespaced [registry](https://vyui.dev/r) generated from `@vyui/kit` source. See the **[CLI guide](https://vyui.dev/getting-started/cli)**.
 
 ## Quick start
 
@@ -106,6 +118,7 @@ vyui/
 ├── packages/
 │   ├── core/                  # @vyui/core — runtime primitives (published)
 │   ├── kit/                   # @vyui/kit — styled components on top of core
+│   ├── cli/                   # @vyui/cli — shadcn-style init/add CLI + registry
 │   ├── shared-build-config/   # shared Vite build config
 │   └── testing-utils/         # shared test helpers
 └── apps/
@@ -183,7 +196,7 @@ porting, and adapting from them.
   on Nuxt UI's approach. MIT.
 
 * **[shadcn/ui](https://ui.shadcn.com)** — Defined the CLI + registry
-  distribution model that the planned `@vyui/cli` and `vyui.dev/registry/*`
+  distribution model that `@vyui/cli` and the `vyui.dev/r/*` registry
   manifests are modeled on. MIT.
 
 * **[Lynx UI](https://github.com/lynx-family/lynx-ui)** — ByteDance's reference

--- a/apps/docs/app/components/LandingFeatures.vue
+++ b/apps/docs/app/components/LandingFeatures.vue
@@ -13,7 +13,12 @@ const features = [
   {
     icon: 'i-lucide-blocks',
     title: 'Mix them freely',
-    description: 'Kit re-exports everything you need from core. Start with kit, drop down to primitives anywhere you need bespoke styling.',
+    description: 'Import styled Vy* components from kit and reach for raw @vyui/core primitives in the same file wherever you need bespoke styling.',
+  },
+  {
+    icon: 'i-lucide-terminal',
+    title: '@vyui/cli — Own the code',
+    description: 'shadcn-style CLI. vyui add button copies the styled component source into your project — you own and edit it, while headless @vyui/core stays an npm dependency.',
   },
 ]
 </script>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,5 +1,64 @@
 # @vyui/core
 
-Alpha. Lynx-native Vue components.
+Headless, accessible UI primitives for [Vue-Lynx](https://vue.lynxjs.org) — the
+Radix-style behavior layer of [Vy UI](https://vyui.dev). Ship native apps for
+iOS, Android, and web from one Vue codebase.
 
-Expect breaking changes on every release until 1.0.0.
+> ⚠️ **Alpha.** Vue-Lynx itself is pre-alpha. Expect breaking changes on every
+> release until 1.0.0.
+
+## What's in it
+
+40+ behavioral primitives — state, focus, keyboard, and gesture handling with
+**no styling of their own**. You bring the styles (or use the styled
+[`@vyui/kit`](https://www.npmjs.com/package/@vyui/kit) layer on top).
+
+Dialog, AlertDialog, Sheet, Popover, DropdownMenu, Combobox, Select, Tabs,
+Accordion, Collapsible, Slider, Swiper, Sortable, Draggable, SwipeAction,
+Checkbox, RadioGroup, Switch, Toggle, NumberField, PinInput, Rating, Stepper,
+Pagination, Progress, Toast, Avatar, FeedList, Form / Field / Label, and more.
+
+Components expose state attributes (`data-state`, `data-disabled`, …) and
+namespaced structural markers (`data-vyui-*`) you can style and select against.
+
+## Install
+
+```sh
+npm install @vyui/core
+# or: pnpm add @vyui/core
+```
+
+Built for Vue-Lynx — `vue` and `@lynx-js/vue` are peer dependencies.
+
+## Usage
+
+Primitives are headless, so they render with your own styling and work without
+any further wiring:
+
+```vue
+<script setup>
+import { SliderRoot, SliderTrack, SliderRange, SliderThumb } from '@vyui/core'
+import { ref } from 'vue'
+const value = ref(50)
+</script>
+
+<template>
+  <SliderRoot v-model="value" :max="100">
+    <SliderTrack><SliderRange /></SliderTrack>
+    <SliderThumb />
+  </SliderRoot>
+</template>
+```
+
+## The rest of Vy UI
+
+- **[`@vyui/kit`](https://www.npmjs.com/package/@vyui/kit)** — styled `Vy*`
+  components built on these primitives, themeable via Tailwind Variants.
+- **[`@vyui/cli`](https://www.npmjs.com/package/@vyui/cli)** — shadcn-style CLI
+  that copies styled component source into your project so you own it.
+
+Full docs, API tables, and live examples: **[vyui.dev](https://vyui.dev)**.
+
+## License
+
+MIT © Kealan Clarke and Vy UI contributors

--- a/packages/kit/README.md
+++ b/packages/kit/README.md
@@ -1,8 +1,41 @@
 # @vyui/kit
 
-Alpha. Styled Vue-Lynx components built on `@vyui/core`.
+Styled `Vy*` components for [Vue-Lynx](https://vue.lynxjs.org), built on the
+headless [`@vyui/core`](https://www.npmjs.com/package/@vyui/core) primitives —
+the ready-to-use layer of [Vy UI](https://vyui.dev). Ship native apps for iOS,
+Android, and web from one Vue codebase.
 
-Expect breaking changes on every release until 1.0.0.
+> ⚠️ **Alpha.** Expect breaking changes on every release until 1.0.0.
+
+`@vyui/kit` depends on `@vyui/core` but does **not** re-export the full core
+surface: import styled `Vy*` components from kit, and raw primitives from core.
+
+## Install
+
+```sh
+npm install @vyui/core @vyui/kit
+# or: pnpm add @vyui/core @vyui/kit
+```
+
+Kit ships its styling as a Tailwind preset and a theme stylesheet that need
+wiring alongside the Lynx preset. Follow the
+**[installation guide](https://vyui.dev/getting-started/installation)** for the
+full setup, or use the [`@vyui/cli`](https://www.npmjs.com/package/@vyui/cli) to
+scaffold it — `npx @vyui/cli init`.
+
+## Usage
+
+```vue
+<script setup>
+import { VyButton } from '@vyui/kit'
+</script>
+
+<template>
+  <VyButton color="primary">Click me</VyButton>
+</template>
+```
+
+Full docs, API tables, and live examples: **[vyui.dev](https://vyui.dev)**.
 
 ## Colors
 


### PR DESCRIPTION
Fixes stale/blank docs surfaces flagged in a discoverability audit.

- `@vyui/core` README was a 4-line stub — wrote a full README (what it is, install, usage, links); it published as 0 chars on npm.
- `@vyui/kit` README had only a colors deep-dive — prepended intro, install, and `VyButton` usage; also published as 0 chars on npm.
- Homepage "Two layers" section now pitches `@vyui/cli` (added a card); root README Architecture, package block, project tree, and shadcn acknowledgement now include the shipped CLI.
- Fixed the landing-page "Kit re-exports everything you need from core" claim — it contradicted the installation guide; kit does not re-export the full core surface.

README changes only reach npm on the next release publish — no code changed, no changeset.

Done separately (live now, not in this diff): repo description + topics updated via API. Still manual — upload the homepage OG card as the repo Social preview (Settings → General).