### PR TITLE
chore(core): drop redundant @vueuse/shared dependency

### DIFF
--- a/.changeset/drop-vueuse-shared.md
+++ b/.changeset/drop-vueuse-shared.md
@@ -1,0 +1,5 @@
+---
+"@vyui/core": patch
+---
+
+Drop the redundant `@vueuse/shared` dependency — `@vueuse/core` already re-exports it (`export * from '@vueuse/shared'`), so the two `reactivePick`/`reactiveOmit` imports now come from `@vueuse/core` directly.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -94,7 +94,6 @@
     "@iconify/utils": "^3.1.3",
     "@internationalized/date": "^3.5.0",
     "@vueuse/core": "^14.1.0",
-    "@vueuse/shared": "^14.1.0",
     "ohash": "^2.0.11",
     "tailwind-merge": "^2.5.4"
   },

--- a/packages/core/src/components/Popover/PopoverContent.vue
+++ b/packages/core/src/components/Popover/PopoverContent.vue
@@ -16,7 +16,7 @@ export interface PopoverContentProps extends PopoverContentImplProps {
 </script>
 
 <script setup lang="ts">
-import { reactiveOmit } from '@vueuse/shared'
+import { reactiveOmit } from '@vueuse/core'
 import { Presence } from '@/components/Presence'
 import { useEmitAsProps, useForwardExpose } from '@/shared'
 import PopoverContentModal from './PopoverContentModal.vue'

--- a/packages/core/src/shared/useForwardProps.test.ts
+++ b/packages/core/src/shared/useForwardProps.test.ts
@@ -1,6 +1,6 @@
 // Adapted from reka-ui (MIT) — https://github.com/unovue/reka-ui
 import { mount } from '@vue/test-utils'
-import { reactivePick } from '@vueuse/shared'
+import { reactivePick } from '@vueuse/core'
 import { describe, expect, it } from 'vitest'
 import { computed, defineComponent, watch } from 'vue'
 import { useForwardProps } from './useForwardProps'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -540,9 +540,6 @@ importers:
       '@vueuse/core':
         specifier: ^14.1.0
         version: 14.3.0(vue@3.5.34(typescript@5.9.3))
-      '@vueuse/shared':
-        specifier: ^14.1.0
-        version: 14.3.0(vue@3.5.34(typescript@5.9.3))
       ohash:
         specifier: ^2.0.11
         version: 2.0.11


### PR DESCRIPTION
@vueuse/core already re-exports @vueuse/shared in full, so declaring it separately was pure duplication.

- Swap `reactivePick`/`reactiveOmit` imports from `@vueuse/shared` to `@vueuse/core` (`PopoverContent.vue`, `useForwardProps.test.ts`)
- Drop `@vueuse/shared` from `packages/core/package.json`
- Add patch changeset