### PR TITLE
chore(examples): drop MT-worklet side-effect import stopgap (#58 cleanup)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,14 +89,11 @@ vue-lynx's MT worklet loader — which only walks relative imports, not
 These are the recurring footguns. If a worklet-touching change goes sideways,
 ninety percent of the time it's one of these:
 
-- The `worklet-loader-mt` regex only walks **relative imports** — bare
-  `@vyui/core` imports don't propagate to the MT graph. The consumer must
-  reach worklet source via a relative path for SWC to follow the chain.
-- Every demo entry has a **side-effect relative anchor** at the top of its
-  entry file, e.g.
-  `import '../../../../packages/core/src'`. **Don't delete it.** Without it
-  the MT walker never sees the package and worklets disappear from the MT
-  bundle.
+- The MT worklet walker follows the demos' **source aliases** natively
+  (vue-lynx ≥ 0.4.2). Real `node_modules` consumers instead need
+  `pluginVueLynx({ includeWorkletPackages: ['@vyui/core', '@vyui/kit'] })` —
+  without it, bare `@vyui/*` imports never reach the MT graph and worklets
+  crash with `bind of undefined`.
 - **Cross-file `'main thread'` calls work but are fragile.** Inline every
   worklet inside the component that uses it.
 - **Storing arrow functions in `useMainThreadRef<() => void>` kills the

--- a/apps/examples/docs-playground/src/index.ts
+++ b/apps/examples/docs-playground/src/index.ts
@@ -1,12 +1,3 @@
-// MT-worklet propagation: vue-lynx's `worklet-loader-mt` only walks RELATIVE
-// imports into the main-thread graph; bare specifiers like `@vyui/core` are
-// silently skipped, so the MT bundle never registers any of our worklets and
-// every touch crashes with `bind of undefined`. Drop a single side-effect
-// relative import here so the walker can descend through core.
-// @ts-expect-error — path resolves at build time via rspack; out of the
-// playground's TS project file list. See `packages/core/src/index.ts`.
-import '../../../../packages/core/src'
-
 import { createApp } from 'vue-lynx'
 import { VyUI } from '@vyui/kit'
 import lucide from '@iconify-json/lucide/icons.json'

--- a/apps/examples/kit-demo/src/index.ts
+++ b/apps/examples/kit-demo/src/index.ts
@@ -1,12 +1,3 @@
-// MT-worklet propagation: vue-lynx's `worklet-loader-mt` only walks RELATIVE
-// imports into the main-thread graph; bare specifiers like `@vyui/core` are
-// silently skipped, so the MT bundle never registers any of our worklets and
-// every touch crashes with `bind of undefined`. Drop a single side-effect
-// relative import here so the walker can descend through core.
-// @ts-expect-error — path resolves at build time via rspack; out of the
-// demo's TS project file list. See `packages/core/src/index.ts`.
-import '../../../../packages/core/src'
-
 import { createApp } from 'vue-lynx'
 import { COLORS, VyUI } from '@vyui/kit'
 import { installVyui } from '../../_shared/installVyui'

--- a/apps/examples/linear-demo/src/index.ts
+++ b/apps/examples/linear-demo/src/index.ts
@@ -1,12 +1,3 @@
-// MT-worklet propagation: vue-lynx's `worklet-loader-mt` only walks RELATIVE
-// imports into the main-thread graph; bare specifiers like `@vyui/core` are
-// silently skipped, so the MT bundle never registers any of our worklets and
-// every touch crashes with `bind of undefined`. Drop a single side-effect
-// relative import here so the walker can descend through core.
-// @ts-expect-error — path resolves at build time via rspack; out of the
-// demo's TS project file list. See `packages/core/src/index.ts`.
-import '../../../../packages/core/src'
-
 import { createApp } from 'vue-lynx'
 import { VyUI } from '@vyui/kit'
 import iconParkOutline from '@iconify-json/icon-park-outline/icons.json'

--- a/apps/examples/shadcn-demo/src/index.ts
+++ b/apps/examples/shadcn-demo/src/index.ts
@@ -1,10 +1,3 @@
-// MT-worklet propagation: vue-lynx's `worklet-loader-mt` only walks RELATIVE
-// imports into the main-thread graph; bare specifiers like `@vyui/core` are
-// silently skipped. Drop a single side-effect relative import so the walker
-// descends through core (same as kit-demo).
-// @ts-expect-error — resolves at build time via rspack; outside the demo's TS project.
-import '../../../../packages/core/src'
-
 import { createApp } from 'vue-lynx'
 import { VyUI } from '@vyui/kit'
 import lucide from '@iconify-json/lucide/icons.json'

--- a/apps/examples/tiktok-demo/src/index.ts
+++ b/apps/examples/tiktok-demo/src/index.ts
@@ -1,12 +1,3 @@
-// MT-worklet propagation: vue-lynx's `worklet-loader-mt` only walks RELATIVE
-// imports into the main-thread graph; bare specifiers like `@vyui/core` are
-// silently skipped, so the MT bundle never registers any of our worklets and
-// every touch crashes with `bind of undefined`. Drop a single side-effect
-// relative import here so the walker can descend through core.
-// @ts-expect-error — path resolves at build time via rspack; out of the
-// demo's TS project file list. See `packages/core/src/index.ts`.
-import '../../../../packages/core/src'
-
 import { createApp } from 'vue-lynx'
 import { VyUI } from '@vyui/kit'
 import iconParkOutline from '@iconify-json/icon-park-outline/icons.json'

--- a/apps/examples/vyai/src/index.ts
+++ b/apps/examples/vyai/src/index.ts
@@ -1,12 +1,3 @@
-// MT-worklet propagation: vue-lynx's `worklet-loader-mt` only walks RELATIVE
-// imports into the main-thread graph; bare specifiers like `@vyui/core` are
-// silently skipped, so the MT bundle never registers any of our worklets and
-// every touch crashes with `bind of undefined`. Drop a single side-effect
-// relative import here so the walker can descend through core.
-// @ts-expect-error — path resolves at build time via rspack; out of the
-// demo's TS project file list. See `packages/core/src/index.ts`.
-import '../../../../packages/core/src'
-
 import { createApp } from 'vue-lynx'
 import { VyUI } from '@vyui/kit'
 import iconParkOutline from '@iconify-json/icon-park-outline/icons.json'


### PR DESCRIPTION
Final #58 cleanup now that vue-lynx#190 shipped (0.4.2, adopted in #142 which already removed the patch + `patchedDependencies`).

- remove the `import '../../../../packages/core/src'` side-effect (+ its comment block) from all 6 demo `index.ts` files
- `includeWorkletPackages` deliberately NOT added to demo configs: demos alias `@vyui/*` at workspace source (`_shared/vyui-aliases.ts`), so the 0.4.2 resolver follows those imports natively — the option only matters for real `node_modules` consumers and is documented in the installation guide
- MT bundle audit re-run post-removal: `UNRESOLVED: 0` on every demo (regs/refs unchanged, e.g. kit-demo 166/158)

Remaining before closing #58: device-verify drag/gesture on a demo build. Note the checklist's vue-lynx 0.5.1 bump is blocked by an upstream MT-transform regression (Draggable) — documented in `docs/upstream/vue-lynx-mt-worklet-import-issue.md`; 0.4.2 contains both halves of #190.

Closes #58.