### PR TITLE
fix(docs): 301 /packages to /packages/core

### DIFF
--- a/apps/docs/public/_redirects
+++ b/apps/docs/public/_redirects
@@ -1,0 +1,1 @@
+/packages /packages/core 301


### PR DESCRIPTION
Search Console reported `https://vyui.dev/packages` as a 404. `content/2.packages/` has no `index.md`, so the section path has never resolved — Googlebot picked the URL up from the string in the nav chunk (`app/composables/useNavigation.ts:108`) rather than from a rendered link.

- Adds `apps/docs/public/_redirects` with a single 301 to `/packages/core`
- Same hand-written Cloudflare Pages convention as the existing `public/_headers`
- Docs-only, no published package source touched, so no changeset

The other Search Console entries are noise: `http://vyui.dev/` is the http→https redirect working, `/_nuxt/` is a guessed directory path (not worth a robots `Disallow` — blocking JS costs more than a phantom 404), and `/changelog.xml` is an RSS feed, which is never indexed.