### PR TITLE
chore(overlay): phase-1 cleanup — dead API, Modal.dismissible, duration desync

### DIFF
--- a/.changeset/overlay-phase1-cleanup.md
+++ b/.changeset/overlay-phase1-cleanup.md
@@ -5,7 +5,7 @@
 
 Overlay cleanup ahead of the shared-core refactor.
 
-**Breaking** (pre-1.0 patch by repo policy): removes the dead `velocityThreshold` prop from `SheetRoot` (documented as unused/reserved — release logic uses the coast projection) and the consumerless `useSheetBehavior()` reactive wrapper, `progressFor`, and their types from `@vyui/core`. The pure spec helpers (`pickRelease`, `directionAxis`, `viewportSnapsToPositions`, …) remain.
+**Breaking** (pre-1.0 patch by repo policy): removes the dead `velocityThreshold` prop from `SheetRoot` (documented as unused/reserved — release logic uses the coast projection) and the consumerless `useSheetBehavior()` reactive wrapper, `progressFor`, `pickSnap`/`PickSnapOpts` (never adopted by Sheet; `pickRelease` is the one release spec), and their types from `@vyui/core`. The pure spec helpers (`pickRelease`, `directionAxis`, `viewportSnapsToPositions`, …) remain.
 
 - kit `VyModal`: wire the declared-but-dead `dismissible` prop — backdrop taps are now blocked when `false` and emit `close:prevent` (mirrors `VyPopover`)
 - sheet enter/exit keyframes now take their duration from the `duration` prop (inline `animation-duration` longhand) instead of a hardcoded 280ms, fixing the enter/settle desync for consumers like `VyTray` that pass `duration: 300`

--- a/.changeset/overlay-phase1-cleanup.md
+++ b/.changeset/overlay-phase1-cleanup.md
@@ -1,0 +1,11 @@
+---
+"@vyui/core": patch
+"@vyui/kit": patch
+---
+
+Overlay cleanup ahead of the shared-core refactor.
+
+**Breaking** (pre-1.0 patch by repo policy): removes the dead `velocityThreshold` prop from `SheetRoot` (documented as unused/reserved — release logic uses the coast projection) and the consumerless `useSheetBehavior()` reactive wrapper, `progressFor`, and their types from `@vyui/core`. The pure spec helpers (`pickRelease`, `directionAxis`, `viewportSnapsToPositions`, …) remain.
+
+- kit `VyModal`: wire the declared-but-dead `dismissible` prop — backdrop taps are now blocked when `false` and emit `close:prevent` (mirrors `VyPopover`)
+- sheet enter/exit keyframes now take their duration from the `duration` prop (inline `animation-duration` longhand) instead of a hardcoded 280ms, fixing the enter/settle desync for consumers like `VyTray` that pass `duration: 300`

