### PR TITLE
chore(fixtures): drop dead vue-shim reference from fixture-consumer

### DIFF
--- a/fixtures/fixture-consumer/src/lynx-env.d.ts
+++ b/fixtures/fixture-consumer/src/lynx-env.d.ts
@@ -1,4 +1,3 @@
-/// <reference path="../../_shared/vue-shim.d.ts" />
 // Augments Vue's `GlobalComponents` with the Lynx intrinsic elements (`view`,
 // `text`, …) so this fixture's SFC template type-checks against Lynx props.
 // Paired with the Volar plugin in `tsconfig.json` (`vue-lynx/types/volar-plugin`).


### PR DESCRIPTION
Removes a `/// <reference path>` in the type-lock fixture that has never resolved to a real file.

- `fixtures/fixture-consumer/src/lynx-env.d.ts` referenced `../../_shared/vue-shim.d.ts` → `fixtures/_shared/`, which does not exist.
- The shim lives at `apps/examples/_shared/`; the relative path came along unchanged when the fixture moved out of the demos.
- It only declares `*.vue` for `import App from './App.vue'` — this fixture has no such import, so nothing replaces it.
- No changeset: `@vyui/fixture-consumer` is private.