### PR TITLE
docs: document the host persistence seam

### DIFF
--- a/apps/docs/content/8.guides/13.native-host-integration.md
+++ b/apps/docs/content/8.guides/13.native-host-integration.md
@@ -118,6 +118,40 @@ useGlobalEvent('connectivitychanged', (...args) => {
 
 The listener attaches on mount and detaches on unmount; on web and in vitest there is no `lynx` global and the call is a no-op, so components using it stay portable.
 
+## Persisting state
+
+Lynx leaves storage to the host. There is no `localStorage` inside a `LynxView`, and the SDK's type definitions declare no storage module, so anything that has to survive an app restart round-trips through the two channels above.
+
+Reading at boot is just another global prop. The host reads its own store — `UserDefaults` on iOS, `SharedPreferences` on Android — and adds the value to the dictionary it already pushes:
+
+```swift
+"savedTheme": UserDefaults.standard.string(forKey: "theme") ?? "system",
+```
+
+Writing goes the other way, through a native module the host registers and the bundle calls on the background thread. Container apps each register their own, so the module name and its methods are yours to choose and yours to document:
+
+```ts
+NativeModules.bridge.call('setPref', { theme: 'dark' }, () => {})
+```
+
+Vy UI ships no storage composable, deliberately. The module name, its signatures, and the store behind it are all host-defined, so a wrapper in the library would be a rename of the call you already wrote. The one piece of Vy UI state worth persisting is the color mode, and its `mode` ref is writable — restore it at setup, save it on change:
+
+```vue
+<script setup lang="ts">
+import { watch } from 'vue'
+import { useColorMode } from '@vyui/kit'
+
+const { mode } = useColorMode()
+
+const saved = lynx.__globalProps?.savedTheme
+if (saved === 'light' || saved === 'dark') mode.value = saved
+
+watch(mode, m => NativeModules.bridge.call('setPref', { theme: m }, () => {}))
+</script>
+```
+
+`savedTheme` is a different signal from `theme`: `theme` is the device appearance the host observes, `savedTheme` is the choice the user made in a previous session. Leaving the saved value at `'system'` folds one into the other.
+
 ## Viewport size
 
 Not host-injected, but part of the same "no `window`" story: the bundle reads its size from `SystemInfo` in physical pixels. [`getViewportSize()`](/composables/get-viewport-size) converts that to logical px, and `VyApp`'s `viewport-change` emit tells you when it changes (rotation, split screen).
@@ -129,3 +163,4 @@ Not host-injected, but part of the same "no `window`" story: the bundle reads it
 - [ ] Android: `os: "android"`, insets handled on the native view
 - [ ] `theme` prop at boot, `themechanged` event on change
 - [ ] Custom host events named and documented next to the native code that sends them
+- [ ] Persisted preferences read into global props at boot, written back through a host module


### PR DESCRIPTION
Adds a "Persisting state" section to the native host integration guide. Stacked on #177, which is where the guide itself lives.

- Lynx leaves storage to the host: no `localStorage`, no storage module in the SDK types
- Read path is a global prop the host fills from `UserDefaults` / `SharedPreferences`
- Write path is a host-registered module called via `NativeModules.bridge.call`
- States why Vy UI ships no storage composable, with the color-mode persistence snippet as the worked example
- One extra checklist line

Docs-only, no changeset.