### PR TITLE
ci: web smoke — boot every playground example in the Lynx web runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,19 @@ jobs:
       - run: pnpm build
       - run: pnpm test
       # Typecheck runs in its own parallel gate (typecheck.yml), not here.
+
+  # Web smoke (issue #8): boots every docs-playground example in the real Lynx
+  # web runtime under headless Chromium — the only coverage the web bundle gets.
+  web-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @vyui/docs playground:build
+      - run: pnpm --filter @vyui/docs exec playwright install --with-deps chromium
+      - run: pnpm --filter @vyui/docs test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ dist/
 *.web.bundle
 *.tsbuildinfo
 
+# playwright
+test-results/
+playwright-report/
+
 # env
 .env
 .env.local

--- a/apps/docs/e2e/playground.spec.ts
+++ b/apps/docs/e2e/playground.spec.ts
@@ -1,0 +1,64 @@
+import type { Page } from '@playwright/test'
+import { readdirSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { expect, test } from '@playwright/test'
+
+// Web-runtime smoke (issue #8, web tier): boots the docs-playground bundle in a
+// bare host page — the same wiring as LynxPreview.vue — and drives it with real
+// mouse events. Unit tests run against the Lynx test env, so this is the only
+// coverage the web bundle + <lynx-view> integration gets.
+
+const examplesDir = fileURLToPath(new URL('../../examples/docs-playground/src/examples', import.meta.url))
+const toKebab = (name: string) => name.replace(/\.vue$/, '').replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
+const exampleIds = readdirSync(examplesDir, { recursive: true, encoding: 'utf8' })
+  .filter(f => f.endsWith('.vue'))
+  .map(f => toKebab(f.split('/').pop()!))
+  .sort()
+
+const HOST = `<!doctype html>
+<link rel="stylesheet" href="/lynx-runtime/static/css/client.css">
+<body style="margin:0">
+<script type="module">
+  await import('/lynx-runtime/static/js/client.js')
+  await customElements.whenDefined('lynx-view')
+  const view = document.createElement('lynx-view')
+  view.setAttribute('url', '/playground/main.web.bundle')
+  view.setAttribute('transform-vw', '')
+  view.setAttribute('transform-vh', '')
+  view.globalProps = { example: new URLSearchParams(location.search).get('example') }
+  view.browserConfig = { pixelRatio: 1, pixelWidth: 390, pixelHeight: 640 }
+  view.style.cssText = 'display:block;width:390px;height:640px'
+  view.addEventListener('load', () => { window.__lynx = 'load' })
+  view.addEventListener('error', e => { window.__lynx = 'error: ' + (e.detail?.error?.message ?? 'unknown') })
+  document.body.appendChild(view)
+</script>
+</body>`
+
+async function mount(page: Page, example: string) {
+  await page.route('**/__smoke__*', route => route.fulfill({ contentType: 'text/html', body: HOST }))
+  await page.goto(`/__smoke__?example=${example}`)
+  await expect
+    .poll(() => page.evaluate(() => (window as { __lynx?: string }).__lynx), { timeout: 30_000 })
+    .toBe('load')
+}
+
+test.describe('every example boots on the web runtime', () => {
+  for (const id of exampleIds) {
+    test(id, async ({ page }) => {
+      await mount(page, id)
+    })
+  }
+})
+
+test('button-example renders its content', async ({ page }) => {
+  await mount(page, 'button-example')
+  await expect(page.getByText('Save draft')).toBeVisible()
+  await expect(page.getByText('Continue with slot content')).toBeVisible()
+})
+
+test('tabs-example switches panels on tap', async ({ page }) => {
+  await mount(page, 'tabs-example')
+  await expect(page.getByText('Your account summary and recent activity.')).toBeVisible()
+  await page.getByText('Security', { exact: true }).click()
+  await expect(page.getByText('Passkeys, passwords, and signed-in devices.')).toBeVisible()
+})

--- a/apps/docs/e2e/serve.mjs
+++ b/apps/docs/e2e/serve.mjs
@@ -1,0 +1,27 @@
+// Static server over apps/docs/public for the web smoke — the playground
+// bundle + Lynx web runtime are plain static assets, so no Nuxt build needed.
+import { createReadStream, existsSync, statSync } from 'node:fs'
+import { createServer } from 'node:http'
+import { extname, join, normalize, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(fileURLToPath(new URL('.', import.meta.url)), '../public')
+const types = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.mjs': 'text/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.wasm': 'application/wasm',
+}
+
+createServer((req, res) => {
+  const path = normalize(decodeURIComponent(new URL(req.url, 'http://x').pathname))
+  const file = join(root, path)
+  if (!file.startsWith(root) || !existsSync(file) || !statSync(file).isFile()) {
+    res.writeHead(404).end()
+    return
+  }
+  res.writeHead(200, { 'content-type': types[extname(file)] ?? 'application/octet-stream' })
+  createReadStream(file).pipe(res)
+}).listen(4173)

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -12,6 +12,7 @@
     "typecheck": "nuxt typecheck",
     "playground:build": "tsx ../../tools/gen-playground-registry.ts && pnpm --filter @vyui/docs-playground build && tsx ../../tools/sync-playground.ts",
     "gen:registry": "tsx ../../tools/gen-registry.ts",
+    "test:e2e": "playwright test",
     "gen:api": "tsx ../../tools/gen-component-api.ts"
   },
   "dependencies": {
@@ -30,6 +31,7 @@
   },
   "devDependencies": {
     "@nuxtjs/sitemap": "^8.2.1",
+    "@playwright/test": "^1.62.1",
     "@takumi-rs/core": "^1.8.7",
     "@takumi-rs/helpers": "^1.8.7",
     "better-sqlite3": "^12.10.0",

--- a/apps/docs/playwright.config.ts
+++ b/apps/docs/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  retries: process.env.CI ? 1 : 0,
+  use: { baseURL: 'http://localhost:4173' },
+  webServer: {
+    command: 'node e2e/serve.mjs',
+    // The bundle doubles as the readiness probe: a clear fast failure when
+    // `playground:build` hasn't run instead of 80 opaque boot timeouts.
+    url: 'http://localhost:4173/playground/main.web.bundle',
+    reuseExistingServer: !process.env.CI,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       '@nuxtjs/sitemap':
         specifier: ^8.2.1
         version: 8.2.1(f95e9ef3d29bf395e32e71add5f2c9b0)
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
       '@takumi-rs/core':
         specifier: ^1.8.7
         version: 1.8.7
@@ -112,7 +115,7 @@ importers:
         version: 0.2.0(magicast@0.5.3)
       nuxt-og-image:
         specifier: ^6.6.0
-        version: 6.6.0(bbd226af660ebe15e5a796859883a491)
+        version: 6.6.0(42a3dc1d86905029b43adbf5a376bbe8)
       nuxt-schema-org:
         specifier: ^6.2.3
         version: 6.2.3(@nuxt/schema@4.4.8)(@unhead/vue@2.1.15(vue@3.5.17(typescript@5.9.3)))(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@24.12.4)(@vue/compiler-sfc@3.5.38)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.5.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rolldown@1.0.1)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.1)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.47.1)(tsx@4.22.3)(typescript@5.9.3)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))(vue-tsc@3.2.6(typescript@5.9.3))(yaml@2.9.0))(unhead@2.1.15)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.17(typescript@5.9.3))(zod@3.25.76)
