### PR TITLE
fix(toggle): surface kit ToggleProps and regen collision-prone API tables

### DIFF
--- a/.changeset/toggle-props-extends-core.md
+++ b/.changeset/toggle-props-extends-core.md
@@ -1,0 +1,5 @@
+---
+"@vyui/kit": patch
+---
+
+`VyToggle`'s `ToggleProps` now extends the core primitive's props, so `as`, `asChild`, and `defaultValue` get real TypeScript/IDE support. They already worked at runtime via `$attrs` fall-through; this only closes the typing gap.

--- a/apps/docs/app/generated/api/App.json
+++ b/apps/docs/app/generated/api/App.json
@@ -14,6 +14,12 @@
       "description": "Corner radius in rem — sets `--ui-radius` on the root. Omit to keep the\n`@vyui/kit/style.css` default."
     },
     {
+      "name": "safeArea",
+      "type": "boolean | undefined",
+      "required": false,
+      "description": "Provide app-wide safe-area insets to the whole tree (`useSafeArea()`).\n`false` opts the app out with zeros (e.g. a fullscreen surface drawing its\nown chrome). Omit to use the container's reported insets as-is. A subtree\ncan still override with its own `provideSafeAreaInsets`."
+    },
+    {
       "name": "ui",
       "type": "Partial<Record<\"root\", any>> | undefined",
       "required": false

--- a/apps/docs/app/generated/api/Button.json
+++ b/apps/docs/app/generated/api/Button.json
@@ -1,36 +1,122 @@
 {
   "props": [
     {
-      "name": "as",
-      "type": "AsTag | undefined",
-      "required": false,
-      "default": "\"view\"",
-      "description": "Underlying element. Defaults to `view`."
-    },
-    {
-      "name": "asChild",
+      "name": "autofocus",
       "type": "boolean | undefined",
       "required": false,
-      "description": "Merge props onto the slot child instead of wrapping."
+      "description": "Focus the button on mount. Kept for API parity with Nuxt UI v4 — the\nVue-Lynx core button renders a non-focusable `<view>`, so this is\ncurrently a no-op."
+    },
+    {
+      "name": "avatar",
+      "type": "AvatarProps | undefined",
+      "required": false,
+      "description": "When set, render `<VyAvatar>` in the leading slot instead of an icon."
+    },
+    {
+      "name": "block",
+      "type": "boolean | undefined",
+      "required": false
+    },
+    {
+      "name": "color",
+      "type": "keyof VyuiColorRegistry | undefined",
+      "required": false
     },
     {
       "name": "disabled",
       "type": "boolean | undefined",
-      "required": false,
-      "default": "false",
-      "description": "Disables tap + active feedback."
-    }
-  ],
-  "events": [
+      "required": false
+    },
     {
-      "name": "tap",
-      "type": "[]"
+      "name": "icon",
+      "type": "string | undefined",
+      "required": false,
+      "description": "Iconify shorthand. Routed to the trailing side when `trailing` is true,\notherwise to the leading side. Explicit `leadingIcon` / `trailingIcon`\nalways win."
+    },
+    {
+      "name": "label",
+      "type": "string | undefined",
+      "required": false,
+      "description": "Text label. Overridden by the default slot if provided."
+    },
+    {
+      "name": "leading",
+      "type": "boolean | undefined",
+      "required": false,
+      "description": "Force `icon` shorthand onto the leading side."
+    },
+    {
+      "name": "leadingIcon",
+      "type": "string | undefined",
+      "required": false,
+      "description": "Iconify name shown on the leading side (wins over `icon`)."
+    },
+    {
+      "name": "loading",
+      "type": "boolean | undefined",
+      "required": false
+    },
+    {
+      "name": "loadingIcon",
+      "type": "string | undefined",
+      "required": false,
+      "description": "Iconify name for the spinner. Defaults to `appConfig.ui.icons.loading`."
+    },
+    {
+      "name": "size",
+      "type": "\"xs\" | \"sm\" | \"md\" | \"lg\" | \"xl\" | undefined",
+      "required": false
+    },
+    {
+      "name": "square",
+      "type": "boolean | undefined",
+      "required": false
+    },
+    {
+      "name": "trailing",
+      "type": "boolean | undefined",
+      "required": false,
+      "description": "Force `icon` shorthand onto the trailing side."
+    },
+    {
+      "name": "trailingIcon",
+      "type": "string | undefined",
+      "required": false,
+      "description": "Iconify name shown on the trailing side (wins over `icon`)."
+    },
+    {
+      "name": "type",
+      "type": "\"button\" | \"submit\" | \"reset\" | undefined",
+      "required": false,
+      "default": "\"button\"",
+      "description": "HTML button type. Kept for API parity with Nuxt UI v4 — the Vue-Lynx\ncore button renders a `<view>`, so this is currently a no-op forward."
+    },
+    {
+      "name": "ui",
+      "type": "Partial<Record<\"leadingIcon\" | \"trailingIcon\" | \"label\" | \"base\" | \"leadingAvatar\" | \"leadingAvatarSize\", any>> | undefined",
+      "required": false
+    },
+    {
+      "name": "variant",
+      "type": "\"solid\" | \"outline\" | \"soft\" | \"subtle\" | \"ghost\" | \"link\" | undefined",
+      "required": false
     }
   ],
+  "events": [],
   "slots": [
     {
       "name": "default",
-      "type": "{ active: boolean; disabled: boolean; }"
+      "type": "{} | undefined"
+    },
+    {
+      "name": "leading",
+      "type": "{ iconColor: string; }",
+      "description": "Receives `iconColor` so custom icons can match the variant's resolved foreground."
+    },
+    {
+      "name": "trailing",
+      "type": "{ iconColor: string; }",
+      "description": "Receives `iconColor` so custom icons can match the variant's resolved foreground."
     }
   ]
 }

