### PR TITLE
test: fix vacuous tests found by suite audit

### DIFF
--- a/packages/cli/src/update-project.test.ts
+++ b/packages/cli/src/update-project.test.ts
@@ -34,7 +34,7 @@ describe('planProjectUpdates', () => {
     expect(lynx).toContain(`includeWorkletPackages: ['@vyui/core']`)
   })
 
-  it('allowlists worklets idempotently and warns when pluginVueLynx is absent', () => {
+  it('allowlists worklets idempotently', () => {
     const cwd = mkdtempSync(join(tmpdir(), 'vyui-update-'))
     mkdirSync(join(cwd, 'src'))
     writeFileSync(join(cwd, 'package.json'), JSON.stringify({ dependencies: { 'vue-lynx': '^0.4.0' } }))
@@ -47,5 +47,20 @@ describe('planProjectUpdates', () => {
 
     expect(plan.updates.some(update => update.path === 'lynx.config.ts')).toBe(false)
     expect(plan.warnings.some(w => w.includes('lynx.config'))).toBe(false)
+  })
+
+  it('warns instead of editing when pluginVueLynx is absent from lynx.config', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'vyui-update-'))
+    mkdirSync(join(cwd, 'src'))
+    writeFileSync(join(cwd, 'package.json'), JSON.stringify({ dependencies: { 'vue-lynx': '^0.4.0' } }))
+    // Neither includeWorkletPackages nor a pluginVueLynx(…) call to graft onto.
+    writeFileSync(join(cwd, 'lynx.config.ts'), `export default { plugins: [] }\n`)
+
+    const info = detectProject(cwd)
+    const config = defaultConfig('/registry', 'default', 'src', '@', 'slate')
+    const plan = planProjectUpdates(info, config)
+
+    expect(plan.updates.some(update => update.path === 'lynx.config.ts')).toBe(false)
+    expect(plan.warnings.some(w => w.includes('pluginVueLynx'))).toBe(true)
   })
 })

--- a/packages/core/src/components/AlertDialog/AlertDialog.test.ts
+++ b/packages/core/src/components/AlertDialog/AlertDialog.test.ts
@@ -128,20 +128,6 @@ describe('alertDialog', () => {
     expect(q(container, 'content')).not.toBeNull()
   })
 
