### PR TITLE
fix(core): omit undefined attrs in Primitive

### DIFF
--- a/.changeset/undefined-attr-semantics.md
+++ b/.changeset/undefined-attr-semantics.md
@@ -1,0 +1,9 @@
+---
+"@vyui/core": patch
+---
+
+`Primitive` now omits `undefined`-valued attributes instead of forwarding them to the renderer, matching Vue's DOM semantics.
+
+vue-lynx's `patchProp` has no nullish guard, so an `undefined` attr was patched like any other: it crossed the op bridge as JSON (`undefined` → `null` in the ops array) and landed as `__SetAttribute(el, key, null)` — a native prop-reset for a prop that was never set. A stock `Textarea` emitted ~11 of these per mount. An explicit `null` still reaches the element, and clearing a prop at runtime is unaffected.
+
+Alongside it, `Textarea` no longer applies a `maxLength` of `140` by default. The prop is now unset, leaving the platform's own limit in place — unlimited on iOS and Android, `140` on Harmony. Pass an explicit value to enforce a limit or to get identical behavior on every platform.

--- a/apps/docs/app/generated/api/Textarea.json
+++ b/apps/docs/app/generated/api/Textarea.json
@@ -61,8 +61,7 @@
       "name": "maxLength",
       "type": "number | undefined",
       "required": false,