--- a/apps/docs/app/generated/api/FeedList.json
+++ b/apps/docs/app/generated/api/FeedList.json
@@ -3,64 +3,43 @@
     {
       "name": "bounces",
       "type": "boolean | undefined",
-      "required": false,
-      "default": "true",
-      "description": "Native list bounce at the edges (ignored on the PTR list, which forces it\noff so the top-edge pull isn't stolen)."
-    },
-    {
-      "name": "defaultLoadingMore",
-      "type": "boolean | undefined",
-      "required": false,
-      "default": "false",
-      "description": "Initial loading-more state when uncontrolled."
-    },
-    {
-      "name": "defaultRefreshing",
-      "type": "boolean | undefined",
-      "required": false,
-      "default": "false",
-      "description": "Initial refreshing state when uncontrolled."
+      "required": false
     },
     {
       "name": "disabled",
       "type": "boolean | undefined",
       "required": false,
-      "default": "false",
-      "description": "Disable scrolling and refresh interactions."
+      "description": "Disable scrolling."
     },
     {
       "name": "enableBounce",
       "type": "boolean | undefined",
       "required": false,
-      "default": "false",
-      "description": "Rubber-band overscroll bounce at both edges that springs back on release.\nIndependent of `enableRefresh`: enable it alone for a bounce-only list, or\nalongside refresh to add a bottom-edge bounce (the top edge already bounces\nwhile pulling to refresh)."
+      "description": "Rubber-band overscroll bounce at both edges."
     },
     {
       "name": "enableLoadMore",
       "type": "boolean | undefined",
       "required": false,
-      "default": "false",
       "description": "Enable load-more on scroll-to-lower."
     },
     {
       "name": "enableRefresh",
       "type": "boolean | undefined",
       "required": false,
-      "default": "false",
-      "description": "Enable the rubber-band pull-to-refresh. Off → a bare `<list>`, no touch\nhandlers."
+      "description": "Enable the custom rubber-band pull-to-refresh (touch worklets)."
     },
     {
       "name": "itemKey",
       "type": "((item: T, index: number) => string) | undefined",
       "required": false,
-      "description": "Alternative to `itemKeyField`: a function returning the key. Wins if both set."
+      "description": "Alternative to `itemKeyField`: a function returning the key."
     },
     {
       "name": "itemKeyField",
       "type": "(keyof T & string) | undefined",
       "required": false,
-      "default": "\"id\" as never",
-      "description": "Field on `T` used as the unique key per row. Required by Lynx's `<list>`\nfor diffing — unstable keys recycle rows wrong. The native diff appends /\nremoves by key but does NOT reorder, so when the data order changes (e.g. a\nrefresh) replace the keys rather than permuting existing ones."
+      "description": "Field on `T` to use as the unique key per row. Defaults to `'id'`."
     },
     {
       "name": "items",
@@ -72,34 +51,25 @@
       "name": "itemSnap",
       "type": "boolean | { factor: number; offset: number; } | undefined",
       "required": false,
-      "description": "Native `<list>` `item-snap` paging. `true` snaps each item to the top\n(`{ factor: 0, offset: 0 }`, full-screen paging); pass an object for a\ncustom factor/offset. `listType: 'single'` only."
+      "description": "Snap each item to a rest position after scrolling (native `item-snap`).\n`true` = full-screen paging (snap each item to the top); pass an object for\na custom `{ factor, offset }`. `listType: 'single'` only."
     },
     {
       "name": "listType",
       "type": "\"single\" | \"flow\" | \"waterfall\" | undefined",
       "required": false,
-      "default": "\"single\"",
-      "description": "Layout type. `'flow'` / `'waterfall'` require `spanCount > 1`."
-    },
-    {
-      "name": "loadingMore",
-      "type": "boolean | undefined",
-      "required": false,
-      "description": "Controlled loading-more state. Bind with `v-model:loadingMore`."
+      "description": "Layout type. `'flow'` and `'waterfall'` require `spanCount > 1`."
     },
     {
       "name": "loadMoreThresholdItemCount",
       "type": "number | undefined",
       "required": false,
-      "default": "2",
-      "description": "Items from the bottom that triggers `load-more`."
+      "description": "Number of items from the bottom that triggers `load-more`."
     },
     {
       "name": "noMoreData",
       "type": "boolean | undefined",
       "required": false,
-      "default": "false",
-      "description": "No more data to load. Shows the `noMoreDataFooter` slot (end-of-list). Until\nthis is `true` — and while not `loadingMore` — no footer renders, so a list\nwith more pages to fetch never displays an \"end of list\" message."
+      "description": "No more data to load — stops `loadMore` and shows the end-of-list footer."
     },
     {
       "name": "refreshing",
@@ -111,43 +81,39 @@
       "name": "refreshThreshold",
       "type": "number | undefined",
       "required": false,
-      "default": "64",
-      "description": "Pull distance (px) past which release triggers a refresh."
+      "description": "Pull distance (px) past which release triggers a refresh. Default 64."
     },
     {
       "name": "scrollBarEnable",
       "type": "boolean | undefined",
-      "required": false,
-      "default": "true"
+      "required": false
     },
     {
       "name": "scrollOrientation",
       "type": "\"vertical\" | \"horizontal\" | undefined",
-      "required": false,
-      "default": "\"vertical\""
+      "required": false
     },
     {
       "name": "spanCount",
       "type": "number | undefined",
       "required": false,
-      "default": "1",
       "description": "Columns / rows for `flow` / `waterfall`."
+    },
+    {
+      "name": "ui",
+      "type": "Partial<Record<string | number | symbol, any>> | undefined",
+      "required": false
     },
     {
       "name": "upperThresholdItemCount",
       "type": "number | undefined",
       "required": false,
-      "default": "0",
-      "description": "Items from the top that triggers `scrollToUpper`."
+      "description": "Number of items from the top that triggers `scrollToUpper`."
     }
   ],
   "events": [
     {
       "name": "update:refreshing",
-      "type": "[value: boolean]"
-    },
-    {
-      "name": "update:loadingMore",
       "type": "[value: boolean]"
     },
     {
@@ -192,22 +158,22 @@
     {
       "name": "refreshHeader",
       "type": "{ state: FeedListRefreshState; progress: number; }",
-      "description": "Pull-to-refresh header. `state` is the current refresh state; `progress` is\nthe pull distance as a fraction of `refreshThreshold` (0..1, clamped)."
-    },
-    {
-      "name": "loadMoreFooter",
-      "type": "any",
-      "description": "Shown at the bottom while `loadingMore` is true."
-    },
-    {
-      "name": "noMoreDataFooter",
-      "type": "any",
-      "description": "Shown at the bottom when there is no more data to load."
+      "description": "Pull-to-refresh header. `state` is the lifecycle phase; `progress` is the\npull distance as a fraction of the threshold (0..1)."
     },
     {
       "name": "empty",
-      "type": "any",
+      "type": "{} | undefined",
       "description": "Rendered in place of the list when `items` is empty."
+    },
+    {
+      "name": "loadMoreFooter",
+      "type": "{ loading: boolean; }",
+      "description": "Footer shown at the bottom while more data can be loaded."
+    },
+    {
+      "name": "noMoreDataFooter",
+      "type": "{} | undefined",
+      "description": "Footer shown at the bottom once `noMoreData` is true."
     }
   ]
 }

