### PR TITLE
feat: animation feel — Collapsible/Accordion height, velocity settle, TabsIndicator

### DIFF
--- a/.changeset/collapsible-height-morph.md
+++ b/.changeset/collapsible-height-morph.md
@@ -1,0 +1,6 @@
+---
+"@vyui/core": patch
+"@vyui/kit": patch
+---
+
+Animate Collapsible/Accordion height on open/close by tweening a measured px height (Tray recipe); kept-mounted content morphs both directions.

--- a/.changeset/sheet-velocity-settle.md
+++ b/.changeset/sheet-velocity-settle.md
@@ -1,0 +1,5 @@
+---
+"@vyui/core": patch
+---
+
+Scale the Sheet settle/dismiss duration by release velocity so a hard flick settles quicker while a slow release keeps the current feel.

--- a/.changeset/tabs-indicator-one-roundtrip.md
+++ b/.changeset/tabs-indicator-one-roundtrip.md
@@ -1,0 +1,5 @@
+---
+"@vyui/core": patch
+---
+
+Cache the TabsIndicator list rect and re-measure it only on layout/orientation/dir changes, so a tab switch costs one `boundingClientRect` round-trip instead of two.

--- a/packages/core/src/components/AlertDialog/AlertDialogContent.vue
+++ b/packages/core/src/components/AlertDialog/AlertDialogContent.vue
@@ -4,7 +4,7 @@ import type {
   AlertDialogContentImplProps,
 } from './AlertDialogContentImpl.vue'
 
-/** Preventable outside-interaction / focus events — see `AlertDialogContentImpl`. */
+/** Focus lifecycle events (inert on Lynx) — see `AlertDialogContentImpl`. */
 export type AlertDialogContentEmits = AlertDialogContentImplEmits
 
 export interface AlertDialogContentProps extends Omit<AlertDialogContentImplProps, 'trapFocus'> {

--- a/packages/core/src/components/AlertDialog/AlertDialogContentImpl.vue
+++ b/packages/core/src/components/AlertDialog/AlertDialogContentImpl.vue
@@ -2,10 +2,9 @@
 import type { PrimitiveProps } from '@/components/Primitive'
 
 /**
- * Emits kept for API parity with reka-ui's `DialogContentImpl`. All four are
- * inert on Lynx: there is no focus model (`openAutoFocus` / `closeAutoFocus`)
- * and an AlertDialog is never dismissed by an outside tap, so
- * `interactOutside` / `pointerDownOutside` are declared but never fired.
+ * Emits kept for API parity with reka-ui's `DialogContentImpl`. Both are inert
+ * on Lynx: there is no focus model, so `openAutoFocus` / `closeAutoFocus` never
+ * fire.
  */
 export type AlertDialogContentImplEmits = {
   /** Auto-focus on open. Inert on Lynx — kept so call sites mirror reka-ui. */

--- a/packages/core/src/components/Collapsible/Collapsible.test.ts
+++ b/packages/core/src/components/Collapsible/Collapsible.test.ts
@@ -90,6 +90,31 @@ describe('given a Collapsible with `unmountOnHide:false`', () => {
   })
 })
 
