### PR TITLE
chore(docs): rename defineOgImageComponent to defineOgImage

### DIFF
--- a/apps/docs/app/components/OgImage/Default.takumi.vue
+++ b/apps/docs/app/components/OgImage/Default.takumi.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 // Branded social card rendered to PNG at build time by nuxt-og-image.
-// title/description are passed per-route via defineOgImageComponent so each
+// title/description are passed per-route via defineOgImage so each
 // page gets its own card. Styles are inline because the renderer (takumi)
 // supports only a flexbox/inline-style subset — no external CSS or classes.
 withDefaults(defineProps<{ title?: string, description?: string }>(), {

--- a/apps/docs/app/pages/[...slug].vue
+++ b/apps/docs/app/pages/[...slug].vue
@@ -53,7 +53,7 @@ useSchemaOrg([
 ])
 
 // Per-page social card (rendered to PNG at build time).
-defineOgImageComponent('Default', { title, description })
+defineOgImage('Default', { title, description })
 
 const headline = computed(() => findPageHeadline(navigation?.value, page.value?.path))
 

--- a/apps/docs/app/pages/changelog.vue
+++ b/apps/docs/app/pages/changelog.vue
@@ -74,7 +74,7 @@ useSeoMeta({
     description: "Release notes for Vy UI — @vyui/core and @vyui/kit.",
 });
 
-defineOgImageComponent("Default", {
+defineOgImage("Default", {
     title: "Changelog",
     description: "Release notes for Vy UI — @vyui/core and @vyui/kit.",
 });

--- a/apps/docs/app/pages/index.vue
+++ b/apps/docs/app/pages/index.vue
@@ -26,7 +26,7 @@ useSchemaOrg([
   }),
 ])
 
-defineOgImageComponent('Default', {
+defineOgImage('Default', {
   title: 'Vy UI',
   description: 'Styled & headless components for Vue-Lynx — native iOS, Android & web from one codebase.',
 })


### PR DESCRIPTION
Clears the nuxt-og-image v6 deprecation warning in the docs app.

- `defineOgImage` takes the identical `(component, props, options)` signature, so this is a straight rename
- Updated all three call sites: `index.vue`, `changelog.vue`, `[...slug].vue`, plus a stale comment in `OgImage/Default.takumi.vue`

Ran the rename directly rather than `npx nuxt-og-image migrate v6` — no call shapes change. No changeset: docs app only, nothing published.