--- a/apps/docs/app/generated/api/FormField.json
+++ b/apps/docs/app/generated/api/FormField.json
@@ -4,19 +4,66 @@
       "name": "defaultValue",
       "type": "unknown",
       "required": false,
-      "description": "Initial value when the form's `defaultValues` doesn't supply one.\nForm-level `defaultValues` takes precedence."
+      "description": "Initial value when the form's `defaultValues` doesn't supply one."
+    },
+    {
+      "name": "description",
+      "type": "string | undefined",
+      "required": false,
+      "description": "Description rendered between the label and the control. Overridden by the `description` slot."
+    },
+    {
+      "name": "error",
+      "type": "string | undefined",
+      "required": false,
+      "description": "Manual error override. When provided, takes precedence over the\nvalidator-derived error from the surrounding `<VyForm>`."
+    },
+    {
+      "name": "help",
+      "type": "string | undefined",
+      "required": false,
+      "description": "Helper text rendered below the control. Hidden when an error is showing."
+    },
+    {
+      "name": "hint",
+      "type": "string | undefined",
+      "required": false,
+      "description": "Small auxiliary text rendered next to the label (right-aligned). Overridden by the `hint` slot."
+    },
+    {
+      "name": "label",
+      "type": "string | undefined",
+      "required": false,
+      "description": "Label text rendered above the control. Overridden by the `label` slot."
     },
     {
       "name": "name",
       "type": "string",
       "required": true,
-      "description": "Field name — must be unique within the form."
+      "description": "Field name — must be unique within the parent `<VyForm>`."
+    },
+    {
+      "name": "required",
+      "type": "boolean | undefined",
+      "required": false,
+      "default": "false",
+      "description": "Marks the field as required — appends a red asterisk to the label."
+    },
+    {
+      "name": "size",
+      "type": "\"sm\" | \"md\" | \"lg\" | \"xl\" | undefined",
+      "required": false
+    },
+    {
+      "name": "ui",
+      "type": "Partial<Record<\"root\" | \"label\" | \"error\" | \"description\" | \"hint\" | \"help\" | \"wrapper\" | \"labelWrapper\" | \"container\", any>> | undefined",
+      "required": false
     },
     {
       "name": "validators",
       "type": "FormFieldValidator[] | undefined",
       "required": false,
-      "description": "Synchronous validators. Each returns `null` (or `undefined`) for valid,\nor a non-empty string describing the error. Stops at the first error."
+      "description": "Synchronous validators (see `@vyui/core`). Stops at the first error."
     }
   ],
   "events": [],
@@ -24,6 +71,26 @@
     {
       "name": "default",
       "type": "{ value: unknown; error: string | null; setValue: (value: unknown) => void; disabled: boolean; }"
+    },
+    {
+      "name": "label",
+      "type": "{} | undefined"
+    },
+    {
+      "name": "description",
+      "type": "{} | undefined"
+    },
+    {
+      "name": "hint",
+      "type": "{} | undefined"
+    },
+    {
+      "name": "help",
+      "type": "{} | undefined"
+    },
+    {
+      "name": "error",
+      "type": "{ error: string; }"
     }
   ]
 }