+describe('given a keep-mounted Collapsible (height morph)', () => {
+  it('collapses the content to height:0 while closed', async () => {
+    const { container } = render(Collapsible, { unmountOnHide: false })
+    await waitForUpdate()
+    const content = container.querySelector('[hidden]')!
+    expect(content).not.toBeNull()
+    expect(content.getAttribute('style') ?? '').toContain('height: 0px')
+  })
+
+  it('tweens to the measured natural height on open', async () => {
+    const { container } = render(Collapsible, { unmountOnHide: false })
+    await waitForUpdate()
+    const content = container.querySelector('[hidden]')!
+    const contentId = content.id
+    // The inner wrapper reports its natural height via @layoutchange; the outer
+    // container then animates to that concrete px value.
+    fireEvent.layoutchange(content.firstElementChild!, { detail: { height: 120 } })
+    fireEvent.tap(container.querySelector('[data-testid="trigger"]')!)
+    await waitForUpdate()
+    const open = container.querySelector(`#${contentId}`)!
+    expect(open.getAttribute('style') ?? '').toContain('height: 120px')
+    expect(open.hasAttribute('hidden')).toBe(false)
+  })
+})
+
 describe('given an open uncontrolled Collapsible', () => {
   describe('when first rendered', () => {
     let container: Element

--- a/packages/core/src/components/Collapsible/CollapsibleContent.vue
+++ b/packages/core/src/components/Collapsible/CollapsibleContent.vue
@@ -7,7 +7,7 @@ export interface CollapsibleContentProps extends PrimitiveProps {
 </script>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import { Primitive } from '@/components/Primitive'
 import { useForwardExpose, useId } from '@/shared'
 import { injectCollapsibleRootContext } from './CollapsibleRoot.vue'
@@ -31,6 +31,64 @@ const isHidden = computed(() => !isOpen.value)
 const shouldMount = computed(
   () => props.forceMount || isOpen.value || !rootContext.unmountOnHide.value,
 )
+
+// -- Height morph -------------------------------------------------------------
+// Animate open/close by tweening the outer container's height between 0 and the
+// content's natural height (the device-proven Lynx recipe from `Tray` — MT
+// `setStyleProperty('height')` is a no-op, so the height rides an inline px
+// value that the consumer's `transition-[height]` class interpolates; core
+// stays headless and ships neither the clip nor the timing). The inner wrapper
+// is never height-constrained, so its `@layoutchange` reports the natural
+// height even while the outer clips it to 0.
+const measuredHeight = ref<number | null>(null)
+
+function onContentLayout(event: { detail?: { height?: number } } | undefined) {
+  const h = event?.detail?.height
+  if (typeof h === 'number' && h > 0)
+    measuredHeight.value = Math.round(h)
+}
+
+// Disarmed for the first paint so a `defaultOpen` panel (or a CSS reload)
+// doesn't animate growing in from zero — only genuine toggles after mount
+// tween. Same one-tick arm idiom as `TabsIndicator`.
+const armed = ref(false)
+onMounted(() => { nextTick(() => { armed.value = true }) })
+
+// A fresh open needs a committed `0` baseline before it can tween up: a
+// brand-new node (unmount mode) or one sitting at `height:0` (kept mounted) has
+// nothing to transition FROM if it paints straight at its natural height. So
+// render `0` for one tick when opening, then release to the measured height and
+// CSS interpolates 0 → natural.
+const growingFromZero = ref(false)
+watch(isOpen, (open) => {
+  if (!open)
+    return
+  growingFromZero.value = true
+  nextTick(() => { growingFromZero.value = false })
+})
+
+const contentStyle = computed(() => {
+  // `transitionProperty: 'none'` (inline) beats the consumer's
+  // `transition-[height]` until armed; `undefined` drops it so the class wins.
+  const transitionProperty = armed.value ? undefined : 'none'
+  // Closed, or the one-frame open baseline → 0. Open + measured → a concrete px
+  // value (so both the grow and a later content-resize tween from it). Open
+  // before the first measure → auto (no explicit height): nothing animates in.
+  if (!isOpen.value || growingFromZero.value)
+    return { height: '0px', transitionProperty }
+  if (measuredHeight.value == null)
+    return { transitionProperty }
+  return { height: `${measuredHeight.value}px`, transitionProperty }
+})
+
+// ponytail: a close in the DEFAULT unmount mode still snaps — the content is
+// v-if'd out the instant `open` flips false, before the collapse can play.
+// Animating it needs the leave gated on the height `@transitionend` (keep the
+// node mounted through the tween, then unmount), i.e. wrapping this in
+// `Presence` the way `SheetContentImpl` does. That changes the synchronous
+// unmount timing every current Collapsible/Accordion test (and consumers) rely
+// on, so it's deferred; the kept-mounted path (`unmountOnHide: false`) morphs
+// both directions today.
 </script>
 
 <template>
@@ -44,7 +102,10 @@ const shouldMount = computed(
     :data-state="isOpen ? 'open' : 'closed'"
     :data-disabled="rootContext.disabled?.value ? '' : undefined"
     :hidden="!rootContext.unmountOnHide.value && isHidden ? '' : undefined"
+    :style="contentStyle"
   >
-    <slot />
+    <view @layoutchange="onContentLayout">
+      <slot />
+    </view>
   </Primitive>
 </template>

--- a/packages/core/src/components/Sheet/SheetContentImpl.vue
+++ b/packages/core/src/components/Sheet/SheetContentImpl.vue
@@ -501,11 +501,18 @@ function _onTouchEnd() {
     && (velocity >= dismissVelocityRef.current
       || projected > mostClosed + extentPx * 0.4)
 
-  // Settle timings derive from SheetRoot's `duration` prop: snap settle uses
-  // the full duration; dismiss is a slightly quicker 0.9× cut (matches the
-  // previous hardcoded 280 / 250ms feel at the default duration).
+  // Settle timing scales with release speed: a hard flick reaches its target in
+  // less time (`remaining / speed`), so the settle plays quicker; a slow or
+  // stationary release yields a huge time that clamps to `durationMs`, keeping
+  // the unflicked feel. Floored at 120ms so a violent flick can't snap
+  // instantly. MIRRORS `settleDurationMs` in physics.ts (worklets can't import
+  // it — keep in sync); dismiss keeps its 0.9× cut over the scaled base.
+  const MIN_SETTLE_MS = 120
   if (shouldDismiss) {
-    const dismissMs = Math.round(durationMs * 0.9)
+    let base = (Math.abs(extentPx - pos) / Math.max(Math.abs(velocity), 0.001)) * 1000
+    if (base < MIN_SETTLE_MS) base = MIN_SETTLE_MS
+    if (base > durationMs) base = durationMs
+    const dismissMs = Math.round(base * 0.9)
     // Slide off from the live drag position (`animation: none` suppresses the
     // `.ui-leaving` keyframe so it can't snap to translateY(0) first; the
     // frame-1 re-pin in `_settleTo` guards the flick case). `@transitionend`
@@ -526,12 +533,15 @@ function _onTouchEnd() {
       }
     }
     const target = positions.length > 0 ? positions[idx] : 0
+    let settleMs = (Math.abs(target - pos) / Math.max(Math.abs(velocity), 0.001)) * 1000
+    if (settleMs < MIN_SETTLE_MS) settleMs = MIN_SETTLE_MS
+    if (settleMs > durationMs) settleMs = durationMs
     // Below fully open, inline `animation: none` stays on the panel so a
     // later non-drag close can't start `.ui-leaving` from translateY(0)
     // (`_slideOffFromCurrent` drives those closes). At fully open the
     // inline animation is cleared (empty-string value) so the keyframe paths
     // apply again.
-    _settleTo(target, _translate(target), durationMs, 'ease-out', target === 0)
+    _settleTo(target, _translate(target), Math.round(settleMs), 'ease-out', target === 0)
     runOnBackground(_settle as any)(idx)
   }
 }

--- a/packages/core/src/components/Tabs/TabsIndicator.vue
+++ b/packages/core/src/components/Tabs/TabsIndicator.vue
@@ -41,13 +41,23 @@ const indicatorStyle = ref<IndicatorStyle>({
 // queue (same idiom as `TabsTrigger`'s deferred registration).
 const ready = ref(false)
 
+// The list rect only moves on a layout change (or an orientation/dir flip), so
+// cache it and re-measure only then. A plain tab switch reuses the cache and
+// costs a single trigger `boundingClientRect` round-trip instead of two.
+// ponytail: assumes the list rect is stable between `layoutTick` bumps —
+// TabsList + TabsTrigger bump it from their own `@layoutchange`, so a list that
+// shifts without emitting one would read stale until the next bump.
+let cachedListRect: Awaited<ReturnType<typeof useElementRect>> | null = null
+
 /**
  * Measure the active trigger relative to the tabs list via Lynx's
  * `boundingClientRect` (see `useElementRect`). Replaces the prior
  * `querySelectorAll('[role="tab"]')` + `offsetWidth`/`offsetLeft` reads which
- * relied on a DOM that does not exist on Lynx native.
+ * relied on a DOM that does not exist on Lynx native. `refreshList` re-measures
+ * the cached list rect (a layout/orientation/dir change); a tab switch leaves
+ * it false and measures only the trigger.
  */
-async function updateIndicatorStyle() {
+async function updateIndicatorStyle(refreshList = false) {
   const activeValue = context.modelValue.value
   if (activeValue === undefined)
     return
@@ -57,10 +67,10 @@ async function updateIndicatorStyle() {
   if (!triggerEl || !listEl)
     return
 
-  const [triggerRect, listRect] = await Promise.all([
-    useElementRect(triggerEl),
-    useElementRect(listEl),
-  ])
+  if (refreshList || cachedListRect == null)
+    cachedListRect = await useElementRect(listEl)
+  const listRect = cachedListRect
+  const triggerRect = await useElementRect(triggerEl)
 
   // First paint on Lynx can return a zero rect; skip that frame and wait for
   // the follow-up `@layoutchange` (which bumps `layoutTick` and re-runs us).
@@ -87,23 +97,28 @@ async function updateIndicatorStyle() {
     Promise.resolve().then(() => { ready.value = true })
 }
 
-// Re-measure on active value / orientation / direction changes, plus on the
-// `layoutTick` that `TabsList` + `TabsTrigger` bump from their
-// `@layoutchange`. The triggers map is intentionally NOT a watch source:
-// mutating it (from `TabsTrigger`'s deferred registration) used to wake this
-// `flush: 'post'` watcher mid-patch under nested Tabs and produce
+// A tab switch moves the trigger but not the list — reuse the cached list rect.
+watch(
+  () => context.modelValue.value,
+  () => { updateIndicatorStyle() },
+  { flush: 'post' },
+)
+
+// Orientation / direction / `layoutTick` changes can move the list itself, so
+// refresh the cached list rect. `layoutTick` is bumped by `TabsList` +
+// `TabsTrigger` from their `@layoutchange`; `immediate` drives the first
+// measurement once the triggers paint. The triggers map is intentionally NOT a
+// watch source: mutating it (from `TabsTrigger`'s deferred registration) used
+// to wake this `flush: 'post'` watcher mid-patch under nested Tabs and produce
 // `Cannot read property 'parent' of null` from `node-ops.parentNode`. The
-// trigger element is read inside `updateIndicatorStyle` instead — the
-// layoutchange tick is sufficient to drive the first measurement once the
-// triggers paint.
+// trigger element is read inside `updateIndicatorStyle` instead.
 watch(
   () => [
-    context.modelValue.value,
     context.orientation.value,
     context?.dir?.value,
     context.layoutTick.value,
   ],
-  () => { updateIndicatorStyle() },
+  () => { updateIndicatorStyle(true) },
   { immediate: true, flush: 'post' },
 )
 

--- a/packages/core/src/date/calendar.ts
+++ b/packages/core/src/date/calendar.ts
@@ -125,7 +125,7 @@ export function startOfDecade(dateObj: DateValue) {
 }
 
 export function endOfDecade(dateObj: DateValue) {
-  // round to the lowest nearest 10 when building the decade
+  // round up to the end of the decade (the highest nearest 10)
   return endOfYear(dateObj.add({ years: Math.ceil((dateObj.year + 1) / 10) * 10 - dateObj.year - 1 }).set({ day: 35, month: 12 }))
 }
 

--- a/packages/core/src/shared/gesture/physics.test.ts
+++ b/packages/core/src/shared/gesture/physics.test.ts
@@ -23,6 +23,7 @@ import {
   pruneQueue,
   resolveAxisLock,
   rubberEffect,
+  settleDurationMs,
   sortableDropTarget,
 } from './physics'
 
@@ -377,6 +378,28 @@ describe('projectMomentum', () => {
   })
   it('zero velocity stays put', () => {
     expect(projectMomentum(7, 0, 5)).toBe(7)
+  })
+})
+
+describe('settleDurationMs', () => {
+  it('falls back to maxMs for a slow or stationary release', () => {
+    expect(settleDurationMs(200, 0, 300)).toBe(300)
+    // 200 / 100 * 1000 = 2000 → clamped to maxMs.
+    expect(settleDurationMs(200, 100, 300)).toBe(300)
+  })
+  it('floors a violent flick at minMs', () => {
+    // 50 / 5000 * 1000 = 10 → floored to 120.
+    expect(settleDurationMs(50, 5000, 300)).toBe(120)
+  })
+  it('scales linearly between the bounds for a medium flick', () => {
+    // 200 / 800 * 1000 = 250.
+    expect(settleDurationMs(200, 800, 300)).toBeCloseTo(250)
+  })
+  it('is sign-agnostic (uses magnitudes)', () => {
+    expect(settleDurationMs(-200, -800, 300)).toBeCloseTo(250)
+  })
+  it('honors a custom floor', () => {
+    expect(settleDurationMs(10, 5000, 300, 80)).toBe(80)
   })
 })
 

--- a/packages/core/src/shared/gesture/physics.ts
+++ b/packages/core/src/shared/gesture/physics.ts
@@ -367,6 +367,33 @@ export function projectMomentum(position: number, velocity: number, decel = 5): 
   return position + velocity / decel
 }
 
+/**
+ * Settle duration (ms) for a released drag, scaled by release speed. `time =
+ * distance / speed`: a hard flick covers the remaining travel in less time, so
+ * the settle plays quicker; a slow or stationary release yields a huge time
+ * that clamps to `maxMs` (the component's configured duration), preserving the
+ * unflicked feel. Floored at `minMs` so a violent flick can't snap instantly.
+ *
+ * Sign-agnostic — only the magnitudes of distance and velocity matter.
+ * Mirrored inline by `SheetContentImpl`'s `_onTouchEnd` worklet (worklets
+ * can't call across files — keep the two in sync).
+ */
+export function settleDurationMs(
+  remainingPx: number,
+  velocity: number,
+  maxMs: number,
+  minMs = 120,
+): number {
+  'main thread'
+  const speed = Math.max(Math.abs(velocity), 1e-3)
+  const ms = (Math.abs(remainingPx) / speed) * 1000
+  if (ms < minMs)
+    return minMs
+  if (ms > maxMs)
+    return maxMs
+  return ms
+}
+
 export type SwipeActionDecision = 'commit' | 'open' | 'close'
 
 export interface SwipeActionDecisionOpts {

--- a/packages/core/src/shared/useFilter.ts
+++ b/packages/core/src/shared/useFilter.ts
@@ -2,22 +2,6 @@ import type { MaybeRef } from 'vue'
 import { computed, unref } from 'vue'
 
 /**
- * Provides locale-aware string filtering functions.
- * Uses `Intl.Collator` for comparison when available to ensure proper Unicode
- * handling, and falls back to a case-insensitive comparison otherwise.
- *
- * @param options - Optional collator options to customize comparison behavior.
- *   See [Intl.CollatorOptions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator#options) for details.
- * @returns An object with methods to check if a string starts with, ends with, or contains a substring.
- *
- * @example
- * const { startsWith, endsWith, contains } = useFilter();
- *
- * startsWith('hello', 'he'); // true
- * endsWith('hello', 'lo'); // true
- * contains('hello', 'ell'); // true
- */
-/**
  * Safely applies Unicode NFC normalization.
  *
  * Lynx's JS engine (PrimJS) does not implement `String.prototype.normalize`,
@@ -50,6 +34,22 @@ function createCompare(options: Intl.CollatorOptions | undefined): Compare {
   }
 }
 
+/**
+ * Provides locale-aware string filtering functions.
+ * Uses `Intl.Collator` for comparison when available to ensure proper Unicode
+ * handling, and falls back to a case-insensitive comparison otherwise.
+ *
+ * @param options - Optional collator options to customize comparison behavior.
+ *   See [Intl.CollatorOptions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator#options) for details.
+ * @returns An object with methods to check if a string starts with, ends with, or contains a substring.
+ *
+ * @example
+ * const { startsWith, endsWith, contains } = useFilter();
+ *
+ * startsWith('hello', 'he'); // true
+ * endsWith('hello', 'lo'); // true
+ * contains('hello', 'ell'); // true
+ */
 export function useFilter(options?: MaybeRef<Intl.CollatorOptions>) {
   const computedOptions = computed(() => unref(options))
   const compare = computed(() => createCompare(computedOptions.value))

--- a/packages/core/src/shared/useSize.ts
+++ b/packages/core/src/shared/useSize.ts
@@ -45,7 +45,6 @@ export function useSize(element: MaybeElementRef) {
           height = el.offsetHeight
         }
 
-        // temporary disable width/height from resize observer. borderSizeEntry seems to be incorrect
         size.value = { width, height }
       })
 

--- a/packages/kit/src/theme/accordion.ts
+++ b/packages/kit/src/theme/accordion.ts
@@ -2,9 +2,11 @@
  * Accordion theme — adapted from nuxt/ui v3.0.2 `theme/accordion.ts` for
  * Vue-Lynx. Dark rides the semantic tokens; `focus-visible:*` / `dark:*` / `shadow-*` removed.
  *
- * Nuxt UI relies on bespoke `accordion-down` / `accordion-up` keyframes; we
- * fall back to a plain `transition-all` since Lynx's CSS engine doesn't ship
- * those named keyframes by default.
+ * Nuxt UI relies on bespoke `accordion-down` / `accordion-up` keyframes (which
+ * animate to `height: auto` — impossible in CSS and unsupported by Lynx). We
+ * instead tween a measured px height: `CollapsibleContent` writes the natural
+ * height as an inline `height`, and the `content` slot's `transition-[height]`
+ * interpolates it (device-proven `Tray` recipe).
  */
 export default {
   slots: {
@@ -13,7 +15,7 @@ export default {
     header: 'flex flex-row',
     trigger:
       'group flex-1 flex flex-row items-center gap-1.5 font-medium text-sm py-3.5 min-w-0',
-    content: 'overflow-hidden',
+    content: 'overflow-hidden transition-[height] ease-out',
     // `body` is a wrapping <view>; `enableCSSInheritance: false` means its
     // `text-*` can't reach the nested content <text>, so the foreground color
     // moves onto `bodyText` (applied to the string-content <text> in


### PR DESCRIPTION
Three animation improvements from the feel-gap audit, each in its own commit.

- Animate Collapsible/Accordion height on open/close via a measured px tween (Tray recipe); core stays headless, consumer theme supplies clip + timing.
- Scale Sheet settle/dismiss duration by release velocity so a hard flick settles quicker while a slow release keeps the current feel.
- Cache the TabsIndicator list rect so a tab switch costs one `boundingClientRect` round-trip instead of two.

Ceilings left deliberately: default `unmountOnHide` Collapsible still snaps on close (needs `Presence`-gated leave); Sheet keeps CSS-transition settle (no JS spring).

Notes for review:
- Item 5 wraps the Collapsible slot in a `<view>` — a structural change for all consumers; verify existing flex/gap layouts don't shift.
- Collapsible first-reveal animation depends on the closed content being measurable on device (if `hidden` maps to `display:none`, the first open snaps).
- Changesets are all patch. No visual verification done — on-device feel is yours to confirm.