### PR TITLE
chore(core): export combineGroupState, drop DialogContent's inlined copy

### DIFF
--- a/.changeset/presence-combine-export.md
+++ b/.changeset/presence-combine-export.md
@@ -1,0 +1,5 @@
+---
+"@vyui/core": patch
+---
+
+Export `combineGroupState` from Presence and use it in `DialogContent`, deleting the inlined copy that noted "(not exported)".

--- a/packages/core/src/components/Dialog/DialogContent.vue
+++ b/packages/core/src/components/Dialog/DialogContent.vue
@@ -20,7 +20,7 @@ export interface DialogContentProps extends Omit<DialogContentImplProps, 'trapFo
 
 <script setup lang="ts">
 import { computed, provide, ref, watch } from 'vue'
-import { PresenceState } from '@/components/Presence'
+import { PresenceState, combineGroupState } from '@/components/Presence'
 import { useEmitAsProps, useForwardExpose } from '@/shared'
 import DialogContentModal from './DialogContentModal.vue'
 import DialogContentNonModal from './DialogContentNonModal.vue'
@@ -60,28 +60,12 @@ const panelState = ref<PresenceState>(
   showRef.value ? PresenceState.Entering : PresenceState.Left,
 )
 
-function combine(states: PresenceState[]): PresenceState {
-  // DelayedEntering > Entering > Leaving > Entered > Left precedence.
-  // Inlined from `usePresenceGroup.combineGroupState` (not exported).
-  if (states.some(s => s === PresenceState.DelayedEntering))
-    return PresenceState.DelayedEntering
-  if (states.some(s => s === PresenceState.Entering))
-    return PresenceState.Entering
-  if (states.some(s => s === PresenceState.Leaving))
-    return PresenceState.Leaving
-  if (states.every(s => s === PresenceState.Entered))
-    return PresenceState.Entered
-  if (states.every(s => s === PresenceState.Left))
-    return PresenceState.Left
-  return PresenceState.Left
-}
-
 // Mirror the combined state up to the root context so DialogTrigger/Close
 // can `resolveBusyState` against it without injecting Presence.
 watch(
   [backdropState, panelState],
   ([a, b]) => {
-    rootContext.setGroupState(combine([a, b]))
+    rootContext.setGroupState(combineGroupState([a, b]))
   },
   { immediate: true },
 )

--- a/packages/core/src/components/Presence/index.ts
+++ b/packages/core/src/components/Presence/index.ts
@@ -27,6 +27,7 @@ export {
 } from './usePresence'
 
 export {
+  combineGroupState,
   usePresenceGroup,
   type PresenceGroupChild,
   type UsePresenceGroupOptions,

--- a/packages/core/src/components/Presence/usePresenceGroup.ts
+++ b/packages/core/src/components/Presence/usePresenceGroup.ts
@@ -69,7 +69,12 @@ export interface UsePresenceGroupReturn {
   mountView: Ref<boolean>
 }
 
-function combineGroupState(states: PresenceState[]): PresenceState {
+/**
+ * Combine member states into the group's state. Exported for overlays that
+ * coordinate their layers with manually-controlled `<Presence>` wrappers
+ * (Dialog's backdrop + panel) instead of `usePresenceGroup`'s render path.
+ */
+export function combineGroupState(states: PresenceState[]): PresenceState {
   // `DelayedEntering` wins over `Entering` so the parent can keep
   // `enableDelay`'d members in their layout-settle phase.
   if (states.some(s => s === PresenceState.DelayedEntering)) {


### PR DESCRIPTION
Small phase-2 consolidation slice from the overlay audit.

- export `combineGroupState` from `Presence` (was module-private; `DialogContent` carried a hand-inlined copy marked "not exported")
- `DialogContent` now imports it; inline `combine()` deleted

Dialog/Presence/AlertDialog tests green, core typecheck passes.