--- a/apps/docs/app/generated/api/Input.json
+++ b/apps/docs/app/generated/api/Input.json
@@ -1,73 +1,122 @@
 {
   "props": [
     {
-      "name": "as",
-      "type": "AsTag | Component | undefined",
-      "required": false,
-      "default": "\"input\"",
-      "description": "The element or component this component should render as. Can be overwritten by `asChild`."
-    },
-    {
-      "name": "asChild",
-      "type": "boolean | undefined",
-      "required": false,
-      "description": "Change the default rendered element for the one passed as a child, merging their props and behavior.\n\nUse this when you need a component to render through a child element while keeping the primitive's props and behavior."
-    },
-    {
       "name": "autocapitalize",
       "type": "string | undefined",
       "required": false,
-      "description": "Browser/native capitalization hint forwarded to the underlying input."
+      "description": "Forwarded to the underlying `<input>`. Defaults to `'none'` for email and password inputs."
+    },
+    {
+      "name": "autocomplete",
+      "type": "string | undefined",
+      "required": false,
+      "default": "\"off\"",
+      "description": "Forwarded to the underlying `<input>`. Defaults to `'off'`."
     },
     {
       "name": "autocorrect",
       "type": "string | undefined",
       "required": false,
-      "description": "Browser/native correction hint forwarded to the underlying input."
+      "description": "Forwarded to the underlying `<input>`. Defaults to `'off'` for email and password inputs."
+    },
+    {
+      "name": "autofocus",
+      "type": "boolean | undefined",
+      "required": false,
+      "description": "Focus the input on mount (after `autofocusDelay` ms)."
+    },
+    {
+      "name": "autofocusDelay",
+      "type": "number | undefined",
+      "required": false,
+      "default": "0",
+      "description": "Delay before applying `autofocus`, in milliseconds."
+    },
+    {
+      "name": "avatar",
+      "type": "AvatarProps | undefined",
+      "required": false,
+      "description": "When set, render `<VyAvatar>` in the leading slot instead of an icon."
+    },
+    {
+      "name": "avoidKeyboard",
+      "type": "boolean | undefined",
+      "required": false,
+      "description": "Native keyboard avoidance (Lynx `avoid-keyboard`): the platform shifts\nthe whole LynxView up so the focused input clears the keyboard — exact\nnative window-coordinate math, no JS. Zero-setup alternative to the\n`VyKeyboardAware*` family for simple forms; do NOT combine with a\n`VyKeyboardAwareRoot`, the two lifts stack. Pair with\n`avoidKeyboardSpacing` to also clear the field's bottom chrome."
+    },
+    {
+      "name": "avoidKeyboardSpacing",
+      "type": "number | undefined",
+      "required": false,
+      "description": "Extra clearance in px above the keyboard when `avoidKeyboard` is set."
+    },
+    {
+      "name": "color",
+      "type": "keyof VyuiColorRegistry | undefined",
+      "required": false
     },
     {
       "name": "confirmType",
       "type": "InputConfirmType | undefined",
       "required": false,
-      "default": "\"send\"",
-      "description": "On-screen return-key label — see `InputConfirmType`."
-    },
-    {
-      "name": "defaultValue",
-      "type": "string | undefined",
-      "required": false,
-      "description": "Initial value when uncontrolled."
+      "description": "On-screen return-key label and behavior. Maps to iOS `returnKeyType` /\nAndroid `imeOptions`. Defaults to `'done'` from the core primitive.\nPair with `@confirm` to handle the tap."
     },
     {
       "name": "disabled",
       "type": "boolean | undefined",
+      "required": false
+    },
+    {
+      "name": "highlight",
+      "type": "boolean | undefined",
       "required": false,
-      "default": "false",
-      "description": "When `true`, prevents the user from interacting with the input."
+      "description": "Forces the colored ring on permanently; by default it paints while focused."
+    },
+    {
+      "name": "icon",
+      "type": "string | undefined",
+      "required": false,
+      "description": "Iconify shorthand. Routed to the trailing side when `trailing` is true,\notherwise to the leading side. Explicit `leadingIcon` / `trailingIcon`\nalways win."
     },
     {
       "name": "id",
       "type": "string | undefined",
+      "required": false,
+      "description": "Forwarded to the underlying `<input>`."
+    },
+    {
+      "name": "leading",
+      "type": "boolean | undefined",
+      "required": false,
+      "description": "Force `icon` shorthand onto the leading side."
+    },
+    {
+      "name": "leadingIcon",
+      "type": "string | undefined",
+      "required": false,
+      "description": "Iconify name shown on the leading side (wins over `icon`)."
+    },
+    {
+      "name": "loading",
+      "type": "boolean | undefined",
       "required": false
     },
     {
-      "name": "inputFilter",
+      "name": "loadingIcon",
       "type": "string | undefined",
       "required": false,
-      "description": "Regex string filter applied by the native input before the value is\nsurfaced to JS. Passed through unchanged."
-    },
-    {
-      "name": "maxLength",
-      "type": "number | undefined",
-      "required": false,
-      "default": "140",
-      "description": "Maximum number of characters allowed. Defaults to `140` per the Lynx\ndefault — set explicitly to `0` for no limit on platforms that support it."
+      "description": "Iconify name for the spinner. Defaults to `appConfig.ui.icons.loading`."
     },
     {
       "name": "modelValue",
+      "type": "string | number | undefined",
+      "required": false
+    },
+    {
+      "name": "name",
       "type": "string | undefined",
       "required": false,
-      "description": "Controlled value — pair with `@update:modelValue` (or `v-model`)."
+      "description": "Forwarded to the underlying `<input>`."
     },
     {
       "name": "placeholder",
@@ -75,61 +124,82 @@
       "required": false
     },
     {
-      "name": "readonly",
+      "name": "required",
       "type": "boolean | undefined",
       "required": false,
-      "default": "false",
-      "description": "Whether the input renders as read-only."
+      "description": "Forwarded to the underlying `<input>`."
     },
     {
-      "name": "showSoftInputOnFocus",
+      "name": "size",
+      "type": "\"sm\" | \"md\" | \"lg\" | \"xl\" | undefined",
+      "required": false
+    },
+    {
+      "name": "trailing",
       "type": "boolean | undefined",
       "required": false,
-      "default": "true",
-      "description": "When `false`, focus will not raise the software keyboard."
+      "description": "Force `icon` shorthand onto the trailing side."
+    },
+    {
+      "name": "trailingIcon",
+      "type": "string | undefined",
+      "required": false,
+      "description": "Iconify name shown on the trailing side (wins over `icon`)."
     },
     {
       "name": "type",
       "type": "InputType | undefined",
       "required": false,
       "default": "\"text\"",
-      "description": "Input mode hint — see `InputType`."
+      "description": "Input mode — drives the on-screen software keyboard on native and the\n`type` attribute on web. `'digit'` shows a pure 0-9 pad (no decimal /\nsign), `'number'` shows the numeric keyboard with decimal, `'tel'` /\n`'email'` give the matching layouts, `'password'` masks input."
+    },
+    {
+      "name": "ui",
+      "type": "Partial<Record<\"root\" | \"leadingIcon\" | \"trailingIcon\" | \"leading\" | \"trailing\" | \"base\" | \"leadingAvatar\", any>> | undefined",
+      "required": false
+    },
+    {
+      "name": "variant",
+      "type": "\"outline\" | \"soft\" | \"subtle\" | \"ghost\" | \"none\" | undefined",
+      "required": false
     }
   ],
   "events": [
     {
-      "name": "input",
-      "type": "[value: string, selectionStart: number, selectionEnd: number, isComposing: boolean]"
-    },
-    {
       "name": "update:modelValue",
-      "type": "[value: string]"
-    },
-    {
-      "name": "focus",
-      "type": "[value: string]"
-    },
-    {
-      "name": "blur",
-      "type": "[value: string]"
+      "type": "any[]"
     },
     {
       "name": "confirm",
-      "type": "[value: string]"
+      "type": "any[]"
     },
     {
-      "name": "selectionChange",
-      "type": "[selectionStart: number, selectionEnd: number]"
+      "name": "focus",
+      "type": "any[]"
+    },
+    {
+      "name": "blur",
+      "type": "any[]"
     },
     {
       "name": "keyboard",
-      "type": "[info: { visible: boolean; height: number; safeAreaBottom: number; }]"
+      "type": "any[]"
     }
   ],
   "slots": [
     {
+      "name": "leading",
+      "type": "{ iconColor: string; }",
+      "description": "Receives `iconColor` so custom icons can match the input's resolved theme color."
+    },
+    {
+      "name": "trailing",
+      "type": "{ iconColor: string; }",
+      "description": "Receives `iconColor` so custom icons can match the input's resolved theme color."
+    },
+    {
       "name": "default",
-      "type": "{}"
+      "type": "{} | undefined"
     }
   ]
 }