--- a/apps/docs/app/generated/api/Modal.json
+++ b/apps/docs/app/generated/api/Modal.json
@@ -85,6 +85,10 @@
     {
       "name": "update:open",
       "type": "[value: boolean]"
+    },
+    {
+      "name": "close:prevent",
+      "type": "[]"
     }
   ],
   "slots": [

--- a/apps/docs/app/generated/api/SheetRoot.json
+++ b/apps/docs/app/generated/api/SheetRoot.json
@@ -69,13 +69,6 @@
       "description": "Snap points as fractions of viewport extent on the sheet axis, low → high.\ne.g. `[0.25, 0.5, 0.9]`. For `top`/`bottom` this is viewport height;\nfor `left`/`right` this is viewport width."
     },
     {
-      "name": "velocityThreshold",
-      "type": "number | undefined",
-      "required": false,
-      "default": "400",
-      "description": "Absolute velocity (px/s) above which a fling advances by one snap regardless\nof position. Currently unused — the release logic (mirroring\n`pickRelease`) implements flick-advance via a 100ms coast projection\ninstead. Reserved."
-    },
-    {
       "name": "viewportHeight",
       "type": "number | undefined",
       "required": false,

--- a/apps/docs/content/3.components/modal.md
+++ b/apps/docs/content/3.components/modal.md
@@ -169,7 +169,6 @@ Set `close="false"` to hide the built-in close button.
 
 ### Current API limitations
 
-- `dismissible` is declared and defaults to `true`, but the kit component does not currently forward it to the core dialog. Backdrop taps therefore still dismiss when `dismissible` is `false`.
 - `overlay="false"` removes the dimming class, but the full-screen transparent backdrop still renders, blocks interaction behind the modal, and dismisses on tap.
 - `portal` is retained for API parity, but changing it has no effect. Dialog content is always registered with the Lynx `OverlayRoot`.
 - In uncontrolled mode, the `close()` slot helper only emits updates and does not directly change the core dialog's internal state. Prefer controlled state when using the helper. The built-in close control and backdrop still close uncontrolled dialogs.
@@ -189,7 +188,7 @@ Set `close="false"` to hide the built-in close button.
 | `portal` | `boolean` | `true` | API-parity prop; currently does not change Lynx overlay registration. |
 | `close` | `boolean \| Partial<ButtonProps>` | `true` | Shows the built-in close button and optionally forwards button props. |
 | `closeIcon` | `string` | App icon / `i-lucide-x` | Iconify name for the built-in close button. |
-| `dismissible` | `boolean` | `true` | Declared API prop; currently not wired, so backdrop dismissal remains enabled. |
+| `dismissible` | `boolean` | `true` | When `false`, backdrop taps are blocked and emit `close:prevent` instead of closing. |
 | `class` | `any` | `undefined` | Classes merged onto the trigger wrapper, not the modal panel. |
 | `ui` | `Partial<Record<ModalSlot, any>>` | `undefined` | Per-instance theme slot overrides. |
 
@@ -199,6 +198,7 @@ Set `close="false"` to hide the built-in close button.
 | --- | --- | --- |
 | `update:open` | `boolean` | Open-state update for `v-model:open`. |
 | `update:modelValue` | `boolean` | Open-state update for `v-model`. |
+| `close:prevent` | none | An outside tap was blocked because `dismissible` is `false`. |
 
 ## Slots
 

--- a/packages/core/src/components/Sheet/SheetBackdropImpl.vue
+++ b/packages/core/src/components/Sheet/SheetBackdropImpl.vue
@@ -68,6 +68,9 @@ const handlers = presence?.animationHandlers
       bottom: '0',
       zIndex: '1000',
       backgroundColor: 'rgba(0, 0, 0, 0.4)',
+      // Inline longhand overrides the 280ms keyframe shorthands below so the
+      // fade tracks the sheet's `duration` prop (panel does the same).
+      animationDuration: `${ctx.duration.value}ms`,
     }"
     @tap="emits('tap')"
     @animationstart="handlers?.handleKFStart"

--- a/packages/core/src/components/Sheet/SheetContentImpl.vue
+++ b/packages/core/src/components/Sheet/SheetContentImpl.vue
@@ -144,7 +144,7 @@ const panelStyle = computed(() => {
   // track the real hugged height.
   if (props.fitContent) return duration
   const size = `${maxSnap.value * 100}${axis.value === 'x' ? 'vw' : 'vh'}`
-  return axis.value === 'x' ? { width: size, ...duration } : { height: size, ...duration }
+  return { ...duration, [axis.value === 'x' ? 'width' : 'height']: size }
 })
 
 // `SystemInfo` is not reactive, but the panel receives a layout event whenever

--- a/packages/core/src/components/Sheet/SheetContentImpl.vue
+++ b/packages/core/src/components/Sheet/SheetContentImpl.vue
@@ -134,13 +134,17 @@ const closeSign = computed(() => directionCloseSign(ctx.side.value))
 // `vh`, not `dvh` — Lynx native drops the dynamic-viewport unit, collapsing
 // the panel to its content height.
 const panelStyle = computed(() => {
+  // Inline longhand overrides the 280ms in the enter/leave keyframe
+  // shorthands below, so the CSS default and the MT settle paths (which
+  // read `durationMsRef`) can't desync when a consumer sets `duration`.
+  const duration = { animationDuration: `${ctx.duration.value}ms` }
   // Content-hug mode: emit no explicit extent so the panel takes its natural
   // content size. `measuredPanelHeight/Width` (from `@layoutchange`) still
   // feeds `panelExtentPx`, so the drag threshold and backdrop-fade progress
   // track the real hugged height.
-  if (props.fitContent) return {}
+  if (props.fitContent) return duration
   const size = `${maxSnap.value * 100}${axis.value === 'x' ? 'vw' : 'vh'}`
-  return axis.value === 'x' ? { width: size } : { height: size }
+  return axis.value === 'x' ? { width: size, ...duration } : { height: size, ...duration }
 })
 
 // `SystemInfo` is not reactive, but the panel receives a layout event whenever
