### PR TITLE
docs: scope the alpha status notice to what actually moves

### DIFF
--- a/.changeset/scope-alpha-status.md
+++ b/.changeset/scope-alpha-status.md
@@ -1,0 +1,6 @@
+---
+"@vyui/core": patch
+"@vyui/kit": patch
+---
+
+Scope the alpha status notice in both package READMEs. The blanket "expect breaking changes on every release" was doing the libraries a disservice — the component surface has held steady across `@vyui/core` `0.2.x` and `@vyui/kit` `0.3.x`, and the breaking changes to date removed unused exports rather than reshaping APIs. The notice now says that, and points at the pre-alpha Vue-Lynx runtime underneath as the part that can still move.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Vy UI** brings a Radix-style primitives layer to the Vue-Lynx ecosystem. Build native mobile apps for iOS, Android, and Web from a single Vue codebase, with components you own and can modify.
 
-> ⚠️ **Status: alpha.** Vue-Lynx itself is pre-alpha. APIs will change. Not production-ready.
+> ⚠️ **Status: alpha.** Component names, props, and slots have held steady across recent releases — the breaking changes so far removed unused exports rather than reshaping APIs. What can still shift is underneath: Vue-Lynx labels itself pre-alpha. Pin your versions and read the [changelog](https://vyui.dev/changelog) before upgrading.
 
 ***
 

--- a/apps/docs/app/app.vue
+++ b/apps/docs/app/app.vue
@@ -66,7 +66,7 @@ provide('navigation', navigation)
     <UBanner
       id="alpha-banner"
       icon="i-lucide-flask-conical"
-      title="Vy UI is alpha and Vue-Lynx is pre-alpha — breaking changes ahead."
+      title="Vy UI is alpha — component APIs are settling; Vue-Lynx underneath is pre-alpha."
       close
       :ui="{
         root: 'bg-(--color-vue-mint) border-b border-(--color-ink)/10',

--- a/apps/docs/content/1.getting-started/1.index.md
+++ b/apps/docs/content/1.getting-started/1.index.md
@@ -66,7 +66,9 @@ Vy UI is a two-layer component system for [Vue-Lynx](https://vue.lynxjs.org/) â€
 
 ## Status
 
-Vy UI is **alpha**. Vue-Lynx itself is pre-alpha. Expect breaking changes to component names, props, and slots. Things will break. Don't ship this to production yet.
+Vy UI is **alpha**. In practice that has meant a steady component surface with churn underneath it: component names, props, and slots have held across `@vyui/kit` `0.3.x` and `@vyui/core` `0.2.x`, and the breaking changes so far removed unused exports rather than reshaping APIs.
+
+The moving part is the layer below. Vue-Lynx labels itself pre-alpha, so build and runtime breakage can still reach you from upstream on a minor bump. Pin your versions, read the [changelog](/changelog) before upgrading, and treat shipping to production as a judgement about Vue-Lynx's maturity as much as Vy UI's.
 
 ## What's inside
 

--- a/apps/docs/content/8.guides/11.why-vy-ui.md
+++ b/apps/docs/content/8.guides/11.why-vy-ui.md
@@ -52,7 +52,7 @@ The benefit of that model is that a component you need to change becomes a file 
 
 ## What you are accepting
 
-Vy UI is alpha and Vue Lynx labels itself pre-alpha, so component names, props, and slots will move under you. That is the real cost, and it is larger than the dependency risk people usually weigh.
+Vy UI is alpha and Vue Lynx labels itself pre-alpha. Vy UI's own component names, props, and slots have held steady so far, but the runtime under them has not settled, and upstream churn reaches you through the build. That is the real cost, and it is larger than the dependency risk people usually weigh.
 
 Accessibility on web is incomplete in a way it is not on native, because Lynx emits `accessibility-*` properties that VoiceOver and TalkBack consume directly while browsers ignore them entirely. Internationalization is early, since `Intl` is not fully present in the Lynx runtime. Both are [documented gaps](/accessibility) rather than things you will discover after committing.
 

--- a/apps/docs/content/8.guides/2.lynx-ui-frameworks.md
+++ b/apps/docs/content/8.guides/2.lynx-ui-frameworks.md
@@ -41,7 +41,7 @@ Headless means the visual layer stays yours, and no ReactLynx equivalent to shad
 
 `@vyui/kit` is the styled layer, 48 components on those primitives themed through Tailwind Variants. A [three-tier semantic token system](/theming) flips the whole set into dark mode through a single class instead of per-component `dark:` variants, and a [shadcn-style CLI](/getting-started/cli) copies component source into your repository when you would rather own the code.
 
-Vy UI is alpha and Vue Lynx labels itself pre-alpha, so pick it once you have settled on Vue and accepted that APIs will move. It is MIT licensed and community-maintained rather than official.
+Vy UI is alpha, though its component surface has held steady across recent releases; Vue Lynx labels itself pre-alpha, and that is where the movement actually comes from. Pick it once you have settled on Vue. It is MIT licensed and community-maintained rather than official.
 
 ### Skipping the libraries entirely
 

--- a/apps/docs/content/8.guides/3.vue-lynx.md
+++ b/apps/docs/content/8.guides/3.vue-lynx.md
@@ -67,7 +67,7 @@ ReactLynx came first and remains the reference frontend, so the documentation, e
 Vue Lynx's constraint is ecosystem age. Its API surface still moves, and ReactLynx libraries cannot be consumed from Vue because they are React components. I would take ReactLynx for the most-supported path today, and Vue Lynx when your team writes Vue and a rewrite is not on the table.
 
 ::callout{icon="i-lucide-flask-conical" color="warning"}
-Vue Lynx ships under a pre-alpha label and Vy UI is alpha, so both will introduce breaking changes, and neither is where I would point a production launch today.
+Vue Lynx ships under a pre-alpha label and Vy UI is alpha. Vy UI's component surface has been the steadier of the two; the pre-alpha runtime underneath is the reason I would not point a production launch here today.
 ::
 
 ## Where components come from

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,8 +4,10 @@ Headless, accessible UI primitives for [Vue-Lynx](https://vue.lynxjs.org) — th
 Radix-style behavior layer of [Vy UI](https://vyui.dev). Ship native apps for
 iOS, Android, and web from one Vue codebase.
 
-> ⚠️ **Alpha.** Vue-Lynx itself is pre-alpha. Expect breaking changes on every
-> release until 1.0.0.
+> ⚠️ **Alpha.** Primitive names, props, and slots have held steady across
+> `0.2.x` — the breaking changes were removals of unused exports, plus one move
+> of overlay backgrounds out to the styling layer. What can still shift is
+> underneath: Vue-Lynx labels itself pre-alpha. Pin your versions.
 
 ## What's in it
 

--- a/packages/kit/README.md
+++ b/packages/kit/README.md
@@ -5,7 +5,9 @@ headless [`@vyui/core`](https://www.npmjs.com/package/@vyui/core) primitives —
 the ready-to-use layer of [Vy UI](https://vyui.dev). Ship native apps for iOS,
 Android, and web from one Vue codebase.
 
-> ⚠️ **Alpha.** Expect breaking changes on every release until 1.0.0.
+> ⚠️ **Alpha.** Component names, props, and slots have held steady across
+> `0.3.x`. What can still shift is underneath: Vue-Lynx labels itself
+> pre-alpha. Pin your versions.
 
 `@vyui/kit` depends on `@vyui/core` but does **not** re-export the full core
 surface: import styled `Vy*` components from kit, and raw primitives from core.


### PR DESCRIPTION
The blanket "alpha, expect breaking changes on every release, not production-ready" notice told readers nothing they could act on, and it reads to both humans and LLM assistants as "do not use". Scoped it to what has actually been unstable.

- Root, `@vyui/core` and `@vyui/kit` READMEs: state that component names, props and slots have held across `core` `0.2.x` / `kit` `0.3.x`, and that the breaking changes so far removed unused exports.
- Point at the pre-alpha Vue-Lynx runtime underneath as the part that can still move, using upstream's own label.
- Docs site alpha banner, getting-started Status section, and the three guides that repeated the blanket claim.
- Patch changeset — both package READMEs ship to npm.

Claims are checked against the changelogs: the only non-removal break in the window was overlay backgrounds moving out to the styling layer (#167 era), which the core README now names. No status is upgraded — still alpha, still pinned to a pre-alpha runtime.