--- a/apps/docs/app/generated/api/Label.json
+++ b/apps/docs/app/generated/api/Label.json
@@ -1,30 +1,32 @@
 {
   "props": [
     {
-      "name": "as",
-      "type": "AsTag | Component | undefined",
-      "required": false,
-      "default": "\"text\"",
-      "description": "The element or component this component should render as. Can be overwritten by `asChild`."
-    },
-    {
-      "name": "asChild",
-      "type": "boolean | undefined",
-      "required": false,
-      "description": "Change the default rendered element for the one passed as a child, merging their props and behavior.\n\nUse this when you need a component to render through a child element while keeping the primitive's props and behavior."
-    },
-    {
       "name": "for",
       "type": "string | undefined",
       "required": false,
-      "description": "The id of the element the label is associated with."
+      "description": "The id of the form control this label is associated with."
+    },
+    {
+      "name": "required",
+      "type": "boolean | undefined",
+      "required": false
+    },
+    {
+      "name": "size",
+      "type": "\"sm\" | \"md\" | \"lg\" | \"xl\" | undefined",
+      "required": false
+    },
+    {
+      "name": "ui",
+      "type": "Partial<Record<\"base\", any>> | undefined",
+      "required": false
     }
   ],
   "events": [],
   "slots": [
     {
       "name": "default",
-      "type": "{}"
+      "type": "{} | undefined"
     }
   ]
 }

--- a/apps/docs/app/generated/api/Separator.json
+++ b/apps/docs/app/generated/api/Separator.json
@@ -1,36 +1,55 @@
 {
   "props": [
     {
-      "name": "as",
-      "type": "AsTag | Component | undefined",
-      "required": false,
-      "description": "The element or component this component should render as. Can be overwritten by `asChild`."
-    },
-    {
-      "name": "asChild",
-      "type": "boolean | undefined",
-      "required": false,
-      "description": "Change the default rendered element for the one passed as a child, merging their props and behavior.\n\nUse this when you need a component to render through a child element while keeping the primitive's props and behavior."
+      "name": "color",
+      "type": "keyof VyuiColorRegistry | undefined",
+      "required": false
     },
     {
       "name": "decorative",
       "type": "boolean | undefined",
       "required": false,
-      "description": "Whether or not the component is purely decorative. <br>When `true`, accessibility-related attributes\nare updated so that that the rendered element is removed from the accessibility tree."
+      "description": "Forwarded to the underlying Separator primitive — strips a11y attrs."
+    },
+    {
+      "name": "icon",
+      "type": "string | undefined",
+      "required": false,
+      "description": "Iconify name shown in the middle."
+    },
+    {
+      "name": "label",
+      "type": "string | undefined",
+      "required": false,
+      "description": "Display a label in the middle."
     },
     {
       "name": "orientation",
-      "type": "DataOrientation | undefined",
+      "type": "\"vertical\" | \"horizontal\" | undefined",
       "required": false,
-      "default": "\"horizontal\"",
-      "description": "Orientation of the component.\n\nEither `vertical` or `horizontal`. Defaults to `horizontal`."
+      "default": "\"horizontal\""
+    },
+    {
+      "name": "size",
+      "type": "\"sm\" | \"md\" | \"lg\" | \"xl\" | undefined",
+      "required": false
+    },
+    {
+      "name": "type",
+      "type": "\"solid\" | \"dashed\" | \"dotted\" | undefined",
+      "required": false
+    },
+    {
+      "name": "ui",
+      "type": "Partial<Record<\"root\" | \"icon\" | \"label\" | \"container\" | \"border\", any>> | undefined",
+      "required": false
     }
   ],
   "events": [],
   "slots": [
     {
       "name": "default",
-      "type": "{}"
+      "type": "{} | undefined"
     }
   ]
 }

--- a/apps/docs/app/generated/api/SwipeAction.json
+++ b/apps/docs/app/generated/api/SwipeAction.json
@@ -4,21 +4,7 @@
       "name": "actionWidth",
       "type": "number",
       "required": true,