@@ -221,9 +225,9 @@ const snapTargetPos = computed(() => {
   return positions[positions.length - 1 - idx] ?? 0
 })
 
-// Release physics from SheetRoot's props. `ctx.velocityThreshold` is
-// deliberately not mirrored — `pickRelease` (and the worklet mirror of it)
-// implements flick-advance via the coast projection instead.
+// Release physics from SheetRoot's props. Flick-advance needs no velocity
+// threshold — `pickRelease` (and the worklet mirror of it) implements it
+// via the coast projection instead.
 const dismissVelocityRef = useMainThreadRef<number>(ctx.dismissVelocity.value)
 const durationMsRef = useMainThreadRef<number>(ctx.duration.value)
 const snapPositionsRef = useMainThreadRef<number[]>(snapPositionsPx.value)

--- a/packages/core/src/components/Sheet/SheetRoot.vue
+++ b/packages/core/src/components/Sheet/SheetRoot.vue
@@ -47,14 +47,6 @@ export interface SheetRootProps {
    */
   viewportWidth?: number
   /**
-   * Absolute velocity (px/s) above which a fling advances by one snap regardless
-   * of position. Currently unused — the release logic (mirroring
-   * `pickRelease`) implements flick-advance via a 100ms coast projection
-   * instead. Reserved.
-   * @defaultValue `400`
-   */
-  velocityThreshold?: number
-  /**
    * Downward velocity (px/s) at which a fling dismisses from any position
    * (when `enableDragToClose`).
    * @defaultValue `600`
@@ -101,7 +93,6 @@ const props = withDefaults(defineProps<SheetRootProps>(), {
   defaultSnapIndex: 0,
   side: 'bottom',
   snapPoints: () => [1],
-  velocityThreshold: 400,
   dismissVelocity: 600,
   duration: 280,
   enableDragToClose: true,
@@ -175,7 +166,6 @@ provideSheetRootContext({
   snapPoints,
   viewportHeight,
   viewportWidth,
-  velocityThreshold: computed(() => props.velocityThreshold),
   dismissVelocity: computed(() => props.dismissVelocity),
   duration: computed(() => props.duration),
   enableDragToClose: computed(() => props.enableDragToClose),

--- a/packages/core/src/components/Sheet/sheetContext.ts
+++ b/packages/core/src/components/Sheet/sheetContext.ts
@@ -24,12 +24,6 @@ export interface SheetRootContext {
   viewportHeight: ComputedRef<number>
   /** Viewport width in px (resolved from prop / runtime). */
   viewportWidth: ComputedRef<number>
-  /**
-   * Velocity threshold for fling-to-snap (px/s). Currently unused — the
-   * release logic (mirroring `pickRelease`) implements flick-advance via
-   * its coast projection instead. Reserved.
-   */
-  velocityThreshold: ComputedRef<number>
   /** Velocity threshold for fling-to-dismiss (px/s). */
   dismissVelocity: ComputedRef<number>
   /** Animation duration for settle (ms). */

--- a/packages/core/src/shared/composables/index.ts
+++ b/packages/core/src/shared/composables/index.ts
@@ -46,10 +46,8 @@ export {
   directionAxis,
   directionCloseSign,
   pickRelease,
-  progressFor,
   resolveSnapPositions,
   resolveSnapToPosition,
-  useSheetBehavior,
   viewportSnapsToPositions,
 } from './useSheetBehavior.js'
 export type {
@@ -57,6 +55,4 @@ export type {
   PickReleaseResult,
   SheetDirection,
   SheetSnap,
-  UseSheetBehaviorOptions,
-  UseSheetBehaviorReturn,
 } from './useSheetBehavior.js'

--- a/packages/core/src/shared/composables/useSheetBehavior.test.ts
+++ b/packages/core/src/shared/composables/useSheetBehavior.test.ts
@@ -1,14 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
 
 import {
   directionAxis,
   directionCloseSign,
   pickRelease,
-  progressFor,
   resolveSnapPositions,
   resolveSnapToPosition,
-  useSheetBehavior,
   viewportSnapsToPositions,
 } from './useSheetBehavior.js'
 
@@ -103,33 +100,11 @@ describe('viewportSnapsToPositions', () => {
   })
 })
 
