### PR TITLE
docs: shorten guide titles

### DIFF
--- a/apps/docs/content/8.guides/1.index.md
+++ b/apps/docs/content/8.guides/1.index.md
@@ -14,7 +14,7 @@ These pages cover the ecosystem Vy UI sits in rather than Vy UI itself, from wha
   :::card
   ---
   icon: i-lucide-help-circle
-  title: Why use Vy UI
+  title: Why Vy UI
   to: /guides/why-vy-ui
   ---
   What a component library is worth on Lynx, and the three ways to consume this one.
@@ -32,7 +32,7 @@ These pages cover the ecosystem Vy UI sits in rather than Vy UI itself, from wha
   :::card
   ---
   icon: i-lucide-component
-  title: What is Vue Lynx
+  title: Vue Lynx
   to: /guides/vue-lynx
   ---
   How Vue renders to native iOS, Android, and web through Lynx, and what changes in your code.
@@ -50,7 +50,7 @@ These pages cover the ecosystem Vy UI sits in rather than Vy UI itself, from wha
   :::card
   ---
   icon: i-lucide-smartphone
-  title: Testing on your phone
+  title: Testing on device
   to: /guides/testing-on-device
   ---
   Run your app on a real device with Lynx Go, and the config that has to be right first.
@@ -68,7 +68,7 @@ These pages cover the ecosystem Vy UI sits in rather than Vy UI itself, from wha
   :::card
   ---
   icon: i-lucide-terminal
-  title: The rspeedy dev server
+  title: rspeedy dev server
   to: /guides/rspeedy-dev-server
   ---
   The three dev URLs, and cycling the QR code between entries and schemas.
@@ -104,7 +104,7 @@ These pages cover the ecosystem Vy UI sits in rather than Vy UI itself, from wha
   :::card
   ---
   icon: i-lucide-zap
-  title: Instant first-frame rendering
+  title: Instant first frame
   to: /guides/instant-first-frame-rendering
   ---
   Painting the first screen before the background thread boots, and what it costs.

--- a/apps/docs/content/8.guides/10.instant-first-frame-rendering.md
+++ b/apps/docs/content/8.guides/10.instant-first-frame-rendering.md
@@ -1,5 +1,5 @@
 ---
-title: Instant first-frame rendering
+title: Instant first frame
 description: Vue Lynx 0.5 can render your first screen on the main thread before any background JavaScript runs, which removes the blank frame at launch. The flag, the rules your components have to obey, and what it costs.
 navigation:
   icon: i-lucide-zap
@@ -185,7 +185,7 @@ Overlays, sheets, toasts, and anything animated mount after the first paint by d
   :::card
   ---
   icon: i-lucide-component
-  title: What is Vue Lynx
+  title: Vue Lynx
   to: /guides/vue-lynx
   ---
   The dual-thread model IFR is working around.
@@ -194,7 +194,7 @@ Overlays, sheets, toasts, and anything animated mount after the first paint by d
   :::card
   ---
   icon: i-lucide-terminal
-  title: The rspeedy dev server
+  title: rspeedy dev server
   to: /guides/rspeedy-dev-server
   ---
   Where the config in this guide gets picked up.
@@ -203,7 +203,7 @@ Overlays, sheets, toasts, and anything animated mount after the first paint by d
   :::card
   ---
   icon: i-lucide-smartphone
-  title: Testing on your phone
+  title: Testing on device
   to: /guides/testing-on-device
   ---
   Measuring a first frame where it actually counts.

--- a/apps/docs/content/8.guides/11.why-vy-ui.md
+++ b/apps/docs/content/8.guides/11.why-vy-ui.md
@@ -1,5 +1,5 @@
 ---
-title: Why use Vy UI
+title: Why Vy UI
 description: What a component library is actually worth on Lynx, how the headless and styled layers differ, and when copying the source with the CLI beats depending on the package.
 navigation:
   icon: i-lucide-help-circle

--- a/apps/docs/content/8.guides/12.sparkling.md
+++ b/apps/docs/content/8.guides/12.sparkling.md
@@ -131,7 +131,7 @@ The repository has been public since late November 2025 and is under active deve
   :::card
   ---
   icon: i-lucide-smartphone
-  title: Testing on your phone
+  title: Testing on device
   to: /guides/testing-on-device
   ---
   The QR-code loop with Lynx Go, and the config that has to be right first.
@@ -140,7 +140,7 @@ The repository has been public since late November 2025 and is under active deve
   :::card
   ---
   icon: i-lucide-terminal
-  title: The rspeedy dev server
+  title: rspeedy dev server
   to: /guides/rspeedy-dev-server
   ---
   The dev URLs underneath `sparkling dev`, and cycling the QR code.

--- a/apps/docs/content/8.guides/2.lynx-ui-frameworks.md
+++ b/apps/docs/content/8.guides/2.lynx-ui-frameworks.md
@@ -75,7 +75,7 @@ None of this is a reason to avoid Lynx. It is a reason to check the components y
   :::card
   ---
   icon: i-lucide-component