-      "description": "Width of the revealed trailing action panel in px."
-    },
-    {
-      "name": "commitThreshold",
-      "type": "number | undefined",
-      "required": false,
-      "default": "0.5",
-      "description": "Fraction of `rowWidth` the user must drag past to fire `commit` instead\nof just snapping open. Range 0–1."
-    },
-    {
-      "name": "commitVelocity",
-      "type": "number | undefined",
-      "required": false,
-      "default": "1200",
-      "description": "Absolute velocity in px/s (leftward) above which a flick fires `commit`\nregardless of position."
+      "description": "Width of the revealed action panel in px. Forwarded to the core\n`SwipeAction` primitive — required for the threshold math."
     },
     {
       "name": "defaultOpen",
@@ -35,13 +21,6 @@
       "description": "Disable interaction."
     },
     {
-      "name": "duration",
-      "type": "number | undefined",
-      "required": false,
-      "default": "240",
-      "description": "Release animation duration in ms."
-    },
-    {
       "name": "open",
       "type": "boolean | undefined",
       "required": false,
@@ -51,41 +30,47 @@
       "name": "rowWidth",
       "type": "number",
       "required": true,
-      "description": "Width of the row in px. Required to compute the commit threshold."
+      "description": "Width of the row in px. Forwarded to the core primitive — required to\ncompute the commit threshold."
     },
     {
-      "name": "snapThreshold",
-      "type": "number | undefined",
+      "name": "side",
+      "type": "\"right\" | \"left\" | undefined",
       "required": false,
-      "default": "0.5",
-      "description": "Fraction of `actionWidth` the user must drag past (without velocity) to\nsnap open. Range 0–1."
+      "default": "\"right\"",
+      "description": "Which side reveals the actions. Drives styling only — the core\nprimitive currently always reveals from the trailing (right) edge."
     },
     {
-      "name": "velocityThreshold",
+      "name": "threshold",
       "type": "number | undefined",
       "required": false,
-      "default": "400",
-      "description": "Absolute velocity in px/s for \"snap to open\" / \"snap to closed\" override."
+      "description": "Fraction of `actionWidth` the user must drag past to snap open. 0–1.\nMaps to the core `snapThreshold` prop."
+    },
+    {
+      "name": "ui",
+      "type": "Partial<Record<\"root\" | \"actions\" | \"content\", any>> | undefined",
+      "required": false
     }
   ],
   "events": [
     {
-      "name": "update:open",
-      "type": "[value: boolean]"
-    },
-    {
       "name": "commit",
       "type": "[]"
+    },
+    {
+      "name": "update:open",
+      "type": "[value: boolean]"
     }
   ],
   "slots": [
     {
       "name": "default",
-      "type": "{ open: boolean; close: () => void; }"
+      "type": "{ open: boolean; close: () => void; }",
+      "description": "Main row content. Scoped with `{ open, close }` from the core primitive."
     },
     {
-      "name": "action",
-      "type": "{ open: boolean; close: () => void; }"
+      "name": "actions",
+      "type": "{ open: boolean; close: () => void; }",
+      "description": "Action panel revealed on swipe. Scoped with `{ open, close }`."
     }
   ]
 }

