### PR TITLE
fix(changeset): drop private @vyui/testing-utils from mixed changeset

### DIFF
--- a/.changeset/vue-lynx-042-unpatched.md
+++ b/.changeset/vue-lynx-042-unpatched.md
@@ -1,7 +1,6 @@
 ---
 "@vyui/core": patch
 "@vyui/kit": patch
-"@vyui/testing-utils": patch
 ---
 
 Require `vue-lynx@^0.4.2` and drop the local worklet-loader patch: upstream #190 now follows aliased and package worklet imports, with `includeWorkletPackages` for `node_modules` consumers. NPM consumers must set `pluginVueLynx({ includeWorkletPackages: ['@vyui/core', '@vyui/kit'] })` — documented in the installation guide.


### PR DESCRIPTION
Unblocks the Release workflow (run #47 failed in `changeset version`).

- `@vyui/testing-utils` is `private: true` and `privatePackages.version: false` makes changesets treat it as ignored
- Mixing ignored + publishable packages in one changeset is a hard error, so `vue-lynx-042-unpatched` failed the release
- Dropped the testing-utils line; the private package needs no version bump