-  title: What is Vue Lynx
+  title: Vue Lynx
   to: /guides/vue-lynx
   ---
   The Vue renderer for Lynx, its dual-thread model, and what it supports.

--- a/apps/docs/content/8.guides/3.vue-lynx.md
+++ b/apps/docs/content/8.guides/3.vue-lynx.md
@@ -1,5 +1,5 @@
 ---
-title: What is Vue Lynx
+title: Vue Lynx
 description: How Vue Lynx renders Vue components to native iOS, Android, and web through ByteDance's Lynx runtime, and what changes when you write Vue against it.
 navigation:
   icon: i-lucide-component

--- a/apps/docs/content/8.guides/4.lynx-vs-react-native.md
+++ b/apps/docs/content/8.guides/4.lynx-vs-react-native.md
@@ -64,7 +64,7 @@ Lynx is stable, and Vue Lynx and Vy UI are both pre-1.0 and will introduce break
   :::card
   ---
   icon: i-lucide-component
-  title: What is Vue Lynx
+  title: Vue Lynx
   to: /guides/vue-lynx
   ---
   The Vue renderer for Lynx, its dual-thread model, and what it supports.

--- a/apps/docs/content/8.guides/5.testing-on-device.md
+++ b/apps/docs/content/8.guides/5.testing-on-device.md
@@ -1,5 +1,5 @@
 ---
-title: Testing on your phone
+title: Testing on device
 description: How to run a Vue Lynx app on a real iPhone or Android device with Lynx Go, and where the QR-code workflow stops being enough.
 navigation:
   icon: i-lucide-smartphone
@@ -146,7 +146,7 @@ Lynx Go stays the right tool for layout, styling, animation, gesture feel, and a
   :::card
   ---
   icon: i-lucide-component
-  title: What is Vue Lynx
+  title: Vue Lynx
   to: /guides/vue-lynx
   ---
   The Vue renderer for Lynx and what changes in your code.

--- a/apps/docs/content/8.guides/6.testing-with-xcode.md
+++ b/apps/docs/content/8.guides/6.testing-with-xcode.md
@@ -416,7 +416,7 @@ Gate the ATS exemption behind Release stripping from the start, because App Revi
   :::card
   ---
   icon: i-lucide-smartphone
-  title: Testing on your phone
+  title: Testing on device
   to: /guides/testing-on-device
   ---
   The faster Lynx Go loop, and where it runs out.
@@ -434,7 +434,7 @@ Gate the ATS exemption behind Release stripping from the start, because App Revi
   :::card
   ---
   icon: i-lucide-component
-  title: What is Vue Lynx
+  title: Vue Lynx
   to: /guides/vue-lynx
   ---
   The Vue renderer for Lynx and what changes in your code.

--- a/apps/docs/content/8.guides/7.rspeedy-dev-server.md
+++ b/apps/docs/content/8.guides/7.rspeedy-dev-server.md
@@ -1,5 +1,5 @@
 ---
-title: The rspeedy dev server
+title: rspeedy dev server
 description: What rspeedy dev prints, how to cycle the QR code between entries and URL schemas from the terminal, and which of the three URLs to use when.
 navigation:
   icon: i-lucide-terminal
@@ -134,7 +134,7 @@ Vy UI's own component previews run the web path, which is why the docs describe 
   :::card
   ---
   icon: i-lucide-smartphone
-  title: Testing on your phone
+  title: Testing on device
   to: /guides/testing-on-device
   ---
   The Lynx Go loop and the config that has to be right first.

--- a/apps/docs/content/8.guides/8.tailwind-on-lynx.md
+++ b/apps/docs/content/8.guides/8.tailwind-on-lynx.md
@@ -97,7 +97,7 @@ Verified against `@lynx-js/tailwind-preset@0.5.0` and `tailwindcss@4.3.0` on 25 
   :::card
   ---
   icon: i-lucide-smartphone
-  title: Testing on your phone
+  title: Testing on device
   to: /guides/testing-on-device
   ---
   Where styling that works in the browser stops working on device.

--- a/apps/docs/content/8.guides/9.theming-on-lynx.md
+++ b/apps/docs/content/8.guides/9.theming-on-lynx.md
@@ -108,7 +108,7 @@ When the rules run out, fall back to the shape. Something that looks right in th
   :::card
   ---
   icon: i-lucide-smartphone
-  title: Testing on your phone
+  title: Testing on device
   to: /guides/testing-on-device
   ---
   Getting a device check into the loop.


### PR DESCRIPTION
Shortens the guide page titles for the sidebar and H1s; SEO titles are untouched.

- What is Vue Lynx → Vue Lynx
- Why use Vy UI → Why Vy UI
- Testing on your phone → Testing on device
- The rspeedy dev server → rspeedy dev server
- Instant first-frame rendering → Instant first frame
- Cross-link cards updated to match