--- a/apps/docs/app/generated/api/Textarea.json
+++ b/apps/docs/app/generated/api/Textarea.json
@@ -1,80 +1,103 @@
 {
   "props": [
     {
-      "name": "as",
-      "type": "AsTag | Component | undefined",
-      "required": false,
-      "default": "\"textarea\"",
-      "description": "The element or component this component should render as. Can be overwritten by `asChild`."
-    },
-    {
-      "name": "asChild",
+      "name": "autofocus",
       "type": "boolean | undefined",
       "required": false,
-      "description": "Change the default rendered element for the one passed as a child, merging their props and behavior.\n\nUse this when you need a component to render through a child element while keeping the primitive's props and behavior."
+      "description": "Focus the textarea on mount (after `autofocusDelay` ms)."
     },
     {
-      "name": "bounces",
+      "name": "autofocusDelay",
+      "type": "number | undefined",
+      "required": false,
+      "default": "0",
+      "description": "Delay before applying `autofocus`, in milliseconds."
+    },
+    {
+      "name": "avatar",
+      "type": "AvatarProps | undefined",
+      "required": false,
+      "description": "When set, render `<VyAvatar>` in the leading slot instead of an icon."
+    },
+    {
+      "name": "avoidKeyboard",
       "type": "boolean | undefined",
       "required": false,
-      "default": "true",
-      "description": "Whether the textarea scroll-view should bounce at its edges (iOS)."
+      "description": "Native keyboard avoidance (Lynx `avoid-keyboard`) — see `VyInput`'s prop\nof the same name. Do NOT combine with a `VyKeyboardAwareRoot`."
     },
     {
-      "name": "confirmType",
-      "type": "InputConfirmType | undefined",
+      "name": "avoidKeyboardSpacing",
+      "type": "number | undefined",
       "required": false,
-      "default": "\"send\"",
-      "description": "On-screen return-key label — see `InputConfirmType`."
+      "description": "Extra clearance in px above the keyboard when `avoidKeyboard` is set."
     },
     {
-      "name": "defaultValue",
-      "type": "string | undefined",
-      "required": false,
-      "description": "Initial value when uncontrolled."
+      "name": "color",
+      "type": "keyof VyuiColorRegistry | undefined",
+      "required": false
     },
     {
       "name": "disabled",
       "type": "boolean | undefined",
+      "required": false
+    },
+    {
+      "name": "highlight",
+      "type": "boolean | undefined",
       "required": false,
-      "default": "false",
-      "description": "When `true`, prevents the user from interacting with the textarea."
+      "description": "Paints a static ring matching `color`, ignoring focus state."
+    },
+    {
+      "name": "icon",
+      "type": "string | undefined",
+      "required": false,
+      "description": "Iconify shorthand. Routed to the trailing side when `trailing` is true,\notherwise to the leading side. Explicit `leadingIcon` / `trailingIcon`\nalways win."
     },
     {
       "name": "id",
       "type": "string | undefined",
+      "required": false,
+      "description": "Forwarded to the underlying `<textarea>`."
+    },
+    {
+      "name": "leading",
+      "type": "boolean | undefined",
+      "required": false,
+      "description": "Force `icon` shorthand onto the leading side."
+    },
+    {
+      "name": "leadingIcon",
+      "type": "string | undefined",
+      "required": false,
+      "description": "Iconify name shown on the leading side (wins over `icon`)."
+    },
+    {
+      "name": "loading",
+      "type": "boolean | undefined",
       "required": false
     },
     {
-      "name": "inputFilter",
+      "name": "loadingIcon",
       "type": "string | undefined",
       "required": false,
-      "description": "Regex string filter applied by the native input before the value is\nsurfaced to JS."
-    },
-    {
-      "name": "lineSpacing",
-      "type": "string | number | undefined",
-      "required": false,
-      "description": "Spacing between lines in px / lynx-units. Forwarded to the native node."
+      "description": "Iconify name for the spinner. Defaults to `appConfig.ui.icons.loading`."
     },
     {
       "name": "maxLength",
       "type": "number | undefined",
       "required": false,
-      "description": "Maximum number of characters allowed. Unset by default, leaving the\nplatform's own limit in place: iOS and Android are unlimited, while\nHarmony applies the documented Lynx default of 140. Pass an explicit\nvalue to enforce a limit, or to get identical behavior on every platform."
-    },
-    {
-      "name": "maxLines",
-      "type": "number | undefined",
-      "required": false,
-      "default": "40",
-      "description": "Maximum number of visible lines before scrolling kicks in. Defaults to\n`40` to match the React port."
+      "description": "Max input length. Forwarded to the underlying core `<textarea>`."
     },
     {
       "name": "modelValue",
+      "type": "string | number | undefined",
+      "required": false
+    },
+    {
+      "name": "name",
       "type": "string | undefined",
       "required": false,
-      "description": "Controlled value — pair with `@update:modelValue` (or `v-model`)."
+      "description": "Forwarded to the underlying `<textarea>`."
     },
     {
       "name": "placeholder",
@@ -82,61 +105,82 @@
       "required": false
     },
     {
-      "name": "readonly",
+      "name": "required",
       "type": "boolean | undefined",
       "required": false,
-      "default": "false",
-      "description": "Whether the textarea renders as read-only."
+      "description": "Forwarded to the underlying `<textarea>`."
     },
     {
-      "name": "showSoftInputOnFocus",
+      "name": "rows",
+      "type": "number | undefined",
+      "required": false,
+      "default": "3",
+      "description": "Visible rows. Forwarded to the underlying core `<textarea>`."
+    },
+    {
+      "name": "size",
+      "type": "\"sm\" | \"md\" | \"lg\" | \"xl\" | undefined",
+      "required": false
+    },
+    {
+      "name": "trailing",
       "type": "boolean | undefined",
       "required": false,
-      "default": "true",
-      "description": "When `false`, focus will not raise the software keyboard."
+      "description": "Force `icon` shorthand onto the trailing side."
     },
     {
-      "name": "type",
-      "type": "InputType | undefined",
+      "name": "trailingIcon",
+      "type": "string | undefined",
       "required": false,
-      "default": "\"text\"",
-      "description": "Input mode hint — see `InputType`."
+      "description": "Iconify name shown on the trailing side (wins over `icon`)."
+    },
+    {
+      "name": "ui",
+      "type": "Partial<Record<\"root\" | \"leadingIcon\" | \"trailingIcon\" | \"leading\" | \"trailing\" | \"base\" | \"leadingAvatar\", any>> | undefined",
+      "required": false
+    },
+    {
+      "name": "variant",
+      "type": "\"outline\" | \"soft\" | \"subtle\" | \"ghost\" | \"none\" | undefined",
+      "required": false
     }
   ],
   "events": [
     {
-      "name": "input",
-      "type": "[value: string, selectionStart: number, selectionEnd: number, isComposing: boolean]"
-    },
-    {
       "name": "update:modelValue",
-      "type": "[value: string]"
-    },
-    {
-      "name": "focus",
-      "type": "[value: string]"
-    },
-    {
-      "name": "blur",
-      "type": "[value: string]"
+      "type": "any[]"
     },
     {
       "name": "confirm",
-      "type": "[value: string]"
+      "type": "any[]"
     },
     {
-      "name": "selectionChange",
-      "type": "[selectionStart: number, selectionEnd: number]"
+      "name": "focus",
+      "type": "any[]"
+    },
+    {
+      "name": "blur",
+      "type": "any[]"
     },
     {
       "name": "keyboard",
-      "type": "[info: { visible: boolean; height: number; safeAreaBottom: number; }]"
+      "type": "any[]"
     }
   ],
   "slots": [
     {
+      "name": "leading",
+      "type": "{ iconColor: string; }",
+      "description": "Receives `iconColor` so custom icons can match the textarea's resolved theme color."
+    },
+    {
+      "name": "trailing",
+      "type": "{ iconColor: string; }",
+      "description": "Receives `iconColor` so custom icons can match the textarea's resolved theme color."
+    },
+    {
       "name": "default",
-      "type": "{}"
+      "type": "{} | undefined"
     }
   ]
 }

--- a/apps/docs/app/generated/api/Toggle.json
+++ b/apps/docs/app/generated/api/Toggle.json
@@ -4,7 +4,6 @@
       "name": "as",
       "type": "AsTag | Component | undefined",
       "required": false,