-  it('injects root context into Action/Cancel via the captured-provides bridge', async () => {
-    // Painted Action/Cancel live inside the OverlayRoot portal. They call
-    // `rootContext.onOpenChange(false)`, proving the inject succeeded.
-    const { container } = render(AlertDialog)
-    fireEvent.tap(q(container, 'trigger')!)
-    await frames(40)
-    await waitForUpdate()
-    fireEvent.tap(q(container, 'cancel')!)
-    await waitForUpdate()
-    fireLeaveAnimations(container)
-    await waitForUpdate()
-    expect(q(container, 'content')).toBeNull()
-  })
-
   it('unregisters the overlay entry on unmount', async () => {
     const { container, unmount } = render(AlertDialog, { rootProps: { defaultOpen: true } })
     await waitForUpdate()
@@ -169,13 +155,10 @@ describe('alertDialog', () => {
     await waitForUpdate()
     // Sanity: content is still painted while Leaving.
     expect(q(container, 'content')).not.toBeNull()
-    // Drive both painted views to End — they share the same Presence so
-    // either-or settles the state machine; we fire on both to mirror the
-    // backdrop + panel wiring.
-    const content = q(container, 'content')!
-    const backdrop = content.parentElement!
+    // Backdrop only — the panel binds the same handler, so firing on both
+    // would still pass with the backdrop binding deleted.
+    const backdrop = q(container, 'content')!.parentElement!
     fireEvent.animationend(backdrop)
-    fireEvent.animationend(content)
     await waitForUpdate()
     expect(q(container, 'content')).toBeNull()
   })

--- a/packages/core/src/components/FeedList/FeedList.test.ts
+++ b/packages/core/src/components/FeedList/FeedList.test.ts
@@ -3,15 +3,26 @@
 
 import { describe, expect, it, vi } from 'vitest'
 
-// FeedList's pull-to-refresh worklets fire on a device only — under vitest we
-// verify the unit-testable parts: the `keyFor` helper, the SFC's PTR wiring
-// (touch worklets on a bare `<list>`, no native `<refresh>`), and the pure
-// refresh state-machine transitions. Keep the hygienic vue-lynx mock used
-// elsewhere to avoid `internal/ops` source-map noise.
+// FeedList's pull-to-refresh worklets fire on a device only, and its BG helpers
+// (`keyFor`, the refresh callbacks) are `<script setup>`-local with no observable
+// DOM output — so this suite pins the SFC source itself rather than mirroring the
+// logic, which would pass no matter what the component does. Keep the hygienic
+// vue-lynx mock used elsewhere to avoid `internal/ops` source-map noise.
 vi.mock('vue-lynx', async () => {
   const actual = await vi.importActual<typeof import('vue-lynx')>('vue-lynx')
   return { ...actual }
 })
+
+async function readSfc(): Promise<string> {
+  const fs = await import('node:fs')
+  const path = await import('node:path')
+  const here = path.dirname(new URL(import.meta.url).pathname)
+  return fs.readFileSync(path.join(here, 'FeedList.vue'), 'utf8')
+}
+
+function body(sfc: string, fn: string): string {
+  return sfc.match(new RegExp(`function ${fn}[\\s\\S]*?\\n}`))?.[0] ?? ''
+}
 
 describe('FeedList — exports', () => {
   it('exports FeedList default', async () => {
@@ -20,39 +31,21 @@ describe('FeedList — exports', () => {
   })
 })
 
-// Pure logic regression tests for the `keyFor` helper inside FeedList. Kept
-// here so the key-derivation behaviour is verified without rendering (which
-// is blocked on MTS test infra alongside the rest of the mobile suite).
+// `keyFor` feeds the row `v-for` key and the native `item-key` attr; neither
+// derivation is readable back out of the rendered tree, so pin the source.
 describe('FeedList — keyFor', () => {
-  function keyFor<T extends object>(
-    item: T,
-    index: number,
-    opts: { itemKey?: (item: T, i: number) => string, itemKeyField?: string },
-  ): string {
-    if (typeof opts.itemKey === 'function') return opts.itemKey(item, index)
-    const field = opts.itemKeyField ?? 'id'
-    const v = (item as Record<string, unknown>)[field]
-    if (v == null) return String(index)
-    return String(v)
-  }
-
-  it('reads the configured field by default', () => {
-    expect(keyFor({ id: 'a' }, 0, { itemKeyField: 'id' })).toBe('a')
-    expect(keyFor({ sku: 42 }, 7, { itemKeyField: 'sku' })).toBe('42')
+  it('prefers the itemKey fn, then itemKeyField, then the index', async () => {
+    const fn = body(await readSfc(), 'keyFor')
+    expect(fn).toMatch(/if \(typeof props\.itemKey === 'function'\) return props\.itemKey\(item, index\)/)
+    expect(fn).toMatch(/const field = \(props\.itemKeyField \?\? 'id'\)/)
+    expect(fn).toMatch(/if \(v == null\) return String\(index\)/)
+    expect(fn).toMatch(/return String\(v\)/)
   })
 
-  it('falls back to index when the field is missing / nullish', () => {
-    expect(keyFor({}, 3, { itemKeyField: 'id' })).toBe('3')
-    expect(keyFor({ id: null }, 1, { itemKeyField: 'id' })).toBe('1')
-  })
-
-  it('uses itemKey fn when provided, ignoring itemKeyField', () => {
-    expect(
-      keyFor({ id: 'a' }, 5, {
-        itemKey: (item, i) => `${(item as { id: string }).id}-${i}`,
-        itemKeyField: 'id',
-      }),
-    ).toBe('a-5')
+  it('is what both list branches key their rows on', async () => {
+    const sfc = await readSfc()
+    expect(sfc.match(/:key="keyFor\(item, index\)"/g)?.length).toBe(2)
+    expect(sfc.match(/'item-key': keyFor\(item, index\)/g)?.length).toBe(2)
   })
 })
 
@@ -63,13 +56,6 @@ describe('FeedList — keyFor', () => {
 // translated wrapper + the refreshHeader slot exposes `{ state, progress }`,
 // the touch handlers are bound, and the public API matches the demo contract.
 describe('FeedList — PTR wiring (touch worklets)', () => {
-  async function readSfc(): Promise<string> {
-    const fs = await import('node:fs')
-    const path = await import('node:path')
-    const here = path.dirname(new URL(import.meta.url).pathname)
-    return fs.readFileSync(path.join(here, 'FeedList.vue'), 'utf8')
-  }
-
   it('renders a translated wrapper + bare <list> (no native <refresh>) when enableRefresh is true', async () => {
     const sfc = await readSfc()
     // Look only at the <template> block so the explanatory comments above it
@@ -125,114 +111,58 @@ describe('FeedList — PTR wiring (touch worklets)', () => {
   })
 })
 
-// The refresh state machine is plain reactive BG logic (the worklets only feed
-// it `progress` / trigger events). Mirror the transition rules here so the
-// `idle → pulling → releaseReady → refreshing → done → idle` lifecycle and the
-// emitted `refreshStateChange` sequence are pinned without a device.
+// The refresh state machine is plain reactive BG logic driven by the worklets
+// (`runOnBackground(_onPull)` etc). The callbacks are `<script setup>`-local, so
+// the `idle → pulling → releaseReady → refreshing → done → idle` lifecycle and
+// its guards are pinned from the source.
 describe('FeedList — refresh state machine', () => {
-  type State = 'idle' | 'pulling' | 'releaseReady' | 'refreshing' | 'done'
-
-  function makeMachine() {
-    let state: State = 'idle'
-    let refreshing = false
-    let progress = 0
-    const changes: State[] = []
-    let refreshEmitted = 0
-
-    function set(next: State) {
-      if (state === next) return
-      state = next
-      changes.push(next)
-    }
-    // BG callbacks mirrored from FeedList.vue.
-    return {
-      get state() { return state },
-      get progress() { return progress },
-      get changes() { return changes },
-      get refreshEmitted() { return refreshEmitted },
-      onPull(p: number, releaseReady: boolean) {
-        progress = p
-        if (refreshing) return
-        set(releaseReady ? 'releaseReady' : 'pulling')
-      },
-      onRelease() {
-        progress = 0
-        if (!refreshing) set('idle')
-      },
-      onTriggerRefresh() {
-        progress = 1
-        if (refreshing) return
-        refreshing = true
-        set('refreshing')
-        refreshEmitted++
-      },
-      onClosed() {
-        progress = 0
-        set('done')
-        set('idle')
-      },
-      endRefresh() { refreshing = false },
-    }
-  }
-
-  it('pull below threshold then release returns to idle without firing refresh', () => {
-    const m = makeMachine()
-    m.onPull(0.4, false)
-    expect(m.state).toBe('pulling')
-    m.onRelease()
-    expect(m.state).toBe('idle')
-    expect(m.refreshEmitted).toBe(0)
+  it('dedupes state writes so refreshStateChange only fires on real transitions', async () => {
+    const fn = body(await readSfc(), 'setRefreshState')
+    expect(fn).toMatch(/if \(refreshState\.value === next\) return/)
+    expect(fn).toMatch(/emits\('refreshStateChange', next\)/)
   })
 
-  it('pull past threshold reports releaseReady', () => {
-    const m = makeMachine()
-    m.onPull(0.5, false)
-    m.onPull(1, true)
-    expect(m.changes).toEqual(['pulling', 'releaseReady'])
+  it('reports releaseReady past the threshold, and is inert while refreshing', async () => {
+    const fn = body(await readSfc(), '_onPull')
+    expect(fn).toMatch(/pullProgress\.value = progress/)
+    expect(fn).toMatch(/if \(refreshing\.value\) return/)
+    expect(fn).toMatch(/setRefreshState\(releaseReady \? 'releaseReady' : 'pulling'\)/)
   })
 
-  it('crossing threshold + release fires refresh once and enters refreshing', () => {
-    const m = makeMachine()
-    m.onPull(1, true)
-    m.onTriggerRefresh()
-    expect(m.state).toBe('refreshing')
-    expect(m.refreshEmitted).toBe(1)
-    // Further pulls while refreshing do not re-trigger.
-    m.onPull(1, true)
-    m.onTriggerRefresh()
-    expect(m.refreshEmitted).toBe(1)
+  it('returns to idle on release only when no refresh is in flight', async () => {
+    const fn = body(await readSfc(), '_onRelease')
+    expect(fn).toMatch(/pullProgress\.value = 0/)
+    expect(fn).toMatch(/if \(!refreshing\.value\) setRefreshState\('idle'\)/)
   })
 
-  it('consumer ending the refresh springs closed: done then idle', () => {
-    const m = makeMachine()
-    m.onPull(1, true)
-    m.onTriggerRefresh()
-    m.endRefresh()
-    m.onClosed()
-    expect(m.changes).toEqual(['releaseReady', 'refreshing', 'done', 'idle'])
-    expect(m.state).toBe('idle')
-    expect(m.progress).toBe(0)
+  it('fires refresh once — the guard precedes the emit so a held pull cannot re-trigger', async () => {
+    const fn = body(await readSfc(), '_onTriggerRefresh')
+    expect(fn).toMatch(/if \(refreshing\.value\) return/)
+    expect(fn).toMatch(/refreshing\.value = true/)
+    expect(fn).toMatch(/setRefreshState\('refreshing'\)/)
+    expect(fn.indexOf('if (refreshing.value) return')).toBeLessThan(fn.indexOf('emits(\'refresh\')'))
+  })
+
+  it('springs closed through done before idle', async () => {
+    const sfc = await readSfc()
+    expect(body(sfc, '_onClosed')).toMatch(/setRefreshState\('done'\)[\s\S]*setRefreshState\('idle'\)/)
+    // …and the MT spring-back is what calls it.
+    expect(body(sfc, '_springClose')).toMatch(/runOnBackground\(_onClosed as any\)\(\)/)
   })
 })
 
-// The inline rubber-band worklet in FeedList.vue must match the unit-tested
-// `physics.ts` spec (the two are kept in sync by hand). Mirror the same maths
-// and assert it agrees with `rubberEffect` so drift is caught.
-describe('FeedList — inline rubber matches physics.ts', () => {
-  function inlineRubber(delta: number, bounceWidth: number): number {
-    if (delta === 0 || bounceWidth === 0) return 0
-    const swipeLimit = bounceWidth * 2
-    const absDelta = delta < 0 ? -delta : delta
-    const effective = absDelta < swipeLimit ? absDelta : swipeLimit
-    const bounce = effective / (effective / bounceWidth + 1)
-    const sign = delta < 0 ? -1 : 1
-    return sign * bounce * 1.5
-  }
-
-  it('agrees with rubberEffect across a range', async () => {
-    const { rubberEffect } = await import('@/shared/gesture/physics')
-    for (const d of [-200, -64, -1, 0, 1, 32, 64, 128, 256]) {
-      expect(inlineRubber(d, 64)).toBeCloseTo(rubberEffect(d, 64), 6)
-    }
+// `_rubber` is a hand-kept copy of `physics.ts` `rubberEffect` — cross-file
+// worklet calls don't resolve, so the maths is duplicated. physics.test.ts owns
+// the behavioural spec; pin the copy's terms here so drift is caught.
+describe('FeedList — inline rubber mirrors physics.ts', () => {
+  it('keeps the rubberEffect terms in the _rubber worklet', async () => {
+    const fn = body(await readSfc(), '_rubber')
+    expect(fn).toMatch(/'main thread'/)
+    expect(fn).toMatch(/if \(delta === 0 \|\| bounceWidth === 0\) return 0/)
+    expect(fn).toMatch(/const swipeLimit = bounceWidth \* 2/)
+    expect(fn).toMatch(/const effective = absDelta < swipeLimit \? absDelta : swipeLimit/)
+    expect(fn).toMatch(/const bounce = effective \/ \(effective \/ bounceWidth \+ 1\)/)
+    // 1.5 is `scaleFactor` in physics.ts.
+    expect(fn).toMatch(/return sign \* bounce \* 1\.5/)
   })
 })

--- a/packages/core/src/components/Icon/Icon.test.ts
+++ b/packages/core/src/components/Icon/Icon.test.ts
@@ -67,13 +67,6 @@ describe('Icon (string name)', () => {
 })
 
 describe('resolveIconSvg (cache)', () => {
-  it('returns identical results for repeated calls with the same key', () => {
-    const a = resolveIconSvg('lucide:check', { size: 16 })
-    const b = resolveIconSvg('lucide:check', { size: 16 })
-    expect(a).not.toBeNull()
-    expect(b).toBe(a)
-  })
-
   it('keys on size and color so variants do not collide', () => {
     const red = resolveIconSvg('lucide:check', { size: 16, color: '#ff0000' })
     const blue = resolveIconSvg('lucide:check', { size: 16, color: '#0000ff' })

--- a/packages/core/src/components/Input/Textarea.test.ts
+++ b/packages/core/src/components/Input/Textarea.test.ts
@@ -1,12 +1,31 @@
 // Adapted from lynx-family/lynx-ui (Apache-2.0).
 import { describe, expect, it } from 'vitest'
 import { fireEvent, render, waitForUpdate } from '@vyui/testing-utils'
-import { nextTick, ref } from 'vue'
+import { defineComponent, h, markRaw, nextTick, ref } from 'vue'
 import { Textarea } from '.'
 import _Textarea from './story/_Textarea.vue'
 
 function ta(container: Element) {
   return container.querySelector('[data-testid="textarea"]') as HTMLTextAreaElement
+}
+
+/**
+ * Renders Textarea through a probe component in place of the native
+ * `<textarea>` and returns the attrs it forwarded. A DOM assertion cannot tell
+ * "attribute never bound" from "attribute bound as null" — both leave no
+ * attribute — so key presence is the only way to test the maxLength contract.
+ */
+function forwardedAttrs(props?: Record<string, unknown>): Record<string, unknown> {
+  let attrs: Record<string, unknown> = {}
+  const Probe = markRaw(defineComponent({
+    inheritAttrs: false,
+    setup(_, ctx) {
+      attrs = { ...ctx.attrs }
+      return () => h('view')
+    },
+  }))
+  render(Textarea, { as: Probe, ...props })
+  return attrs
 }
 
 describe('Textarea — default render', () => {
@@ -32,6 +51,18 @@ describe('Textarea — default render', () => {
     expect(el.getAttribute('maxlines')).toBe('5')
     expect(el.getAttribute('line-spacing')).toBe('4px')
     expect(el.getAttribute('bounces')).toBe('false')
+  })
+
+  it('binds no maxlength attr at all by default', () => {
+    const attrs = forwardedAttrs()
+    // `maxlines` is the positive control: proves the probe received the attrs,
+    // so the absence below is a real omission and not an empty capture.
+    expect(Object.keys(attrs)).toContain('maxlines')
+    expect(Object.keys(attrs)).not.toContain('maxlength')
+  })
+
+  it('binds maxlength when maxLength is set', () => {
+    expect(forwardedAttrs({ maxLength: 280 }).maxlength).toBe(280)
   })
 })
 

--- a/packages/core/src/components/LazyComponent/LazyComponent.test.ts
+++ b/packages/core/src/components/LazyComponent/LazyComponent.test.ts
@@ -1,19 +1,39 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0.
 
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
+import { defineComponent, h } from 'vue'
 import { render, waitForUpdate } from '@vyui/testing-utils'
 
+import LazyComponent, { type LazyComponentProps } from './LazyComponent.vue'
 import Lazy from './story/_LazyComponent.vue'
 
 function q(container: Element, id: string) {
   return container.querySelector(`[data-testid="${id}"]`) as HTMLElement | null
 }
 
-// NOTE: full exposure-event flow ('exposure' → show=true → mount children)
-// requires a Lynx runtime providing `lynx.getJSModule('GlobalEventEmitter')`.
-// Vitest provides no equivalent. Manual verification via LynxExplorer + the
-// demo app; see plans/mobile-first-pivot.md §3L.
+// The testing env owns the `lynx` global and its GlobalEventEmitter for the
+// whole run — `exposure` is fed through the env's own emitter, exactly as Lynx
+// delivers it (`emit(name, args)` spreads `args` over the listener).
+function emitter(): { emit: (name: string, args?: unknown[]) => void, removeAllListeners: (name?: string) => void } {
+  return (globalThis as any).lynx.getJSModule('GlobalEventEmitter')
+}
+
+// The story forwards only pid/scene/unmountOnExit — mount LazyComponent
+// directly when the margin props or the slot content are what's under test.
+function host(props: Partial<LazyComponentProps> = {}) {
+  return defineComponent({
+    setup: () => () => h('view', [
+      h(
+        LazyComponent,
+        { scene: 'feed', pid: 'a', estimatedStyle: { width: '100%', height: '120px' }, ...props },
+        { default: () => h('view', { 'data-testid': 'loaded' }) },
+      ),
+    ]),
+  })
+}
+
+afterEach(() => emitter().removeAllListeners())
 
 describe('LazyComponent — placeholder render', () => {
   it('renders a placeholder before any exposure event', async () => {
@@ -42,14 +62,41 @@ describe('LazyComponent — placeholder render', () => {
     expect(style).toContain('height: 120px')
   })
 
-  it('placeholder applies custom margin attrs', async () => {
-    // Re-render via story (story only forwards pid/scene/unmountOnExit).
-    // Default margins come from the component prop defaults.
+  it('placeholder applies the default margin attrs', async () => {
     const { container } = render(Lazy, { pid: 'a', scene: 'feed' })
     await waitForUpdate()
     const el = q(container, 'lazy')!
     expect(el.getAttribute('exposure-screen-margin-top')).toBe('10px')
     expect(el.getAttribute('exposure-screen-margin-bottom')).toBe('10px')
+  })
+
+  it('placeholder forwards custom margin props', async () => {
+    const { container } = render(host({ top: '48px', bottom: '64px' }))
+    await waitForUpdate()
+    const el = container.querySelector('[exposure-id="a"]')!
+    expect(el.getAttribute('exposure-screen-margin-top')).toBe('48px')
+    expect(el.getAttribute('exposure-screen-margin-bottom')).toBe('64px')
+  })
+})
+
+describe('LazyComponent — exposure', () => {
+  it('mounts the children once an exposure event names its scene + id', async () => {
+    const { container } = render(host())
+    await waitForUpdate()
+    expect(q(container, 'loaded')).toBeNull()
+
+    emitter().emit('exposure', [[{ 'exposure-id': 'a', 'exposure-scene': 'feed' }]])
+    await waitForUpdate()
+    expect(q(container, 'loaded')).not.toBeNull()
+  })
+
+  it('ignores an exposure event for another element in the same scene', async () => {
+    const { container } = render(host())
+    await waitForUpdate()
+
+    emitter().emit('exposure', [[{ 'exposure-id': 'b', 'exposure-scene': 'feed' }]])
+    await waitForUpdate()
+    expect(q(container, 'loaded')).toBeNull()
   })
 })
 

--- a/packages/core/src/components/List/List.test.ts
+++ b/packages/core/src/components/List/List.test.ts
@@ -27,101 +27,6 @@ describe('List — exports', () => {
   })
 })
 
-// Pure-logic regression tests for the inline alignment math inside the
-// `scrollIntoIdMT` worklet (List.vue ~line 220). Replicated here so the
-// arithmetic is verified without rendering — the worklet itself is blocked
-// by MTS test infra. See plans/mobile-first-pivot.md §3D.
-describe('List — scrollIntoId alignment math', () => {
-  function computeOffset(
-    alignTo: 'top' | 'bottom' | 'middle' | 'none',
-    rect: { upper: number, lower: number, childSize: number },
-    listSize: number,
-  ): number {
-    if (alignTo === 'top') return rect.upper
-    if (alignTo === 'bottom') return rect.lower - listSize
-    if (alignTo === 'middle') return rect.upper - (listSize - rect.childSize) / 2
-    return 0
-  }
-
-  it('top alignment = child upper edge offset', () => {
-    expect(computeOffset('top', { upper: 120, lower: 200, childSize: 80 }, 600)).toBe(120)
-  })
-
-  it('bottom alignment = child lower edge minus viewport', () => {
-    expect(computeOffset('bottom', { upper: 120, lower: 200, childSize: 80 }, 600)).toBe(-400)
-  })
-
-  it('middle alignment centers the child in the viewport', () => {
-    // child of 100 in a 600 viewport at upper 250 → offset 250 - (600-100)/2 = 0
-    expect(computeOffset('middle', { upper: 250, lower: 350, childSize: 100 }, 600)).toBe(0)
-  })
-
-  it('none alignment skips the corrective step (offset 0)', () => {
-    expect(computeOffset('none', { upper: 120, lower: 200, childSize: 80 }, 600)).toBe(0)
-  })
-})
-
-// `invoke()` is the selector-query wrapper used by scrollTo / autoScroll /
-// getVisibleCells. On hosts without the `lynx` global (vitest / SSR) it must
-// resolve `undefined` rather than throw — otherwise SSR / web fallback render
-// of `<List>` would crash on first ref call.
-describe('List — invoke() web fallback', () => {
-  function invoke(method: string, params: Record<string, unknown> = {}, listId = 'vy-list-x'): Promise<unknown> {
-    return new Promise((resolve, reject) => {
-      const g = globalThis as any
-      if (!g?.lynx?.createSelectorQuery) {
-        resolve(undefined)
-        return
-      }
-      g.lynx
-        .createSelectorQuery()
-        .select(`#${listId}`)
-        .invoke({ method, params, success: (r: unknown) => resolve(r), fail: reject })
-        .exec()
-    })
-  }
-
-  it('resolves undefined when `lynx.createSelectorQuery` is absent', async () => {
-    // The vyui test setup installs a default `lynx` global — null out the
-    // selector-query API for this case to exercise the SSR / web-fallback
-    // branch, then restore.
-    const original = (globalThis as any).lynx
-    ;(globalThis as any).lynx = { ...original, createSelectorQuery: undefined }
-    try {
-      await expect(invoke('scrollToPosition', { position: 0 })).resolves.toBeUndefined()
-    }
-    finally {
-      ;(globalThis as any).lynx = original
-    }
-  })
-
-  it('routes to lynx.createSelectorQuery().select().invoke() when available', async () => {
-    const exec = vi.fn()
-    const invokeCall = vi.fn((opts: any) => {
-      // mirror the runtime — fire `success` synchronously.
-      opts.success?.({ ok: true })
-      return { exec }
-    })
-    const select = vi.fn(() => ({ invoke: invokeCall }))
-    const createSelectorQuery = vi.fn(() => ({ select }))
-    ;(globalThis as any).lynx = { createSelectorQuery }
-
-    try {
-      const res = await invoke('scrollToPosition', { position: 3 })
-      expect(createSelectorQuery).toHaveBeenCalledOnce()
-      expect(select).toHaveBeenCalledWith('#vy-list-x')
-      expect(invokeCall).toHaveBeenCalledOnce()
-      expect(invokeCall.mock.calls[0][0].method).toBe('scrollToPosition')
-      expect(invokeCall.mock.calls[0][0].params).toEqual({ position: 3 })
-      expect(exec).toHaveBeenCalledOnce()
-      expect(res).toEqual({ ok: true })
-    }
-    finally {
-      delete (globalThis as any).lynx
-    }
-  })
-})
-
 // Regression — `scrollIntoId` threw on Lynx web and scrolled nowhere.
 //
 // The worklet reached for `lynx.querySelector('#id')` three times. That global
@@ -135,7 +40,7 @@ describe('List — invoke() web fallback', () => {
 // owns and can hold a `main-thread-ref` to. The third targets an arbitrary
 // consumer-owned child, so the global selector is the only route and it has to
 // be feature-checked instead.
-describe('List — scrollIntoId must survive a selector-less main thread', () => {
+describe('List — scrollIntoId must survive a selector-less host', () => {
   async function readSfc(name: string): Promise<string> {
     const fs = await import('node:fs')
     const path = await import('node:path')
@@ -172,6 +77,31 @@ describe('List — scrollIntoId must survive a selector-less main thread', () =>
     // the measured correction as `-offset + extraOffset`.
     expect(fn).toMatch(/offset: extraOffset,/)
     expect(fn).toMatch(/offset: -offset \+ extraOffset,/)
+  })
+
+  // The alignment arithmetic lives inside the worklet, which vitest can't run —
+  // pin the three branches from the source rather than re-deriving them here.
+  it('derives the corrective offset per alignTo branch', async () => {
+    const fn = body(await readSfc('List.vue'), 'scrollIntoIdMT')
+    expect(fn).toMatch(/let offset = 0/)
+    expect(fn).toMatch(/if \(alignTo === 'top'\) \{\s*\n\s*offset = upper\b/)
+    expect(fn).toMatch(/else if \(alignTo === 'bottom'\) \{\s*\n\s*offset = lower - listSize\b/)
+    expect(fn).toMatch(/else if \(alignTo === 'middle'\) \{\s*\n\s*offset = upper - \(listSize - childSize\) \/ 2/)
+    // 'none' has no branch on purpose: offset stays 0 and the step-1 landing stands.
+    expect(fn).not.toMatch(/if \(alignTo === 'none'/)
+    // The edges are picked off the rect by axis before any of that.
+    expect(fn).toMatch(/const upper = isVertical \? rect\.top : rect\.left/)
+    expect(fn).toMatch(/const lower = isVertical \? rect\.bottom : rect\.right/)
+  })
+
+  // Same failure mode one thread over: `invoke()` (scrollTo / autoScroll /
+  // getVisibleCells) must resolve `undefined` on a host with no selector query
+  // instead of throwing, or an SSR / web render crashes on the first ref call.
+  it('feature-checks createSelectorQuery before every ref-driven scroll', async () => {
+    const fn = body(await readSfc('List.vue'), 'invoke')
+    expect(fn).toMatch(/if \(!g\?\.lynx\?\.createSelectorQuery\) \{\s*\n\s*resolve\(undefined\)/)
+    expect(fn).toMatch(/\.select\(`#\$\{listId\.value\}`\)/)
+    expect(fn).toMatch(/\.exec\(\)/)
   })
 })
 

--- a/packages/core/src/components/OverlayRoot/OverlayRoot.test.ts
+++ b/packages/core/src/components/OverlayRoot/OverlayRoot.test.ts
@@ -23,8 +23,10 @@ const Host = defineComponent({
 describe('overlayRoot', () => {
   it('renders nothing when the store is empty', () => {
     const { container } = render(Host)
-    expect(overlayEntries.value.length).toBe(0)
-    expect(container.querySelector('[data-overlay-test]')).toBeNull()
+    // No wrapper `<view>` around the v-for — one would swallow every touch in
+    // its empty regions. Counts painted tags only: v-for anchors are real
+    // zero-size nodes, so `container.children` is never 0.
+    expect(container.querySelectorAll('view').length).toBe(0)
   })
 
   it('paints a registered entry through the portal', async () => {

--- a/packages/core/src/components/Popover/Popover.test.ts
+++ b/packages/core/src/components/Popover/Popover.test.ts
@@ -92,15 +92,6 @@ describe('popover', () => {
     expect(q(container, 'content')).not.toBeNull()
   })
 
-  it('selects the modal variant when modal=true', async () => {
-    // The variant is module-private. Use the captured story state: modal:true
-    // does NOT change semantics on Lynx but the file branches; assert opening
-    // works under both.
-    const mod = await import('../..')
-    expect((mod as any).PopoverContentModal).toBeDefined()
-    expect((mod as any).PopoverContentNonModal).toBeDefined()
-  })
-
   it('unregisters the overlay entry on unmount', async () => {
     const { container, unmount } = render(Popover, { rootProps: { defaultOpen: true } })
     await waitForUpdate()

--- a/packages/core/src/components/Primitive/Primitive.test.ts
+++ b/packages/core/src/components/Primitive/Primitive.test.ts
@@ -51,7 +51,7 @@ describe('Primitive', () => {
     expect(element.childNodes.length).toBe(0)
   })
 
-  it('omits an undefined attr and keeps the defined ones', () => {
+  it('applies the defined attrs to the rendered element', () => {
     const { container } = render(Primitive, { as: 'view', type: 'button', placeholder: undefined })
     const element = container.querySelector('view')!
     expect(element.getAttribute('type')).toBe('button')

--- a/packages/core/src/components/Select/Select.test.ts
+++ b/packages/core/src/components/Select/Select.test.ts
@@ -74,6 +74,8 @@ describe('Select — selection', () => {
   it('SelectItemIndicator is rendered only for selected item', async () => {
     const { container } = render(Select, { modelValue: 'Cherry', defaultOpen: true })
     expect(q(container, 'indicator-Cherry')).not.toBeNull()
+    expect(q(container, 'indicator-Apple')).toBeNull()
+    expect(q(container, 'indicator-Banana')).toBeNull()
   })
 })
 

--- a/packages/core/src/components/Slider/Slider.test.ts
+++ b/packages/core/src/components/Slider/Slider.test.ts
@@ -88,10 +88,8 @@ describe('SliderRoot rendering & a11y traits', () => {
 
   it('marks root and thumb data-disabled when disabled', () => {
     const { container } = mountSlider({ disabled: true })
-    // SliderRoot stamps data-disabled="" on the horizontal track wrapper
-    // and the thumb (`SliderThumbImpl`).
-    const disabledNodes = container.querySelectorAll('[data-disabled=""]')
-    expect(disabledNodes.length).toBeGreaterThanOrEqual(1)
+    expect(container.querySelector('[data-vyui-slider-impl]')!.getAttribute('data-disabled')).toBe('')
+    expect(container.querySelector('.vyui-slider-thumb')!.getAttribute('data-disabled')).toBe('')
   })
 })
 

--- a/packages/core/src/components/Sortable/Sortable.test.ts
+++ b/packages/core/src/components/Sortable/Sortable.test.ts
@@ -28,69 +28,46 @@ describe('Sortable — exports', () => {
   })
 })
 
-describe('Sortable — commitReorder logic', () => {
-  it('moves an item from `from` to `to` within an array', () => {
-    // Mirrors the body of `commitReorder` in SortableRoot.vue. Kept here so
-    // the index math is regression-tested without rendering — the rendering
-    // side is blocked on MTS test infra.
-    function move<T>(list: T[], from: number, to: number): T[] {
-      const next = [...list]
-      const [item] = next.splice(from, 1)
-      next.splice(to, 0, item)
-      return next
-    }
+async function readSfc(name: string): Promise<string> {
+  const fs = await import('node:fs')
+  const path = await import('node:path')
+  return fs.readFileSync(path.join(path.dirname(new URL(import.meta.url).pathname), name), 'utf8')
+}
 
-    expect(move(['a', 'b', 'c', 'd'], 0, 2)).toEqual(['b', 'c', 'a', 'd'])
-    expect(move(['a', 'b', 'c', 'd'], 3, 0)).toEqual(['d', 'a', 'b', 'c'])
-    expect(move(['a', 'b', 'c', 'd'], 1, 1)).toEqual(['a', 'b', 'c', 'd'])
-  })
-})
+function body(sfc: string, fn: string): string {
+  return sfc.match(new RegExp(`function ${fn}[\\s\\S]*?\\n}`))?.[0] ?? ''
+}
 
-// Velocity-aware drop the touchend worklet runs (mirrors the body of
-// `_onTouchEnd` in SortableItem.vue / physics.ts sortableDropTarget): a fast
-// toss lands one row further in the flick direction, clamped to range, never
-// reversing the pointer's committed direction.
-describe('Sortable — velocity-aware drop', () => {
-  function drop(startIdx: number, rawTarget: number, velocity: number, count: number): number {
-    let target = rawTarget
-    if (velocity < 0 ? -velocity >= 300 : velocity >= 300) {
-      const dir = velocity > 0 ? 1 : -1
-      if (dir > 0 && target >= startIdx) target += 1
-      else if (dir < 0 && target <= startIdx) target -= 1
-    }
-    if (target < 0) target = 0
-    if (target > count - 1) target = count - 1
-    return target
-  }
+// The drop target math (`sortableDropTarget`) is unit-tested against the real
+// implementation in `shared/gesture/physics.test.ts`. Worklets can't call
+// across files, so `_gestureEnd` carries a hand-copied mirror, and the guards
+// on the background-side commit run where no test can reach them.
+describe('Sortable — commitReorder guards', () => {
+  it('rejects a no-op or out-of-range reorder before touching the model', async () => {
+    // A drop that never moved, or a target past the end, would otherwise
+    // splice `undefined` into the list and emit a phantom reorder.
+    const fn = body(await readSfc('SortableRoot.vue'), 'commitReorder')
+    expect(fn).toMatch(/if \(from === to \|\| from < 0 \|\| to < 0\) return/)
+    expect(fn).toMatch(/if \(from >= list\.length \|\| to >= list\.length\) return/)
+  })
 
-  it('passes the raw target through when velocity is mild', () => {
-    expect(drop(2, 3, 100, 6)).toBe(3)
-  })
-  it('a fast downward toss throws one row further', () => {
-    expect(drop(0, 2, 400, 6)).toBe(3)
-  })
-  it('a fast upward toss throws one row higher', () => {
-    expect(drop(5, 3, -400, 6)).toBe(2)
-  })
-  it('does not reverse the committed pointer direction', () => {
-    expect(drop(0, 3, -400, 6)).toBe(3)
-  })
-  it('clamps to the list bounds', () => {
-    expect(drop(5, 5, 400, 6)).toBe(5)
-    expect(drop(0, 0, -400, 6)).toBe(0)
+  it('moves on a copy, then publishes and emits', async () => {
+    // Splicing `items.value` in place would mutate the consumer's array before
+    // the range guard had a say, and emitting first would report a reorder the
+    // model has not taken yet.
+    const fn = body(await readSfc('SortableRoot.vue'), 'commitReorder')
+    expect(fn).toMatch(/const list = \[\.\.\.items\.value\][\s\S]*items\.value = list[\s\S]*emits\('reorder', \{ from, to \}\)/)
   })
 })
 
 describe('Sortable — drop settle contract in the SFC source', () => {
-  async function readSfc(name: string): Promise<string> {
-    const fs = await import('node:fs')
-    const path = await import('node:path')
-    return fs.readFileSync(path.join(path.dirname(new URL(import.meta.url).pathname), name), 'utf8')
-  }
-
-  function body(sfc: string, fn: string): string {
-    return sfc.match(new RegExp(`function ${fn}[\\s\\S]*?\\n}`))?.[0] ?? ''
-  }
+  it('keeps the velocity bias and range clamp in the drop target math', async () => {
+    const fn = body(await readSfc('SortableItem.vue'), '_gestureEnd')
+    expect(fn).toMatch(/if \(dir > 0 && target >= startIdx\) target \+= 1/)
+    expect(fn).toMatch(/else if \(dir < 0 && target <= startIdx\) target -= 1/)
+    expect(fn).toMatch(/if \(target < 0\) target = 0/)
+    expect(fn).toMatch(/if \(target > count - 1\) target = count - 1/)
+  })
 
   it('settles the lifted row into its target slot instead of clearing on release', async () => {
     // Clearing on the main thread at release repaints the PRE-DRAG order for

--- a/packages/core/src/components/SwipeAction/SwipeAction.test.ts
+++ b/packages/core/src/components/SwipeAction/SwipeAction.test.ts
@@ -23,98 +23,61 @@ describe('SwipeAction — exports', () => {
   })
 })
 
-// Pure logic the touchend worklet runs. Kept here so the snap / commit
-// decision is regression-tested without rendering. Mirrors the body of
-// `_onTouchEnd` in SwipeAction.vue.
-describe('SwipeAction — release-snap decision', () => {
-  type Decision = 'commit' | 'open' | 'close'
-
-  function decide(opts: {
-    endX: number
-    velocity: number
-    actionWidth: number
-    rowWidth: number
-    snapThreshold: number
-    commitThreshold: number
-    commitVelocity: number
-    velocityThreshold: number
-  }): Decision {
-    // Mirrors `_onTouchEnd` in SwipeAction.vue (and physics.ts
-    // decideSwipeAction): commit on hard leftward flick / past commit
-    // threshold; a rightward flick always closes; else open vs close.
-    const opening = -opts.velocity // positive = leftward (revealing)
-    if (opening >= opts.commitVelocity || -opts.endX >= opts.commitThreshold * opts.rowWidth) {
-      return 'commit'
-    }
-    if (opts.velocity >= opts.velocityThreshold) {
-      return 'close'
-    }
-    if (opening >= opts.velocityThreshold || -opts.endX >= opts.snapThreshold * opts.actionWidth) {
-      return 'open'
-    }
-    return 'close'
+// The release decision itself (`decideSwipeAction`) and the ±45° axis cone
+// (`resolveAxisLock`) are unit-tested against the real implementations in
+// `shared/gesture/physics.test.ts`. Worklets can't call across files, so
+// `_dragEnd` / `_dragMove` carry hand-copied mirrors plus the parts physics.ts
+// cannot see: the order the branches are tested in, where each one settles the
+// row, and what it emits.
+describe('SwipeAction — release contract in the SFC source', () => {
+  async function readSfc(name: string): Promise<string> {
+    const fs = await import('node:fs')
+    const path = await import('node:path')
+    return fs.readFileSync(path.join(path.dirname(new URL(import.meta.url).pathname), name), 'utf8')
   }
 
-  const base = {
-    actionWidth: 80,
-    rowWidth: 320,
-    snapThreshold: 0.5,
-    commitThreshold: 0.5,
-    commitVelocity: 1200,
-    velocityThreshold: 400,
+  function body(sfc: string, fn: string): string {
+    return sfc.match(new RegExp(`function ${fn}[\\s\\S]*?\\n}`))?.[0] ?? ''
   }
 
-  it('closes when drag did not pass snap threshold and velocity is mild', () => {
-    expect(decide({ ...base, endX: -10, velocity: -50 })).toBe('close')
+  it('decides commit, then a closing flick, then open — in that order', async () => {
+    // Order is the contract: a hard leftward flick has to beat the open
+    // threshold, and a rightward flick has to beat the position check, or a
+    // fast flick out of a deep drag resolves to the wrong outcome.
+    const fn = body(await readSfc('SwipeAction.vue'), '_dragEnd')
+    const commit = fn.indexOf('opening >= commitVelocityRef.current')
+    const closeFlick = fn.indexOf('velocity >= velocityThresholdRef.current')
+    const open = fn.indexOf('opening >= velocityThresholdRef.current')
+    expect(commit).toBeGreaterThan(-1)
+    expect(closeFlick).toBeGreaterThan(commit)
+    expect(open).toBeGreaterThan(closeFlick)
   })
 
-  it('opens when drag passes snap threshold', () => {
-    // -endX = 50, snap threshold = 0.5 * 80 = 40 → open.
-    expect(decide({ ...base, endX: -50, velocity: 0 })).toBe('open')
+  it('settles each branch to its own resting position', async () => {
+    // commit → off the row entirely, closing flick → closed, open → the action
+    // panel width, fallthrough → closed.
+    const fn = body(await readSfc('SwipeAction.vue'), '_dragEnd')
+    expect([...fn.matchAll(/_animateTo\((.*?)\)/g)].map(m => m[1]))
+      .toEqual(['-rw', '0', '-aw', '0'])
   })
 
-  it('opens on mild leftward flick even before snap threshold', () => {
-    expect(decide({ ...base, endX: -20, velocity: -500 })).toBe('open')
+  it('emits commit once and otherwise reports the new open state', async () => {
+    const fn = body(await readSfc('SwipeAction.vue'), '_dragEnd')
+    const emitted = [...fn.matchAll(/runOnBackground\((_emit\w+) as any\)\((\w*)\)/g)]
+      .map(m => `${m[1]}(${m[2]})`)
+    expect(emitted).toEqual([
+      '_emitCommit()',
+      '_emitOpen(false)',
+      '_emitOpen(true)',
+      '_emitOpen(false)',
+    ])
   })
 
-  it('commits when dragged past commit threshold (half row width)', () => {
-    // -endX = 200, commit threshold = 0.5 * 320 = 160 → commit.
-    expect(decide({ ...base, endX: -200, velocity: 0 })).toBe('commit')
-  })
-
-  it('commits on hard leftward flick regardless of position', () => {
-    expect(decide({ ...base, endX: -30, velocity: -1400 })).toBe('commit')
-  })
-
-  it('a rightward flick closes even past the open threshold', () => {
-    // position alone (-endX = 50 ≥ 40) would open, but the flick is rightward
-    expect(decide({ ...base, endX: -50, velocity: 600 })).toBe('close')
-  })
-})
-
-// Axis-lock decision the touchmove worklet runs once per gesture: a gesture
-// past the 8px slop is "ours" only when |dx| >= |dy| (the ±45° horizontal
-// cone), otherwise it belongs to the surrounding vertical list scroll.
-describe('SwipeAction — axis lock', () => {
-  function axis(dx: number, dy: number): 0 | 1 | 2 {
-    const displacement = Math.sqrt(dx * dx + dy * dy)
-    if (displacement <= 8) return 0 // undecided
-    return Math.abs(dx) >= Math.abs(dy) ? 1 : 2 // 1 = horizontal, 2 = vertical
-  }
-
-  it('stays undecided below the slop threshold', () => {
-    expect(axis(3, 3)).toBe(0)
-    expect(axis(5, 5)).toBe(0)
-  })
-  it('locks horizontal for a mostly-horizontal drag', () => {
-    expect(axis(20, 4)).toBe(1)
-    expect(axis(-30, 10)).toBe(1)
-  })
-  it('yields to vertical scroll for a mostly-vertical drag', () => {
-    expect(axis(4, 20)).toBe(2)
-    expect(axis(10, -30)).toBe(2)
-  })
-  it('diagonal at exactly 45° is horizontal (boundary inclusive)', () => {
-    expect(axis(20, 20)).toBe(1)
+  it('yields the whole gesture to a vertical scroll once axis-locked', async () => {
+    // The lock is resolved once per gesture and stays sticky, and release is a
+    // no-op for a yielded gesture — snapping there would fight the list scroll.
+    const sfc = await readSfc('SwipeAction.vue')
+    expect(body(sfc, '_dragMove')).toMatch(/if \(axisLockRef\.current === 2\) return/)
+    expect(body(sfc, '_dragEnd')).toMatch(/if \(axisLockRef\.current === 2\) \{[\s\S]*?return/)
   })
 })

--- a/packages/core/src/components/Swiper/Swiper.test.ts
+++ b/packages/core/src/components/Swiper/Swiper.test.ts
@@ -22,9 +22,13 @@ vi.mock('vue-lynx', async () => {
 // NOTE: full render coverage of SwiperRoot is blocked on MTS test infra —
 // the `:main-thread-bind*` template attrs crash under vitest even with the
 // mock above because the binding itself goes through the MT ops pipeline.
-// Tests here exercise the BG-side surface (item count, default index, item
-// width inheritance via SwiperItem context). Touch/drag/snap is verified
-// manually in LynxExplorer. See plans/mobile-first-pivot.md §3D.
+//
+// Drag, snap, clamp, loop wrap, RTL, the align nudge, axis lock and the
+// release physics all run for real in `shared/gesture/useDragGesture.test.ts`
+// (which drives the actual composable) and `shared/gesture/physics.test.ts`.
+// Treat those as the spec. What is left here is the wiring Swiper alone owns
+// and cannot execute, asserted against source text the way
+// mouseDragContract.test.ts and Slider.test.ts do it.
 
 describe('Swiper — exports', () => {
   it('exports SwiperRoot and SwiperItem', async () => {
@@ -35,345 +39,60 @@ describe('Swiper — exports', () => {
   })
 })
 
-// --- Pure-logic regression tests --------------------------------------
-// The Phase-5 rewrite (commit a1d57ac) reshaped SwiperRoot's MT pipeline.
-// Two arithmetic surfaces are easy to break without an MT renderer:
-//   • initial offset placement when `defaultValue` lands at a non-zero index
-//   • SwiperItem width override semantics (per-item `width` > inherited `itemWidth`)
-// Both are exercised below without rendering.
+async function readSource(relPath: string): Promise<string> {
+  const fs = await import('node:fs')
+  const path = await import('node:path')
+  const here = path.dirname(new URL(import.meta.url).pathname)
+  return fs.readFileSync(path.join(here, relPath), 'utf8')
+}
 
-describe('Swiper — initial offset placement', () => {
-  // Mirrors `useMainThreadRef(-(currentIndex.value ?? 0) * props.itemWidth)`
-  // from SwiperRoot.vue. Normalised through `+ 0` so `-0 === 0` under
-  // vitest's `Object.is`-backed `.toBe`.
-  function initialOffset(currentIndex: number | undefined, itemWidth: number): number {
-    return -(currentIndex ?? 0) * itemWidth + 0
-  }
+const CONTROLLER = '../../shared/gesture/useDragGesture.ts'
 
-  it('starts at 0 when index = 0', () => {
-    expect(initialOffset(0, 200)).toBe(0)
+describe('Swiper — resting offset placement', () => {
+  it('places the initial transform at -index * (itemWidth + spaceBetween)', async () => {
+    // The snap unit is the item PLUS the gap. Using itemWidth alone drifts the
+    // track by one gap per index — invisible until a device run, because the
+    // offset is dispatched once at mount and never re-derived.
+    const src = await readSource(CONTROLLER)
+    expect(src).toMatch(/fullSizeOf = \(\) => config\.itemWidth\(\) \+ spaceBetweenGetter\(\)/)
+    expect(src).toMatch(/const initialOffset = -\(currentIndex\.value \?\? 0\) \* fullSizeOf\(\)/)
   })
 
-  it('shifts -itemWidth per index step', () => {
-    expect(initialOffset(2, 200)).toBe(-400)
-    expect(initialOffset(5, 100)).toBe(-500)
-  })
-
-  it('treats undefined index as 0 (uncontrolled before defaultValue resolves)', () => {
-    expect(initialOffset(undefined, 200)).toBe(0)
+  it('dispatches that transform unless the resting position is already translateX(0)', async () => {
+    // An align nudge or RTL still needs the dispatch at index 0; skipping it
+    // there leaves the first item parked at the wrong edge.
+    const src = await readSource(CONTROLLER)
+    expect(src).toMatch(/if \(initialOffset !== 0 \|\| alignOffsetOf\(\) !== 0 \|\| rtlGetter\(\)\)/)
   })
 })
 
-describe('Swiper — SwiperItem width override', () => {
-  // Mirrors `computed(() => props.width ?? ctx.itemWidth.value)` in SwiperItem.vue.
-  function itemWidth(propWidth: number | undefined, ctxItemWidth: number): number {
-    return propWidth ?? ctxItemWidth
-  }
-
-  it('inherits SwiperRoot itemWidth when no `width` prop', () => {
-    expect(itemWidth(undefined, 240)).toBe(240)
+describe('SwiperItem — width override', () => {
+  it('takes the per-item `width` prop over the inherited itemWidth, including 0', async () => {
+    // `??`, not `||`: an explicit 0 is a real width and `||` would silently
+    // fall back to the root's itemWidth.
+    const sfc = await readSource('SwiperItem.vue')
+    expect(sfc).toMatch(/computed\(\(\) => props\.width \?\? ctx\.itemWidth\.value\)/)
+    expect(sfc).toMatch(/width: `\$\{width\.value\}px`/)
   })
 
-  it('per-item `width` prop wins', () => {
-    expect(itemWidth(300, 240)).toBe(300)
-  })
-
-  it('width 0 still wins (explicit zero is intentional)', () => {
-    // `??` semantics — 0 is not nullish, so the override applies.
-    expect(itemWidth(0, 240)).toBe(0)
+  it('carries the gap as a margin, never folded into the item width', async () => {
+    // Folding the gap into `width` would double-count it: the controller
+    // already adds spaceBetween to the snap unit.
+    const sfc = await readSource('SwiperItem.vue')
+    expect(sfc).toMatch(/base\.marginLeft = `\$\{gap\}px`/)
+    expect(sfc).toMatch(/base\.marginRight = `\$\{gap\}px`/)
   })
 })
-
-// --- Loop / clamp index resolution ------------------------------------
-// Mirrors the index wrap/clamp in useDragGesture's `_onTouchEnd`, `_advance`,
-// and `setIndex`. Loop wraps modularly; non-loop clamps to [0, count-1].
-
-describe('Swiper — index wrap (loop) vs clamp', () => {
-  function resolve(target: number, count: number, loop: boolean): number {
-    if (loop) return ((target % count) + count) % count
-    if (target < 0) return 0
-    if (target > count - 1) return count - 1
-    return target
-  }
-
-  it('clamps below 0 to 0 when not looping', () => {
-    expect(resolve(-1, 4, false)).toBe(0)
-  })
-
-  it('clamps past the end when not looping', () => {
-    expect(resolve(7, 4, false)).toBe(3)
-  })
-
-  it('wraps past the end to the start when looping', () => {
-    expect(resolve(4, 4, true)).toBe(0)
-    expect(resolve(5, 4, true)).toBe(1)
-  })
-
-  it('wraps below 0 to the last item when looping', () => {
-    expect(resolve(-1, 4, true)).toBe(3)
-    expect(resolve(-2, 4, true)).toBe(2)
-  })
-
-  it('leaves in-range targets unchanged in both modes', () => {
-    expect(resolve(2, 4, false)).toBe(2)
-    expect(resolve(2, 4, true)).toBe(2)
-  })
-})
-
-// --- Autoplay advance step --------------------------------------------
-// Mirrors useDragGesture's `_advance`: next = cur + 1, wrapping in loop mode
-// and stopping (returning the same index) at the last item otherwise.
 
 describe('Swiper — autoplay advance', () => {
-  function advance(cur: number, count: number, loop: boolean): number {
-    if (count <= 1) return cur
-    let next = cur + 1
-    if (next > count - 1) {
-      if (loop) next = 0
-      else return cur
-    }
-    return next
-  }
-
-  it('advances one item', () => {
-    expect(advance(0, 4, false)).toBe(1)
-    expect(advance(1, 4, false)).toBe(2)
-  })
-
-  it('stops at the last item when not looping', () => {
-    expect(advance(3, 4, false)).toBe(3)
-  })
-
-  it('wraps to the first item at the end when looping', () => {
-    expect(advance(3, 4, true)).toBe(0)
-  })
-
-  it('is a no-op with a single item', () => {
-    expect(advance(0, 1, true)).toBe(0)
-    expect(advance(0, 1, false)).toBe(0)
-  })
-})
-
-// --- Axis-lock classification -----------------------------------------
-// Mirrors useDragGesture's `_onTouchMove` axis decision: a gesture is
-// "horizontal enough" to consume when its angle is within ±45° of either
-// horizontal direction (|angle| <= 45 || |angle| >= 135).
-
-describe('Swiper — axis-lock classification', () => {
-  function isHorizontal(dX: number, dY: number): boolean {
-    const angle = (Math.atan2(dY, dX) * 180) / Math.PI
-    const a = angle < 0 ? -angle : angle
-    return a <= 45 || a >= 135
-  }
-
-  it('treats a pure horizontal drag as horizontal', () => {
-    expect(isHorizontal(20, 0)).toBe(true)
-    expect(isHorizontal(-20, 0)).toBe(true)
-  })
-
-  it('treats a pure vertical drag as not horizontal', () => {
-    expect(isHorizontal(0, 20)).toBe(false)
-    expect(isHorizontal(0, -20)).toBe(false)
-  })
-
-  it('treats a shallow diagonal (< 45°) as horizontal', () => {
-    expect(isHorizontal(20, 10)).toBe(true)
-  })
-
-  it('treats a steep diagonal (> 45°) as not horizontal', () => {
-    expect(isHorizontal(10, 20)).toBe(false)
-  })
-})
-
-// --- spaceBetween / fullSize snap unit --------------------------------
-// Mirrors useDragGesture's switch from `itemWidth` to `fullSize = itemWidth +
-// spaceBetween` as the offset↔index conversion unit.
-
-describe('Swiper — fullSize (spaceBetween) snap unit', () => {
-  function fullSize(itemWidth: number, spaceBetween: number): number {
-    return itemWidth + spaceBetween
-  }
-  function offsetForIndex(index: number, itemWidth: number, spaceBetween: number): number {
-    return -index * fullSize(itemWidth, spaceBetween) + 0
-  }
-
-  it('snap unit includes the gap', () => {
-    expect(fullSize(200, 16)).toBe(216)
-  })
-
-  it('places each index one full period apart', () => {
-    expect(offsetForIndex(0, 200, 16)).toBe(0)
-    expect(offsetForIndex(1, 200, 16)).toBe(-216)
-    expect(offsetForIndex(2, 200, 16)).toBe(-432)
-  })
-
-  it('reduces to itemWidth when there is no gap', () => {
-    expect(offsetForIndex(2, 200, 0)).toBe(-400)
-  })
-})
-
-// --- align nudge -------------------------------------------------------
-// Mirrors useDragGesture's `alignOffsetOf` (the transform-time nudge that puts
-// the active item at start/center/end of the viewport).
-
-describe('Swiper — align nudge', () => {
-  function alignOffset(
-    align: 'start' | 'center' | 'end',
-    containerWidth: number,
-    itemWidth: number,
-  ): number {
-    if (containerWidth <= 0) return 0
-    if (align === 'center') return (containerWidth - itemWidth) / 2
-    if (align === 'end') return containerWidth - itemWidth
-    return 0
-  }
-
-  it('start: no nudge', () => {
-    expect(alignOffset('start', 360, 200)).toBe(0)
-  })
-  it('center: half the slack', () => {
-    expect(alignOffset('center', 360, 200)).toBe(80)
-  })
-  it('end: the full slack', () => {
-    expect(alignOffset('end', 360, 200)).toBe(160)
-  })
-  it('no container width: no nudge regardless of align', () => {
-    expect(alignOffset('center', 0, 200)).toBe(0)
-    expect(alignOffset('end', 0, 200)).toBe(0)
-  })
-})
-
-// --- offsetLimit / align-derived clamp --------------------------------
-// Mirrors useDragGesture's `resolveLimits` + the touchmove clamp:
-// max = startLimit; min = -(count-1)*fullSize + endLimit.
-
-describe('Swiper — offset clamp limits', () => {
-  function resolveLimits(
-    explicit: [number, number] | undefined,
-    align: 'start' | 'center' | 'end',
-    containerWidth: number,
-    itemWidth: number,
-  ): { startLimit: number, endLimit: number } {
-    if (explicit) return { startLimit: explicit[0], endLimit: explicit[1] }
-    if (containerWidth > 0 && align === 'end') {
-      return { startLimit: containerWidth - itemWidth, endLimit: 0 }
-    }
-    return { startLimit: 0, endLimit: 0 }
-  }
-  function clamp(
-    raw: number,
-    count: number,
-    fullSize: number,
-    limits: { startLimit: number, endLimit: number },
-  ): number {
-    const max = limits.startLimit
-    const min = -(count - 1) * fullSize + limits.endLimit
-    if (raw > max) return max
-    if (raw < min) return min
-    return raw
-  }
-
-  it('default clamps exactly to the item range', () => {
-    const l = resolveLimits(undefined, 'start', 360, 200)
-    expect(clamp(50, 4, 200, l)).toBe(0)
-    expect(clamp(-1000, 4, 200, l)).toBe(-600)
-  })
-
-  it('explicit offsetLimit widens the rest range', () => {
-    const l = resolveLimits([0, 160], 'start', 360, 200)
-    // endLimit 160 lets the last item rest 160px short of the left edge.
-    expect(clamp(-1000, 4, 200, l)).toBe(-440)
-  })
-
-  it('align end pulls the first item to the right edge', () => {
-    const l = resolveLimits(undefined, 'end', 360, 200)
-    expect(l.startLimit).toBe(160)
-    expect(clamp(200, 4, 200, l)).toBe(160)
-  })
-})
-
-// --- RTL delta / velocity sign ----------------------------------------
-// Mirrors useDragGesture's RTL handling: a rightward finger move reads as
-// moving toward lower indices, so the drag delta and release velocity flip.
-
-describe('Swiper — RTL direction flip', () => {
-  function delta(rawDx: number, rtl: boolean): number {
-    return rtl ? -rawDx : rawDx
-  }
-  it('LTR: rightward finger increases offset (toward lower index)', () => {
-    expect(delta(40, false)).toBe(40)
-  })
-  it('RTL: rightward finger decreases offset (toward higher index)', () => {
-    expect(delta(40, true)).toBe(-40)
-  })
-})
-
-// --- Seamless loop: raw → wrapped index + seam detection --------------
-// Mirrors useDragGesture's `_animateToIndex`: the raw (unwrapped) target index
-// is wrapped modulo count, and a seam crossing is detected when the raw offset
-// differs from the wrapped offset (so the seamless clone-region animation runs).
-
-describe('Swiper — seamless loop wrap + seam detection', () => {
-  function resolve(rawIndex: number, count: number, loop: boolean, fullSize: number) {
-    let wrapped: number
-    if (loop) wrapped = ((rawIndex % count) + count) % count
-    else wrapped = Math.max(0, Math.min(count - 1, rawIndex))
-    const rawOffset = -rawIndex * fullSize
-    const wrappedOffset = -wrapped * fullSize
-    return { wrapped, seamless: loop && rawOffset !== wrappedOffset }
-  }
-
-  it('forward across the seam wraps last→first AND flags a seam crossing', () => {
-    // count=4: advancing from index 3 yields rawIndex 4 → wraps to 0, seam.
-    const r = resolve(4, 4, true, 100)
-    expect(r.wrapped).toBe(0)
-    expect(r.seamless).toBe(true)
-  })
-
-  it('backward across the seam wraps first→last AND flags a seam crossing', () => {
-    const r = resolve(-1, 4, true, 100)
-    expect(r.wrapped).toBe(3)
-    expect(r.seamless).toBe(true)
-  })
-
-  it('an in-range step wraps to itself with no seam crossing', () => {
-    const r = resolve(2, 4, true, 100)
-    expect(r.wrapped).toBe(2)
-    expect(r.seamless).toBe(false)
-  })
-
-  it('non-loop clamps and never flags a seam crossing', () => {
-    expect(resolve(4, 4, false, 100)).toEqual({ wrapped: 3, seamless: false })
-    expect(resolve(-1, 4, false, 100)).toEqual({ wrapped: 0, seamless: false })
-  })
-})
-
-// --- Programmatic jump: shortest seamless path ------------------------
-// Mirrors useDragGesture's `_jumpAndAnimate` loop branch: setIndex picks the
-// shorter of the forward/backward path around the ring so a jump from the last
-// item to the first slides one step across the seam, not all the way back.
-
-describe('Swiper — programmatic shortest loop path', () => {
-  function step(cur: number, targetIndex: number, count: number): number {
-    const curMod = ((cur % count) + count) % count
-    let forward = targetIndex - curMod
-    forward = ((forward % count) + count) % count
-    const backward = forward - count
-    return Math.abs(forward) <= Math.abs(backward) ? forward : backward
-  }
-
-  it('last → first goes forward one step (over the seam)', () => {
-    // count=4, at index 3, jump to 0 → +1 (not -3).
-    expect(step(3, 0, 4)).toBe(1)
-  })
-  it('first → last goes backward one step (over the seam)', () => {
-    expect(step(0, 3, 4)).toBe(-1)
-  })
-  it('prefers forward on a tie', () => {
-    // count=4, 0 → 2: forward 2, backward -2 → tie → forward.
-    expect(step(0, 2, 4)).toBe(2)
-  })
-  it('short in-range jump stays direct', () => {
-    expect(step(0, 1, 4)).toBe(1)
+  it('steps one item, stops at the last unless looping, and never fights a drag', async () => {
+    // `_advance` fires from an MT timer chain, so no runnable coverage exists
+    // for it in useDragGesture.test.ts.
+    const src = await readSource(CONTROLLER)
+    const fn = src.match(/function _advance\(\)[\s\S]*?\n {2}\}/)?.[0] ?? ''
+    expect(fn).toMatch(/if \(isDraggingRef\.current\) return/)
+    expect(fn).toMatch(/if \(count <= 1\) return/)
+    expect(fn).toMatch(/if \(next > count - 1 && !loopRef\.current\) return/)
+    expect(fn).toMatch(/_animateToIndex\(next\)/)
   })
 })

--- a/packages/core/src/components/Toggle/Toggle.test.ts
+++ b/packages/core/src/components/Toggle/Toggle.test.ts
@@ -7,24 +7,28 @@ import ToggleStory from './story/_Toggle.vue'
 
 describe('given default Toggle', () => {
   let container: Element
-  let toggle: Element
+  // Re-queried, never captured: the node identity changes across re-render, so
+  // a node held from `beforeEach` reads a stale attribute.
+  const toggle = () => container.querySelector('[data-state]')!
 
   beforeEach(() => {
     ;({ container } = render(ToggleStory))
-    toggle = container.querySelector('[data-state]')!
   })
 
   it('starts off', () => {
-    expect(toggle.getAttribute('data-state')).toBe('off')
+    expect(toggle().getAttribute('data-state')).toBe('off')
   })
 
   describe('after toggling', () => {
-    // The previously-skipped "should be toggled on" assertion is replaced by
-    // an emitted-event assertion. The data-state attribute is a side channel
-    // and is set on the same `view` element; the contract for "the toggle
-    // toggled" is the emitted `update:modelValue` value. Two-tick
-    // waitForUpdate did not observe the data-state attribute change reliably
-    // — but the emit fires synchronously inside the tap handler.
+    beforeEach(async () => {
+      fireEvent.tap(toggle())
+      await waitForUpdate()
+    })
+
+    it('is on', () => {
+      expect(toggle().getAttribute('data-state')).toBe('on')
+    })
+
     it('emits update:modelValue with true on tap', async () => {
       const updates: boolean[] = []
       const { container: c } = render({
@@ -42,12 +46,12 @@ describe('given default Toggle', () => {
 
     describe('after toggling again', () => {
       beforeEach(async () => {
-        fireEvent.tap(toggle)
+        fireEvent.tap(toggle())
         await waitForUpdate()
       })
 
       it('is off again', () => {
-        expect(toggle.getAttribute('data-state')).toBe('off')
+        expect(toggle().getAttribute('data-state')).toBe('off')
       })
     })
 
@@ -79,25 +83,24 @@ describe('given default Toggle', () => {
 
 describe('given disabled Toggle', () => {
   let container: Element
-  let toggle: Element
+  const toggle = () => container.querySelector('[data-state]')!
 
   beforeEach(() => {
     ;({ container } = render(ToggleStory, { disabled: true }))
-    toggle = container.querySelector('[data-state]')!
   })
 
   it('starts off', () => {
-    expect(toggle.getAttribute('data-state')).toBe('off')
+    expect(toggle().getAttribute('data-state')).toBe('off')
   })
 
   describe('try toggling', () => {
     beforeEach(async () => {
-      fireEvent.tap(toggle)
+      fireEvent.tap(toggle())
       await waitForUpdate()
     })
 
     it('stays off', () => {
-      expect(toggle.getAttribute('data-state')).toBe('off')
+      expect(toggle().getAttribute('data-state')).toBe('off')
     })
 
     it('does not emit update:modelValue when disabled', async () => {
@@ -116,8 +119,8 @@ describe('given disabled Toggle', () => {
     })
 
     it('renders disabled attributes', () => {
-      expect(toggle.getAttribute('data-disabled')).toBe('')
-      expect(toggle.getAttribute('disabled')).toBe('')
+      expect(toggle().getAttribute('data-disabled')).toBe('')
+      expect(toggle().getAttribute('disabled')).toBe('')
     })
   })
 })

--- a/packages/core/src/shared/composables/useGlobalEvent.test.ts
+++ b/packages/core/src/shared/composables/useGlobalEvent.test.ts
@@ -24,15 +24,21 @@ afterEach(() => {
 })
 
 describe('useGlobalEvent', () => {
-  it('no-ops without a lynx global', () => {
-    const lynx = (globalThis as any).lynx
-    delete (globalThis as any).lynx
-    try {
-      expect(() => render(host(() => useGlobalEvent('ping', vi.fn())))).not.toThrow()
-    }
-    finally {
-      ;(globalThis as any).lynx = lynx
-    }
+  // Deleting the global around `render()` does nothing: render() switches
+  // threads internally and the env reinstalls `lynx` before setup runs. It has
+  // to be deleted inside setup, where the composable actually reads it.
+  it('does not throw and registers nothing when the lynx global is absent', () => {
+    render(host(() => {
+      const lynx = (globalThis as any).lynx
+      delete (globalThis as any).lynx
+      try {
+        useGlobalEvent('ping', vi.fn())
+      }
+      finally {
+        ;(globalThis as any).lynx = lynx
+      }
+    }))
+    expect(emitter().listeners.ping).toBeUndefined()
   })
 
   it('subscribes on mount and unsubscribes on unmount', () => {

--- a/packages/kit/src/components/App.test.ts
+++ b/packages/kit/src/components/App.test.ts
@@ -1,6 +1,6 @@
 import { defineComponent, h, nextTick, onMounted } from 'vue'
 import { mount, type VueWrapper } from '@vue/test-utils'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { OverlayRoot, type SafeAreaInsets, useSafeArea } from '@vyui/core'
 import App from './App.vue'
 import { resetColorModeForTesting, useColorMode } from '../composables/useColorMode'
@@ -94,7 +94,10 @@ describe('VyApp', () => {
     expect(mount(App, { props: { overlays: false } }).findComponent(OverlayRoot).exists()).toBe(false)
   })
 
-  it('provides app-wide safe-area insets that `safeArea: false` zeroes out', () => {
+  // Both assertions need a NON-ZERO container reading to mean anything: with
+  // jsdom's empty global props the container read is already zero, so a
+  // `safeArea: false` assertion of zeros passes even if the opt-out is deleted.
+  describe('safe area', () => {
     const seen: SafeAreaInsets[] = []
     const Probe = defineComponent({
       setup() {
@@ -102,12 +105,29 @@ describe('VyApp', () => {
         return () => h('text', 'probe')
       },
     })
-    // `false` opts the whole app out with zeros (the container read is zero under jsdom too).
-    mount(App, {
-      props: { overlays: false, safeArea: false },
-      slots: { default: () => h(Probe) },
+    const mountWithProbe = (props: Record<string, unknown>) =>
+      mount(App, { props: { overlays: false, ...props }, slots: { default: () => h(Probe) } })
+
+    let originalGlobalProps: unknown
+    beforeEach(() => {
+      seen.length = 0
+      const lynx = ((globalThis as any).lynx ??= {})
+      originalGlobalProps = lynx.__globalProps
+      lynx.__globalProps = { os: 'ios', safeAreaTop: 47, safeAreaBottom: 34 }
     })
-    expect(seen.at(-1)).toEqual({ top: 0, bottom: 0 })
+    afterEach(() => {
+      ;(globalThis as any).lynx.__globalProps = originalGlobalProps
+    })
+
+    it('provides the container insets app-wide', () => {
+      mountWithProbe({})
+      expect(seen.at(-1)).toEqual({ top: 47, bottom: 34 })
+    })
+
+    it('zeroes the insets for the whole tree when `safeArea` is false', () => {
+      mountWithProbe({ safeArea: false })
+      expect(seen.at(-1)).toEqual({ top: 0, bottom: 0 })
+    })
   })
 
   describe('viewport-change', () => {


### PR DESCRIPTION
An audit of all 110 test files (1019 cases) found 18 tests that pass regardless of whether the behaviour they name works, plus 9 candidate findings the adversarial verify stage refuted. This fixes the 18. Test-only — no source changes, so no changeset.

**Tests that re-implemented the logic and asserted against their own copy** — the biggest cluster, and the one that read as substantial coverage while testing nothing:
- Swiper (379 → 99 lines), SwipeAction, Sortable, FeedList, List
- each deletion was checked against `physics.test.ts` / `useDragGesture.test.ts` first; Swiper autoplay turned out NOT to be covered anywhere, so it was converted rather than deleted
- replacements pin the real source (the repo's existing SFC-source idiom) so they fail on genuine drift

**Protection for #179**, which had none:
- `Textarea` and `Primitive` now assert on forwarded attr *keys* — a DOM assertion cannot distinguish "never bound" from "bound as null", so the old checks passed with the fix reverted
- both carry a positive control, so an empty capture cannot masquerade as a passing omission

**Tests that never performed the interaction they named:**
- `Toggle`: `after toggling` had no tap at all; added it plus an intermediate `is on` assertion (without it, `is off again` could never fail, since off is also the initial state), and switched to re-querying nodes so attribute reads are live
- `LazyComponent`: the "vitest provides no GlobalEventEmitter" note was false — the env has always had one — so the exposure flow is now covered end to end, plus real custom-margin forwarding

**Assertions that could not observe what they claimed:**
- `VyApp` safe area asserted zeros against a zero baseline; now stubs non-zero container insets so the provide and the opt-out are both observable
- `OverlayRoot` "renders nothing" now asserts nothing was painted, catching the wrapper-view regression its own source comment warns about
- `Select` indicator, `Slider` disabled markers, `AlertDialog` backdrop binding, CLI `pluginVueLynx` warning path

**Deleted (cannot fail):** Popover variant selection, an AlertDialog duplicate, an Icon self-comparison.

Known risk: Toggle's new `is on` assertion depends on an uncontrolled component's `data-state` flip being visible after re-query. `Tabs.test.ts` does the same thing against an uncontrolled story, but the Toggle file previously claimed the opposite, so CI is the check.