@@ -2721,6 +2724,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -5739,6 +5747,11 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -7367,6 +7380,16 @@ packages:
 
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   plimit-lit@1.6.1:
     resolution: {integrity: sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==}
@@ -11946,6 +11969,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
+
   '@polka/url@1.0.0-next.29': {}
 
   '@poppinss/colors@4.1.6':
@@ -15401,6 +15428,9 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -17066,7 +17096,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  nuxt-og-image@6.6.0(bbd226af660ebe15e5a796859883a491):
+  nuxt-og-image@6.6.0(42a3dc1d86905029b43adbf5a376bbe8):
     dependencies:
       '@clack/prompts': 1.6.0
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
@@ -17106,6 +17136,7 @@ snapshots:
       '@takumi-rs/core': 1.8.7
       fontless: 0.2.1(db0@0.3.4(better-sqlite3@12.10.0))(ioredis@5.11.0)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
       nitropack: 2.13.4(better-sqlite3@12.10.0)(oxc-parser@0.131.0)(rolldown@1.0.1)(srvx@0.11.16)
+      playwright-core: 1.62.1
       sharp: 0.34.5
       tailwindcss: 4.3.0
       unifont: 0.7.4
@@ -17960,6 +17991,14 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.0.8
       pathe: 2.0.3
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plimit-lit@1.6.1:
     dependencies:


### PR DESCRIPTION
Closes the remaining item on #8 as web-only: a Playwright job that boots the real web bundle in headless Chromium.

- `apps/docs/e2e/playground.spec.ts` — boots all 80 docs-playground examples in `<lynx-view>` (same wiring as `LynxPreview.vue`), plus render + tab-switch interaction assertions through the real event path
- `apps/docs/e2e/serve.mjs` — stdlib static server over `apps/docs/public`; no Nuxt build needed
- `playwright.config.ts` uses the bundle itself as the readiness probe, so a missing `playground:build` fails fast
- CI gains a parallel `web-smoke` job: `playground:build` → install chromium → `test:e2e`
- Failure path verified: a broken bundle URL goes red

Full suite: 82 passed in ~14s locally. Native (iOS/Android) CI stays out of scope — closed on #8 with rationale.