### PR TITLE
fix(core): paint Sheet through the app-root OverlayRoot

### DIFF
--- a/.changeset/sheet-overlay-portal.md
+++ b/.changeset/sheet-overlay-portal.md
@@ -1,0 +1,9 @@
+---
+"@vyui/core": patch
+---
+
+Sheet now paints through the app-root `<OverlayRoot>` so it escapes ancestor `overflow: hidden` on Lynx native (#12).
+
+`SheetContent` and `SheetBackdrop` wrap their impls in a new `<OverlayPortal>` (exported from `@vyui/core`), matching how Dialog, DropdownMenu, Combobox and Toast already portal. Presence is unchanged — the portal mounts inside it, so enter/leave animations still run to completion before unmount.
+
+Consumers must have an `<OverlayRoot />` at the app root; `<VyApp>` mounts one by default.

--- a/apps/docs/app/generated/api/Drawer.json
+++ b/apps/docs/app/generated/api/Drawer.json
@@ -84,7 +84,7 @@
       "type": "boolean | undefined",
       "required": false,
       "default": "true",
-      "description": "Render the drawer in a portal. Currently advisory — core `SheetContent` mounts in place."
+      "description": "Render the drawer in a portal. Advisory — sheet content is always portalled through `OverlayRoot`."
     },
     {
       "name": "side",

--- a/apps/docs/app/generated/api/OverlayPortal.json
+++ b/apps/docs/app/generated/api/OverlayPortal.json
@@ -1,0 +1,5 @@
+{
+  "props": [],
+  "events": [],
+  "slots": []
+}

--- a/apps/docs/public/manifest.webmanifest
+++ b/apps/docs/public/manifest.webmanifest
@@ -3,7 +3,7 @@
   "short_name": "Vy UI",
   "description": "Accessible Vue-Lynx component library — headless primitives plus a styled kit that render natively to iOS, Android, and web from one Vue codebase.",
   "start_url": "/",
-  "display": "standalone",
+  "display": "browser",
   "background_color": "#ffffff",
   "theme_color": "#ffffff",
   "icons": [

--- a/packages/core/src/components/OverlayRoot/OverlayPortal.vue
+++ b/packages/core/src/components/OverlayRoot/OverlayPortal.vue
@@ -1,0 +1,32 @@
+<!-- Copyright 2026 The Lynx Authors. All rights reserved.
+     Licensed under the Apache License Version 2.0.
+
+     Renders its slot through the app-root `<OverlayRoot>` instead of in
+     place, so overlay content escapes an ancestor's `overflow: hidden`
+     (Lynx has no `<Teleport>`). Mount/unmount IS the register/unregister —
+     wrap this in `<Presence>` and the leaving animation still plays,
+     because Presence keeps it mounted until `Left`.
+
+     Requires an `<OverlayRoot />` at the app root (`<VyApp>` mounts one);
+     without it the slot paints nowhere. -->
+<script setup lang="ts">
+import { getCurrentInstance, onUnmounted, useSlots } from 'vue'
+import { useId } from '@/shared'
+import { registerOverlay, unregisterOverlay } from './overlayStore'
+
+const slots = useSlots()
+const id = useId()
+// The provides chain is captured here and re-provided by OverlayRoot's
+// ContextBridge, so `inject()` inside the slot (Presence, sheet contexts,
+// SheetClose, …) still resolves despite rendering outside this subtree.
+const capturedProvides = (getCurrentInstance() as
+  | { provides?: Record<any, any> }
+  | null)?.provides
+
+registerOverlay(id, () => slots.default?.(), capturedProvides)
+onUnmounted(() => unregisterOverlay(id))
+</script>
+
+<template>
+  <!-- slot is painted through the app-root <OverlayRoot> -->
+</template>

--- a/packages/core/src/components/OverlayRoot/index.ts
+++ b/packages/core/src/components/OverlayRoot/index.ts
@@ -1,3 +1,4 @@
 export { default as OverlayRoot, type OverlayRootProps } from './OverlayRoot.vue'
 export { default as OverlayBackdrop, type OverlayBackdropProps } from './OverlayBackdrop.vue'
+export { default as OverlayPortal } from './OverlayPortal.vue'
 export { overlayEntries, registerOverlay, unregisterOverlay, type OverlayRenderFn } from './overlayStore'

--- a/packages/core/src/components/Sheet/Sheet.test.ts
+++ b/packages/core/src/components/Sheet/Sheet.test.ts
@@ -161,8 +161,13 @@ describe('SheetBackdrop — Presence wiring', () => {
     const { render } = await import('@vyui/testing-utils')
     const { default: SheetRoot } = await import('./SheetRoot.vue')
     const { default: SheetBackdrop } = await import('./SheetBackdrop.vue')
+    const { OverlayRoot, overlayEntries } = await import('@/components/OverlayRoot')
+    overlayEntries.value = []
 
     const open = ref(initialOpen)
+    // `OverlayRoot` is where the backdrop actually paints — SheetBackdrop only
+    // registers a portal entry (#12). Mirrors the app-root shell every consumer
+    // mounts (`<VyApp>` / the demo `App.vue`s).
     const Wrapper = defineComponent({
       setup() {
         return { open }
@@ -171,8 +176,9 @@ describe('SheetBackdrop — Presence wiring', () => {
         <SheetRoot v-model:open="open" :viewport-height="800">
           <SheetBackdrop data-testid="backdrop" />
         </SheetRoot>
+        <OverlayRoot />
       `,
-      components: { SheetRoot, SheetBackdrop },
+      components: { SheetRoot, SheetBackdrop, OverlayRoot },
     })
 
     const { container } = render(Wrapper)
@@ -304,5 +310,51 @@ describe('SheetContentImpl — viewport height unit (no dvh)', () => {
     expect(sfc).toContain('vyui-sheet-slide-out-to-right')
     expect(sfc).toContain('vyui-sheet-slide-in-from-left')
     expect(sfc).toContain('vyui-sheet-slide-out-to-left')
+  })
+})
+
+// Portal (#12): SheetContent / SheetBackdrop paint through the app-root
+// `<OverlayRoot>` so they escape an ancestor's `overflow: hidden` on Lynx
+// native. Registration is mount-scoped, so with no OverlayRoot rendered the
+// impls never mount — which is also why this can assert without tripping the
+// MTS-binding crash the rest of this file works around.
+describe('Sheet — OverlayRoot portal', () => {
+  async function mountSheet(open: boolean) {
+    const { render } = await import('@vyui/testing-utils')
+    const { default: SheetRoot } = await import('./SheetRoot.vue')
+    const { default: SheetContent } = await import('./SheetContent.vue')
+    const { default: SheetBackdrop } = await import('./SheetBackdrop.vue')
+
+    return render(defineComponent({
+      setup() {
+        return () => h(SheetRoot, { open }, {
+          default: () => [h(SheetBackdrop), h(SheetContent)],
+        })
+      },
+    }))
+  }
+
+  it('registers backdrop + content while open and clears on unmount', async () => {
+    const { overlayEntries } = await import('@/components/OverlayRoot')
+    const { waitForUpdate } = await import('@vyui/testing-utils')
+    overlayEntries.value = []
+
+    const { unmount } = await mountSheet(true)
+    await waitForUpdate()
+    expect(overlayEntries.value.length).toBe(2)
+
+    unmount()
+    await waitForUpdate()
+    expect(overlayEntries.value.length).toBe(0)
+  })
+
+  it('registers nothing while closed', async () => {
+    const { overlayEntries } = await import('@/components/OverlayRoot')
+    const { waitForUpdate } = await import('@vyui/testing-utils')
+    overlayEntries.value = []
+
+    await mountSheet(false)
+    await waitForUpdate()
+    expect(overlayEntries.value.length).toBe(0)
   })
 })

--- a/packages/core/src/components/Sheet/SheetBackdrop.vue
+++ b/packages/core/src/components/Sheet/SheetBackdrop.vue
@@ -21,6 +21,7 @@ export interface SheetBackdropProps {
 
 <script setup lang="ts">
 import { Presence } from '@/components/Presence'
+import { OverlayPortal } from '@/components/OverlayRoot'
 import SheetBackdropImpl from './SheetBackdropImpl.vue'
 import { injectSheetRootContext } from './sheetContext'
 
@@ -38,6 +39,8 @@ function onTap() {
 
 <template>
   <Presence :show="ctx.open.value">
-    <SheetBackdropImpl @tap="onTap" />
+    <OverlayPortal>
+      <SheetBackdropImpl @tap="onTap" />
+    </OverlayPortal>
   </Presence>
 </template>

--- a/packages/core/src/components/Sheet/SheetBackdropImpl.vue
+++ b/packages/core/src/components/Sheet/SheetBackdropImpl.vue
@@ -1,8 +1,10 @@
 <!-- Copyright 2026 The Lynx Authors. All rights reserved.
      Licensed under the Apache License Version 2.0.
 
-     Renders inside `<Presence>` so `inject(PresenceContextKey)` resolves to
-     the parent's payload. Binds `@animationstart` / `@animationend` etc. on
+     Renders inside `<Presence>`, but painted by `OverlayRoot` — so
+     `inject(PresenceContextKey)` resolves through the provides `OverlayPortal`
+     captured at registration, not through tree ancestry.
+     Binds `@animationstart` / `@animationend` etc. on
      the root `<view>` — Lynx fires these as plain BG-thread events on
      keyframe animations, so they advance Presence into Entered / Left. -->
 <script setup lang="ts">

--- a/packages/core/src/components/Sheet/SheetContent.vue
+++ b/packages/core/src/components/Sheet/SheetContent.vue
@@ -23,6 +23,7 @@ export interface SheetContentProps {
 
 <script setup lang="ts">
 import { Presence } from '@/components/Presence'
+import { OverlayPortal } from '@/components/OverlayRoot'
 import SheetContentImpl from './SheetContentImpl.vue'
 import { injectSheetRootContext } from './sheetContext'
 
@@ -36,8 +37,10 @@ const ctx = injectSheetRootContext()
 
 <template>
   <Presence :show="ctx.open.value">
-    <SheetContentImpl :drag-disabled="props.dragDisabled" :fit-content="props.fitContent">
-      <slot />
-    </SheetContentImpl>
+    <OverlayPortal>
+      <SheetContentImpl :drag-disabled="props.dragDisabled" :fit-content="props.fitContent">
+        <slot />
+      </SheetContentImpl>
+    </OverlayPortal>
   </Presence>
 </template>

--- a/packages/kit/src/components/Drawer.vue
+++ b/packages/kit/src/components/Drawer.vue
@@ -33,7 +33,7 @@ export interface DrawerProps {
   transition?: boolean
   /** Render the dim overlay behind the content. */
   overlay?: boolean
-  /** Render the drawer in a portal. Currently advisory — core `SheetContent` mounts in place. */
+  /** Render the drawer in a portal. Advisory — sheet content is always portalled through `OverlayRoot`. */
   portal?: boolean
   /** When `false`, tapping the overlay does not close the drawer. */
   dismissible?: boolean


### PR DESCRIPTION
Sheets now portal to the app-root `<OverlayRoot>` so they escape an ancestor's `overflow: hidden` on Lynx native (#12), plus a small docs fix.

- New `<OverlayPortal>` in `packages/core/src/components/OverlayRoot/` — generalises the register/unregister + captured-provides pattern the 8 existing portal call sites inline.
- `SheetContent` / `SheetBackdrop` wrap their impls in it; `Presence` is untouched, so the portal mounts inside it and leave animations still run to completion.
- Covers the kit components backed by Sheet: Modal, Drawer, Tray, ActionSheet, Select, Combobox, Popover.
- Sheet tests assert register-on-open / clear-on-unmount, and the backdrop Presence test now mounts an `<OverlayRoot>` (that's where it paints).
- Docs manifest `display: standalone` → `browser` — Chrome was offering an install with no service worker behind it, so the installed app had no offline support.

Consumers need an `<OverlayRoot />` at the app root; `<VyApp>` mounts one. Both example apps without one (cli-demo, shadcn-demo) use no sheet-backed components.

`pnpm --filter @vyui/core test` (864 passing) and `typecheck` green. Not device-verified — worth a look on native before merge.