-      "default": "140",
-      "description": "Maximum number of characters allowed. Defaults to `140` per the Lynx\ndefault."
+      "description": "Maximum number of characters allowed. Unset by default, leaving the\nplatform's own limit in place: iOS and Android are unlimited, while\nHarmony applies the documented Lynx default of 140. Pass an explicit\nvalue to enforce a limit, or to get identical behavior on every platform."
     },
     {
       "name": "maxLines",

--- a/apps/docs/content/3.components/textarea.md
+++ b/apps/docs/content/3.components/textarea.md
@@ -145,7 +145,7 @@ The core instance provides `focus()`, `blur()`, `clear()`, `setValue(value)`, `g
 
 - `v-model` sends programmatic changes to the native element without re-pushing every native keystroke.
 - `rows` defaults to `3` and is forwarded as a native attribute by the kit wrapper.
-- `maxLength` is forwarded to core, whose native default is `140` when the prop is absent.
+- `maxLength` is forwarded to core and is unset by default, leaving the platform's own limit in place: iOS and Android accept unlimited text, while Harmony applies the documented Lynx default of `140`. Pass an explicit value to enforce a limit, or to get identical behavior on every platform.
 - `disabled` blocks interaction and applies reduced opacity through the default theme.
 - `loading` adds a spinning leading icon but does not disable the textarea.
 - A custom `leading` slot, `trailing` slot, icon, avatar, or loading state creates the corresponding side region.
@@ -173,7 +173,7 @@ The core instance provides `focus()`, `blur()`, `clear()`, `setValue(value)`, `g
 | `size` | `'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` | Padding, text, gap, and icon scale. |
 | `highlight` | `boolean` | `false` | Always paints a semantic border. |
 | `rows` | `number` | `3` | Visible row hint forwarded to the native textarea. |
-| `maxLength` | `number` | Core default `140` | Maximum character count. |
+| `maxLength` | `number` | `undefined` | Maximum character count. Unset leaves the platform limit: unlimited on iOS/Android, `140` on Harmony. |
 | `id` | `string` | `undefined` | Native identifier. |
 | `name` | `string` | `undefined` | Native field name. |
 | `required` | `boolean` | `false` | Native required marker. |

--- a/packages/core/src/components/Input/Textarea.test.ts
+++ b/packages/core/src/components/Input/Textarea.test.ts
@@ -14,18 +14,21 @@ describe('Textarea — default render', () => {
     const { container } = render(_Textarea)
     const el = ta(container)
     expect(el).not.toBeNull()
-    expect(el.getAttribute('maxlength')).toBe('140')
+    // Unset by default — the platform's own limit applies (see maxLength docs).
+    expect(el.getAttribute('maxlength')).toBeNull()
     expect(el.getAttribute('maxlines')).toBe('40')
     expect(el.getAttribute('confirm-type')).toBe('send')
   })
 
-  it('forwards maxLines / lineSpacing / bounces', () => {
+  it('forwards maxLength / maxLines / lineSpacing / bounces', () => {
     const { container } = render(_Textarea, {
+      maxLength: 280,
       maxLines: 5,
       lineSpacing: '4px',
       bounces: false,
     })
     const el = ta(container)
+    expect(el.getAttribute('maxlength')).toBe('280')
     expect(el.getAttribute('maxlines')).toBe('5')
     expect(el.getAttribute('line-spacing')).toBe('4px')
     expect(el.getAttribute('bounces')).toBe('false')

--- a/packages/core/src/components/Input/Textarea.vue
+++ b/packages/core/src/components/Input/Textarea.vue
@@ -26,8 +26,12 @@ export interface TextareaProps extends PrimitiveProps {
   readonly?: boolean
   /** When `true`, prevents the user from interacting with the textarea. */
   disabled?: boolean
-  /** Maximum number of characters allowed. Defaults to `140` per the Lynx
-   *  default. */
+  /**
+   * Maximum number of characters allowed. Unset by default, leaving the
+   * platform's own limit in place: iOS and Android are unlimited, while
+   * Harmony applies the documented Lynx default of 140. Pass an explicit
+   * value to enforce a limit, or to get identical behavior on every platform.
+   */
   maxLength?: number
   /** Maximum number of visible lines before scrolling kicks in. Defaults to
    *  `40` to match the React port. */
@@ -110,7 +114,6 @@ const props = withDefaults(defineProps<TextareaProps>(), {
   readonly: false,
   disabled: false,
   type: 'text',
-  maxLength: 140,
   maxLines: 40,
   bounces: true,
   confirmType: 'send',

--- a/packages/core/src/components/Primitive/Primitive.test.ts
+++ b/packages/core/src/components/Primitive/Primitive.test.ts
@@ -51,6 +51,59 @@ describe('Primitive', () => {
     expect(element.childNodes.length).toBe(0)
   })
 
+  it('omits an undefined attr and keeps the defined ones', () => {
+    const { container } = render(Primitive, { as: 'view', type: 'button', placeholder: undefined })
+    const element = container.querySelector('view')!
+    expect(element.getAttribute('type')).toBe('button')
+    expect(element.getAttribute('placeholder')).toBeNull()
+  })
+
+  // The DOM outcome above is identical whether the attr is omitted or patched
+  // as null (both leave no attribute), so assert on the native call itself:
+  // an undefined attr must never reach `__SetAttribute`. Asserting the defined
+  // key IS seen keeps the spy honest — if the hook stopped working, this fails
+  // rather than passing vacuously.
+  it('never reaches the native setter for an undefined attr', () => {
+    const mt = (globalThis as any).lynxTestingEnv.mainThread.globalThis
+    const original = mt.__SetAttribute
+    const keys: string[] = []
+    mt.__SetAttribute = (el: any, key: string, value: unknown) => {
+      keys.push(key)
+      return original(el, key, value)
+    }
+
+    try {
+      render(Primitive, { as: 'view', type: 'button', placeholder: undefined })
+    }
+    finally {
+      mt.__SetAttribute = original
+    }
+
+    expect(keys).toContain('type')
+    expect(keys).not.toContain('placeholder')
+  })
+
+  // `null` stays a deliberate "reset this prop" escape hatch — only undefined
+  // is dropped.
+  it('still forwards an explicit null to the native setter', () => {
+    const mt = (globalThis as any).lynxTestingEnv.mainThread.globalThis
+    const original = mt.__SetAttribute
+    const keys: string[] = []
+    mt.__SetAttribute = (el: any, key: string, value: unknown) => {
+      keys.push(key)
+      return original(el, key, value)
+    }
+
+    try {
+      render(Primitive, { as: 'view', type: null })
+    }
+    finally {
+      mt.__SetAttribute = original
+    }
+
+    expect(keys).toContain('type')
+  })
+
   it('renders multiple child elements', () => {
     const Component = defineComponent({
       components: { Primitive },

--- a/packages/core/src/components/Primitive/Primitive.test.ts
+++ b/packages/core/src/components/Primitive/Primitive.test.ts
@@ -58,50 +58,27 @@ describe('Primitive', () => {
     expect(element.getAttribute('placeholder')).toBeNull()
   })
 
-  // The DOM outcome above is identical whether the attr is omitted or patched
-  // as null (both leave no attribute), so assert on the native call itself:
-  // an undefined attr must never reach `__SetAttribute`. Asserting the defined
-  // key IS seen keeps the spy honest — if the hook stopped working, this fails
-  // rather than passing vacuously.
-  it('never reaches the native setter for an undefined attr', () => {
-    const mt = (globalThis as any).lynxTestingEnv.mainThread.globalThis
-    const original = mt.__SetAttribute
-    const keys: string[] = []
-    mt.__SetAttribute = (el: any, key: string, value: unknown) => {
-      keys.push(key)
-      return original(el, key, value)
-    }
+  // The DOM outcome above can't tell the two cases apart — an omitted attr and
+  // one patched as null both leave no attribute. Key *presence* is what drives
+  // the difference (Vue patches every key present in the props object, whatever
+  // its value), so assert on the keys Primitive actually forwards.
+  it('drops undefined attr keys, keeps defined and null ones', () => {
+    let forwarded: Record<string, unknown> = {}
+    const Probe = markRaw(defineComponent({
+      inheritAttrs: false,
+      setup(_, { attrs }) {
+        forwarded = { ...attrs }
+        return () => h('view')
+      },
+    }))
 
-    try {
-      render(Primitive, { as: 'view', type: 'button', placeholder: undefined })
-    }
-    finally {
-      mt.__SetAttribute = original
-    }
+    render(Primitive, { as: Probe, type: 'button', placeholder: undefined, role: null })
 
+    const keys = Object.keys(forwarded)
     expect(keys).toContain('type')
     expect(keys).not.toContain('placeholder')
-  })
-
-  // `null` stays a deliberate "reset this prop" escape hatch — only undefined
-  // is dropped.
-  it('still forwards an explicit null to the native setter', () => {
-    const mt = (globalThis as any).lynxTestingEnv.mainThread.globalThis
-    const original = mt.__SetAttribute
-    const keys: string[] = []
-    mt.__SetAttribute = (el: any, key: string, value: unknown) => {
-      keys.push(key)
-      return original(el, key, value)
-    }
-
-    try {
-      render(Primitive, { as: 'view', type: null })
-    }
-    finally {
-      mt.__SetAttribute = original
-    }
-
-    expect(keys).toContain('type')
+    // null stays a deliberate "reset this prop" signal — only undefined is dropped.
+    expect(keys).toContain('role')
   })
 
   it('renders multiple child elements', () => {

--- a/packages/core/src/components/Primitive/Primitive.ts
+++ b/packages/core/src/components/Primitive/Primitive.ts
@@ -34,6 +34,30 @@ export interface PrimitiveProps {
 // tolerates it, so the breakage is native-only).
 const SELF_CLOSING_TAGS = ['input', 'image']
 
+/**
+ * Drop `undefined`-valued attrs before they reach the renderer.
+ *
+ * Vue's DOM renderer omits an attribute whose value is `undefined`; vue-lynx's
+ * does not. Its `patchProp` has no nullish guard, so the prop is patched like
+ * any other, crosses the op bridge as JSON (`undefined` → `null` inside the
+ * ops array) and lands as `__SetAttribute(el, key, null)` — a native
+ * prop-reset for a prop that was never set. Omitting the key skips the native
+ * call entirely. A stock `<Textarea>` alone emits ~11 of these per mount.
+ *
+ * Only `undefined` is dropped. An explicit `null` still reaches the element,
+ * so it stays available as a deliberate "reset this prop" escape hatch, and
+ * Vue keeps emitting `null` itself when a prop genuinely transitions from a
+ * value to absent (its removed-key path in `patchProps`), so clearing a prop
+ * at runtime is unaffected.
+ */
+function definedAttrs(attrs: Record<string, unknown>): Record<string, unknown> {
+  const defined: Record<string, unknown> = {}
+  for (const key in attrs) {
+    if (attrs[key] !== undefined) defined[key] = attrs[key]
+  }
+  return defined
+}
+
 export const Primitive = defineComponent({
   name: 'Primitive',
   inheritAttrs: false,
@@ -51,11 +75,11 @@ export const Primitive = defineComponent({
     const asTag = props.asChild ? 'template' : props.as
 
     if (typeof asTag === 'string' && SELF_CLOSING_TAGS.includes(asTag))
-      return () => h(asTag, attrs)
+      return () => h(asTag, definedAttrs(attrs))
 
     if (asTag !== 'template')
-      return () => h(props.as, attrs, { default: slots.default })
+      return () => h(props.as, definedAttrs(attrs), { default: slots.default })
 
-    return () => h(Slot, attrs, { default: slots.default })
+    return () => h(Slot, definedAttrs(attrs), { default: slots.default })
   },
 })


### PR DESCRIPTION
Split out of #177. Fixes how `undefined` attribute values reach the Lynx renderer, and the `Textarea` default that surfaced it.

Vue's DOM renderer omits an attribute whose value is `undefined`; vue-lynx's does not. Its `patchProp` has no nullish guard, so the prop is patched like any other and crosses the op bridge as JSON, where `undefined` becomes `null` inside the ops array — a prop-reset for a prop that was never set.

- `Primitive` now filters `undefined`-valued attrs before `h()`
- a stock `Textarea` binds 11 undefined attrs at mount; core templates carry 117 `|| undefined` / `: undefined` idioms that all took this path
- explicit `null` still passes through as a deliberate "reset this prop" escape hatch
- clearing a prop at runtime is unaffected — Vue emits `null` itself via its removed-key path in `patchProps`
- `Textarea` no longer imposes a `maxLength` of `140`; unset leaves the platform limit (unlimited on iOS/Android, `140` on Harmony)

Tests assert on the attr keys `Primitive` forwards, since key presence is what drives the patching and the DOM outcome is identical either way (omitted and null-patched both leave no attribute).

Not device-verified: worth confirming on iOS and Android that a stock `VyTextarea` with no `maxLength` accepts more than 140 characters.