-describe('progressFor', () => {
-  it('returns 1 at position 0 (fully open), 0 at travel (closed)', () => {
-    expect(progressFor(0, 800)).toBe(1)
-    expect(progressFor(800, 800)).toBe(0)
-  })
-
-  it('returns a linear interpolation in between', () => {
-    expect(progressFor(400, 800)).toBe(0.5)
-    expect(progressFor(80, 800)).toBeCloseTo(0.9, 5)
-  })
-
-  it('clamps to [0, 1] for out-of-range positions', () => {
-    expect(progressFor(-100, 800)).toBe(1)
-    expect(progressFor(2000, 800)).toBe(0)
-  })
-
-  it('returns 0 for non-positive travel', () => {
-    expect(progressFor(50, 0)).toBe(0)
-  })
-})
-
 describe('pickRelease', () => {
   const snapPositions = [80, 480] // 0.9 and 0.4 fractions of an 800px sheet
   const baseOpts = {
     snapPositions,
     enableDragToClose: true,
-    velocityThreshold: 400,
     dismissVelocity: 600,
     dismissThreshold: 80,
   }
@@ -142,8 +117,8 @@ describe('pickRelease', () => {
   it('uses projection to bias toward the direction of fling', () => {
     // Releasing midway between snaps with downward velocity should land
     // on the more-closed snap thanks to the coast. Velocity 500 px/s sits
-    // above velocityThreshold (400) but below dismissVelocity (600), so
-    // we stay in the "settle" path. Coast = (500 * 100)/1000 = 50 px →
+    // below dismissVelocity (600), so we stay in the "settle" path.
+    // Coast = (500 * 100)/1000 = 50 px →
     // projected = 330. Distance to 80 is 250; to 480 is 150 → snap to 480.
     const result = pickRelease(280, 500, baseOpts)
     expect(result.dismiss).toBe(false)
@@ -185,63 +160,5 @@ describe('pickRelease', () => {
   it('returns dismiss:false with snapIndex -1 when there are no snaps', () => {
     const result = pickRelease(100, 0, { ...baseOpts, snapPositions: [] })
     expect(result).toEqual({ snapIndex: -1, targetPosition: 100, dismiss: false })
-  })
-})
-
-describe('useSheetBehavior (reactive wrapper)', () => {
-  it('reacts to direction changes', () => {
-    const direction = ref<'top' | 'bottom' | 'left' | 'right'>('bottom')
-    const { axis, closeSign } = useSheetBehavior({
-      direction,
-      snapPoints: [1],
-      travel: 800,
-      velocityThreshold: 400,
-      dismissVelocity: 600,
-      dismissThreshold: 80,
-      enableDragToClose: true,
-    })
-    expect(axis.value).toBe('y')
-    expect(closeSign.value).toBe(1)
-
-    direction.value = 'left'
-    expect(axis.value).toBe('x')
-    expect(closeSign.value).toBe(-1)
-  })
-
-  it('reacts to snap point + travel changes', () => {
-    const travel = ref(800)
-    const { snapPositions } = useSheetBehavior({
-      direction: 'bottom',
-      snapPoints: [0.5, 0.9],
-      travel,
-      velocityThreshold: 400,
-      dismissVelocity: 600,
-      dismissThreshold: 80,
-      enableDragToClose: true,
-    })
-    expect(snapPositions.value[0]).toBeCloseTo(80, 5)
-    expect(snapPositions.value[1]).toBe(400)
-
-    travel.value = 1000
-    expect(snapPositions.value[0]).toBeCloseTo(100, 5)
-    expect(snapPositions.value[1]).toBe(500)
-  })
-
-  it('exposes progressFor + pickRelease bound to the current options', () => {
-    const { progressFor, pickRelease } = useSheetBehavior({
-      direction: 'bottom',
-      snapPoints: [1],
-      travel: 800,
-      velocityThreshold: 400,
-      dismissVelocity: 600,
-      dismissThreshold: 80,
-      enableDragToClose: true,
-    })
-    expect(progressFor(0)).toBe(1)
-    expect(progressFor(800)).toBe(0)
-
-    const result = pickRelease(0, 0)
-    expect(result.dismiss).toBe(false)
-    expect(result.snapIndex).toBe(0)
   })
 })

--- a/packages/core/src/shared/composables/useSheetBehavior.ts
+++ b/packages/core/src/shared/composables/useSheetBehavior.ts
@@ -1,10 +1,9 @@
 /**
- * Shared snap-and-drag math for edge-anchored overlays (mobile `Sheet`,
- * top-level `Drawer`). Two consumers, two adapters: Sheet drives the
- * transform from main-thread worklets, Drawer drives it from a Vue
- * reactive ref with a CSS transition. The behavior surface — direction
- * → axis mapping, snap point resolution, release decision, progress
- * computation — is identical, so it lives here.
+ * Snap-and-drag math for edge-anchored overlays (`Sheet` and its kit
+ * wrappers). Pure, unit-tested spec functions: Sheet's BG side calls
+ * them directly; its MT worklets keep inline copies of the release
+ * math (SWC's worklet transform can't follow imports from a regular
+ * module — see `SheetContentImpl.vue`).
  *
  * ## Coordinate system
  *
@@ -17,12 +16,8 @@
  *
  * ## Velocity convention
  *
- * `px/s`, positive = toward close. Callers convert as needed
- * (`Drawer` natively tracks px/ms; multiply by 1000).
+ * `px/s`, positive = toward close.
  */
-
-import type { ComputedRef, MaybeRefOrGetter } from 'vue'
-import { computed, toValue } from 'vue'
 
 import { clamp } from '../clamp.js'
 
@@ -103,22 +98,11 @@ export function viewportSnapsToPositions(
   )
 }
 
-/** 0 = closed, 1 = fully open. Clamps out-of-range positions. */
-export function progressFor(position: number, travel: number): number {
-  if (travel <= 0) return 0
-  return clamp(1 - position / travel, 0, 1)
-}
-
 export interface PickReleaseOptions {
   /** Sorted ascending; `[0]` = most open. */
   snapPositions: readonly number[]
   /** `enableDragToClose === false` disables dismiss regardless of position/velocity. */
   enableDragToClose: boolean
-  /**
-   * Velocity (px/s, toward close) above which a fling advances by one snap
-   * regardless of release position.
-   */
-  velocityThreshold: number
   /**
    * Velocity (px/s, toward close) at which a fling triggers dismiss when
    * past the most-closed snap. Set to `Infinity` to disable velocity-based
@@ -161,8 +145,8 @@ export interface PickReleaseResult {
  *      (mouse-friendly fallback — desktop drags rarely have fling velocity)
  * 3. Otherwise pick the snap nearest `projected`. The projection naturally
  *    implements a "flick advances one snap" behavior without a separate
- *    rule, as long as `coastMs * velocityThreshold` is roughly half a
- *    typical snap gap.
+ *    velocity-threshold rule — a real flick's coast carries it past the
+ *    midpoint to the next snap.
  */
 export function pickRelease(
   position: number,
@@ -212,67 +196,5 @@ export function pickRelease(
     snapIndex: nearestIdx,
     targetPosition: snapPositions[nearestIdx],
     dismiss: false,
-  }
-}
-
-// --- Reactive wrapper ----------------------------------------------------
-
-export interface UseSheetBehaviorOptions {
-  direction: MaybeRefOrGetter<SheetDirection>
-  snapPoints: MaybeRefOrGetter<readonly SheetSnap[]>
-  /** Sheet extent in px along the drag axis. */
-  travel: MaybeRefOrGetter<number>
-  /** Fling-to-next-snap threshold (px/s, toward close). */
-  velocityThreshold: MaybeRefOrGetter<number>
-  /** Fling-to-dismiss threshold (px/s, toward close). */
-  dismissVelocity: MaybeRefOrGetter<number>
-  /** Position past most-closed (px) that triggers dismiss on release. */
-  dismissThreshold: MaybeRefOrGetter<number>
-  /** Whether drag past most-closed should dismiss. */
-  enableDragToClose: MaybeRefOrGetter<boolean>
-  /** Inertial coast for release snap selection (ms). Default `100`. */
-  coastMs?: MaybeRefOrGetter<number>
-}
-
-export interface UseSheetBehaviorReturn {
-  axis: ComputedRef<'x' | 'y'>
-  closeSign: ComputedRef<1 | -1>
-  /** Resolved snap positions, sorted ascending (`[0]` = most open). */
-  snapPositions: ComputedRef<number[]>
-  /** Map current position → progress 0 (closed) – 1 (open). */
-  progressFor: (position: number) => number
-  /** Decide where to settle on release (px/s velocity, toward close). */
-  pickRelease: (position: number, velocity: number) => PickReleaseResult
-}
-
-/**
- * Reactive wrapper around the pure helpers. Drawer consumes the whole
- * thing; Sheet's BG side uses `snapPositions` and the pure helpers
- * directly (its MT worklets keep inline copies of the release math —
- * SWC's worklet transform can't follow imports from a regular module).
- */
-export function useSheetBehavior(
-  opts: UseSheetBehaviorOptions,
-): UseSheetBehaviorReturn {
-  const axis = computed(() => directionAxis(toValue(opts.direction)))
-  const closeSign = computed(() => directionCloseSign(toValue(opts.direction)))
-
-  const snapPositions = computed(() =>
-    resolveSnapPositions(toValue(opts.snapPoints), toValue(opts.travel)),
-  )
-
-  return {
-    axis,
-    closeSign,
-    snapPositions,
-    progressFor: (position: number) => progressFor(position, toValue(opts.travel)),
-    pickRelease: (position: number, velocity: number) => pickRelease(position, velocity, {
-      snapPositions: snapPositions.value,
-      enableDragToClose: toValue(opts.enableDragToClose),
-      velocityThreshold: toValue(opts.velocityThreshold),
-      dismissVelocity: toValue(opts.dismissVelocity),
-      dismissThreshold: toValue(opts.dismissThreshold),
-      coastMs: opts.coastMs == null ? 100 : toValue(opts.coastMs),
-    }),
   }
 }

--- a/packages/core/src/shared/gesture/physics.test.ts
+++ b/packages/core/src/shared/gesture/physics.test.ts
@@ -19,7 +19,6 @@ import {
   easeOutCubic,
   HORIZONTAL_CONSUME_RANGES,
   isAngleInRanges,
-  pickSnap,
   projectMomentum,
   pruneQueue,
   resolveAxisLock,
@@ -360,46 +359,6 @@ describe('decideSnapTarget', () => {
       ...base, count: 0, startOffset: 0, endOffset: 0, velocity: 0,
     })
     expect(target).toBe(0)
-  })
-})
-
-describe('pickSnap', () => {
-  const opts = { velocityThreshold: 300 }
-
-  // Carousel: uniform negative offsets (0, -100, -200, -300).
-  const pages = [0, -100, -200, -300]
-
-  it('snaps to the nearest candidate with no flick', () => {
-    expect(pickSnap(-80, 0, pages, opts)).toBe(-100)
-    expect(pickSnap(-40, 0, pages, opts)).toBe(0)
-  })
-
-  it('flick advances one candidate in the travel direction', () => {
-    // drag left (offset decreasing) past threshold from near -100 → -200
-    expect(pickSnap(-90, -400, pages, opts)).toBe(-200)
-    // flick back right from near -100 → 0
-    expect(pickSnap(-120, 400, pages, opts)).toBe(0)
-  })
-
-  it('does not advance past the last candidate on a flick', () => {
-    expect(pickSnap(-300, -1000, pages, opts)).toBe(-300)
-    expect(pickSnap(0, 1000, pages, opts)).toBe(0)
-  })
-
-  // Sheet/drawer: "dismiss" is just another candidate. Down = +offset.
-  it('treats dismiss as a candidate (position-based)', () => {
-    const sheet = [0, 600] // 0 = open, 600 = dismissed off-screen
-    expect(pickSnap(100, 0, sheet, opts)).toBe(0) // barely dragged → snap open
-    expect(pickSnap(500, 0, sheet, opts)).toBe(600) // dragged most of the way → dismiss
-  })
-
-  it('treats dismiss as a candidate (velocity flick)', () => {
-    const sheet = [0, 600]
-    expect(pickSnap(100, 800, sheet, opts)).toBe(600) // fast downward flick → dismiss
-  })
-
-  it('returns the position unchanged when there are no candidates', () => {
-    expect(pickSnap(42, 999, [], opts)).toBe(42)
   })
 })
 

--- a/packages/core/src/shared/gesture/physics.ts
+++ b/packages/core/src/shared/gesture/physics.ts
@@ -10,8 +10,8 @@
 // `src/utils/index.ts`.
 //
 // `decideSnapTarget` is the uniform-paging (carousel) specialization;
-// `pickSnap` is the generic candidate-based form that also serves
-// arbitrary snap points + dismiss (Sheet/drawer). See #37.
+// the sheet family's arbitrary-snap release spec lives in
+// `useSheetBehavior.pickRelease` instead.
 
 /** Gospel: `const/index.ts` — slop before axis lock engages. */
 export const GESTURE_THRESHOLD = 8
@@ -339,48 +339,6 @@ export function decideSnapTarget(opts: SnapTargetOpts): number {
   if (target > count - 1)
     return count - 1
   return target
-}
-
-export interface PickSnapOpts {
-  /** Absolute velocity (px/s) above which a flick advances one candidate. */
-  velocityThreshold: number
-}
-
-/**
- * Generic candidate-based snap. Picks the resting offset nearest the release
- * `position`; a flick (`|velocity| >= velocityThreshold`) advances one
- * candidate in the direction of travel instead. Velocity sign is in offset
- * space (positive = offset increasing).
- *
- * This is the policy-agnostic generalization of `decideSnapTarget`: the
- * caller supplies the allowed resting offsets, so it serves both a carousel
- * (uniform item offsets) and a Sheet/drawer (arbitrary snap-point offsets,
- * with "dismiss" expressed as just another candidate). Returns the chosen
- * offset — the caller maps it back to an index / open-state in `onSettle`.
- */
-export function pickSnap(
-  position: number,
-  velocity: number,
-  candidates: number[],
-  { velocityThreshold }: PickSnapOpts,
-): number {
-  'main thread'
-  if (candidates.length === 0)
-    return position
-
-  let nearest = candidates[0]
-  for (let i = 1; i < candidates.length; i++) {
-    if (Math.abs(candidates[i] - position) < Math.abs(nearest - position))
-      nearest = candidates[i]
-  }
-
-  if (Math.abs(velocity) < velocityThreshold)
-    return nearest
-
-  // Flick: step one candidate in the direction of travel.
-  const sorted = candidates.slice().sort((a, b) => a - b)
-  const next = sorted[sorted.indexOf(nearest) + (velocity > 0 ? 1 : -1)]
-  return next === undefined ? nearest : next
 }
 
 /** Gospel: `utils/index.ts:7` — cubic ease-out for snap animation. */

--- a/packages/kit/src/components/Modal.vue
+++ b/packages/kit/src/components/Modal.vue
@@ -74,6 +74,8 @@ export interface ModalProps {
 export interface ModalEmits {
   (e: 'update:open', value: boolean): void
   (e: 'update:modelValue', value: boolean): void
+  /** Fired when `dismissible: false` blocked an outside-tap dismiss. */
+  (e: 'close:prevent'): void
 }
 
 export interface ModalSlots {
@@ -147,6 +149,14 @@ const onUpdateOpen = (value: boolean) => {
 // prop — `<template #footer="{ close }">…@click="close"…`).
 const close = () => onUpdateOpen(false)
 
+// Mirrors Popover: dismissible defaults true; when false, swallow the
+// outside-tap dismiss and surface it as `close:prevent`.
+function onInteractOutside(event: any) {
+  if (props.dismissible) return
+  event?.preventDefault?.()
+  emit('close:prevent')
+}
+
 const ui = computed(() => buildModal(appConfig)({
   transition: props.transition,
 }))
@@ -168,6 +178,7 @@ const resolvedCloseIcon = computed(() => props.closeIcon || appConfig.ui.icons?.
       <DialogContent
         :backdrop-class="overlay ? ui.overlay({ class: props.ui?.overlay }) : undefined"
         :class="ui.content({ class: props.ui?.content })"
+        @interact-outside="onInteractOutside"
       >
         <slot v-if="hasContentSlot" name="content" :close="close" />
 


### PR DESCRIPTION
First slice of the overlay-core work: deletions and small fixes the audit surfaced, independent of the refactor itself.

- remove `SheetRoot.velocityThreshold` — documented as unused/reserved; release logic uses the coast projection (`dismissVelocity` + `coastMs`)
- delete the consumerless `useSheetBehavior()` reactive wrapper, `progressFor`, and their types — the "Drawer consumer" its docs referenced never existed; pure spec helpers stay
- wire kit `VyModal.dismissible` — was declared but never bound; now blocks backdrop-tap dismiss and emits `close:prevent`, mirroring `VyPopover`
- drive sheet enter/exit keyframe duration from the `duration` prop via inline `animation-duration` — was hardcoded 280ms while every MT settle path used the prop, so `VyTray` (300ms) desynced
- update Modal docs (limitation removed, emit documented) and generated API JSON

Verified: 953 tests green across packages, core/kit typecheck + build, kit-demo builds both envs.