### PR TITLE
fix(docs): include current page in BreadcrumbList structured data

### DIFF
--- a/apps/docs/app/pages/[...slug].vue
+++ b/apps/docs/app/pages/[...slug].vue
@@ -38,7 +38,7 @@ useSeoMeta({
 // BreadcrumbList mirrors the sidebar hierarchy so search results can show the
 // section trail (e.g. Components > Accordion) instead of a bare URL.
 const breadcrumb = computed(() =>
-  (findPageBreadcrumb(navigation?.value, page.value?.path) ?? [])
+  (findPageBreadcrumb(navigation?.value, page.value?.path, { current: true }) ?? [])
     .filter(item => item.path)
     .map(item => ({ name: item.title, item: item.path })),
 )


### PR DESCRIPTION
Fixes the Search Console "Missing field itemListElement" error on the 4 nav-root docs pages.

- Pass `{ current: true }` to `findPageBreadcrumb` so root pages (/guides, /components, /theming, /getting-started) emit a non-empty `itemListElement`
- Deep pages now include the current page in the trail (Components > Accordion), matching the original intent

After deploy, re-validate in Search Console.