-      "default": "\"view\"",
       "description": "The element or component this component should render as. Can be overwritten by `asChild`."
     },
     {
@@ -12,6 +11,11 @@
       "type": "boolean | undefined",
       "required": false,
       "description": "Change the default rendered element for the one passed as a child, merging their props and behavior.\n\nUse this when you need a component to render through a child element while\nkeeping the primitive's props and behavior."
+    },
+    {
+      "name": "color",
+      "type": "keyof VyuiColorRegistry | undefined",
+      "required": false
     },
     {
       "name": "defaultValue",
@@ -27,11 +31,32 @@
       "description": "When `true`, prevents the user from interacting with the toggle."
     },
     {
-      "name": "modelValue",
-      "type": "boolean | null | undefined",
+      "name": "icon",
+      "type": "string | undefined",
       "required": false,
-      "default": "undefined",
+      "description": "Iconify name rendered inside the toggle when no default slot is supplied."
+    },
+    {
+      "name": "modelValue",
+      "type": "boolean | undefined",
+      "required": false,
+      "default": "false",
       "description": "The controlled pressed state of the toggle. Can be bind as `v-model`."
+    },
+    {
+      "name": "size",
+      "type": "\"sm\" | \"md\" | \"lg\" | \"xl\" | undefined",
+      "required": false
+    },
+    {
+      "name": "ui",
+      "type": "Partial<Record<\"icon\" | \"base\", any>> | undefined",
+      "required": false
+    },
+    {
+      "name": "variant",
+      "type": "\"solid\" | \"outline\" | \"soft\" | \"ghost\" | undefined",
+      "required": false
     }
   ],
   "events": [
@@ -43,7 +68,8 @@
   "slots": [
     {
       "name": "default",
-      "type": "{ modelValue: boolean; state: DataState; pressed: boolean; disabled: boolean; }"
+      "type": "{ modelValue: boolean; state: \"off\" | \"on\"; pressed: boolean; disabled: boolean; }",
+      "description": "Pressed state and disabled flag forwarded from the core primitive."
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "packageManager": "pnpm@11.4.0",
   "scripts": {
     "dev": "pnpm -r run dev",
-    "build": "pnpm -r --filter='./packages/*' build",
+    "build": "pnpm gen:api && pnpm -r --filter='./packages/*' build",
     "test": "pnpm -r run test",
     "lint": "pnpm -r run lint",
     "typecheck": "pnpm -r typecheck",
@@ -17,7 +17,8 @@
     "release": "pnpm build && changeset publish",
     "new-component": "tsx tools/make-component.ts",
     "gen:registry": "tsx tools/gen-registry.ts",
-    "gen:schemas": "tsx tools/gen-schemas.ts"
+    "gen:schemas": "tsx tools/gen-schemas.ts",
+    "gen:api": "tsx tools/gen-component-api.ts"
   },
   "devDependencies": {
     "@changesets/cli": "2.31.0",

--- a/packages/kit/src/components/Toggle.vue
+++ b/packages/kit/src/components/Toggle.vue
@@ -1,11 +1,15 @@
 <script lang="ts">
+import type { ToggleProps as CoreToggleProps } from '@vyui/core'
 import theme from '../theme/toggle'
 import type { ThemeTV, VariantProps } from '../composables/useStyledComponent'
 
 type ToggleTV = ThemeTV<typeof theme>
 type ToggleVariants = VariantProps<ToggleTV>
 
-export interface ToggleProps {
+// Extends the core primitive so `as` / `asChild` / `defaultValue` — which work
+// at runtime through $attrs fall-through — get real TS/IDE support here too.
+// `modelValue` / `disabled` are narrowed to the kit's concrete types.
+export interface ToggleProps extends CoreToggleProps {
   modelValue?: boolean
   disabled?: boolean
   color?: ToggleVariants['color']

--- a/tools/gen-component-api.ts
+++ b/tools/gen-component-api.ts
@@ -59,6 +59,14 @@ const sources = [
   { name: 'core', tsconfig: resolve(root, 'packages/core/tsconfig.json'), dir: resolve(root, 'packages/core/src/components') },
 ]
 
+// Kit wrappers are the documented surface; core is the headless layer beneath
+// them. When both share an SFC basename (e.g. `Toggle.vue` in kit and core) the
+// two would write the same `Toggle.json`, and the later core write would clobber
+// the kit table. Skip core collidees so the kit wrapper's props win — the headless
+// core component is still reachable through the kit wrapper's inherited props.
+const kitDir = sources.find(s => s.name === 'kit')?.dir
+const kitNames = kitDir ? new Set(vueFilesIn(kitDir).map(file => file.split('/').pop()!.replace(/\.vue$/, ''))) : new Set<string>()
+
 for (const source of sources) {
   if (!statSync(source.tsconfig, { throwIfNoEntry: false })) {
     console.warn(`[gen-api] no tsconfig for ${source.name}, skipping`)
@@ -67,6 +75,7 @@ for (const source of sources) {
   const checker = createChecker(source.tsconfig, { forceUseTs: true, printer: { newLine: 1 } })
   for (const file of vueFilesIn(source.dir)) {
     const name = file.split('/').pop()!.replace(/\.vue$/, '')
+    if (source.name === 'core' && kitNames.has(name)) continue
     if (only.length && !only.includes(name)) continue
     try {
       const meta = checker.getComponentMeta(file)


### PR DESCRIPTION
Follow-up to the MED/LOW API-surface review (#190 covered the inert events and `debugLog` removals).

- `VyToggle.ToggleProps` now extends the core primitive's props, so `as` / `asChild` / `defaultValue` get real TS/IDE support (already worked at runtime via `$attrs` fall-through).
- `tools/gen-component-api.ts` now skips core SFCs whose basename collides with a kit wrapper. Both `Toggle.vue` files were writing `Toggle.json`, and the headless core one clobbered the styled kit table — which is why `color` / `variant` / `size` / `icon` never showed up in the generated Props table.
- Regenerated the affected tables (`Toggle`, plus the other collisions: `Button`, `Input`, `Label`, `Textarea`, `FeedList`, `FormField`, `Separator`, `SwipeAction`) and `App.json`, which had drifted and was missing `safeArea`.

Follow-ups left out of scope: `DialogOverlay` slots table is still `[]` (default slot implemented but no `defineSlots`), and kit wrappers still re-declare a subset of core props instead of extending them.