### PR TITLE
fix(toggle): visible pressed state

### DIFF
--- a/.changeset/toggle-visible-pressed-state.md
+++ b/.changeset/toggle-visible-pressed-state.md
@@ -1,0 +1,5 @@
+---
+"@vyui/kit": patch
+---
+
+Fix `VyToggle` having no visible on-state. The `ghost` default variant only carried `active:` classes, so its pressed surface vanished the moment the tap ended, and the pressed/unpressed `text-*` classes on the icon slot never reached the rasterized SVG. Every variant now paints a resting pressed surface, and the icon fill is baked per state (`iconFg`), matching `VyToggleGroup`. The default slot gains `iconColor` for custom SVG icons.

--- a/apps/docs/content/3.components/toggle-group.md
+++ b/apps/docs/content/3.components/toggle-group.md
@@ -92,6 +92,19 @@ The default slot replaces an entire item's built-in icon and label. It receives 
 </VyToggleGroup>
 ```
 
+### Select boxes
+
+Vertical orientation plus the default slot turns the group into a list of selectable cards: each box is one tap target, and selection paints the container border rather than a separate control. Override `ui.root` to replace the connected `-space-y-px` with a gap, and `ui.item` to round every corner and own the padding.
+
+::component-code
+---
+name: toggle-group-select-box
+height: 260px
+---
+::
+
+Use `type="multiple"` for the multi-select form of the same layout. Render the check icon from your own model state, since the default slot exposes the item, not its pressed state.
+
 ## Features and behavior
 
 - `single` mode stores one string or number. Tapping the selected item again clears the runtime value.

--- a/apps/docs/content/3.components/toggle.md
+++ b/apps/docs/content/3.components/toggle.md
@@ -86,7 +86,7 @@ name: toggle-disabled
 
 | Slot | Props | Description |
 | --- | --- | --- |
-| `default` | `{ modelValue: boolean, state: 'on' \| 'off', pressed: boolean, disabled: boolean }` | Replaces the built-in icon; same prop contract as the core primitive. |
+| `default` | `{ modelValue: boolean, state: 'on' \| 'off', pressed: boolean, disabled: boolean, iconColor: string }` | Replaces the built-in icon; `iconColor` is the resolved hex for the current state, for custom SVG icons. |
 
 ## Styling and theming
 
@@ -103,10 +103,10 @@ The theme combines `color`, `variant`, `size`, and the internal `pressed` state.
 | --- | --- |
 | `solid` | Semantic filled surface with a white icon. |
 | `outline` | Semantic border and foreground with a light active surface. |
-| `soft` | Light semantic surface and semantic foreground. |
-| `ghost` | Transparent surface with semantic foreground and active feedback. |
+| `soft` | Semantic surface and semantic foreground. |
+| `ghost` | Lightest semantic surface with semantic foreground. |
 
-The unpressed state uses a neutral icon and neutral active feedback regardless of `color`. The `size` variant changes root spacing and the `icon` slot from `size-5` through `size-7`.
+Every pressed surface rests on screen rather than only painting while the finger is down. The unpressed state uses a neutral icon and neutral active feedback regardless of `color`. The `size` variant changes root spacing and the `icon` slot from `size-5` through `size-7`.
 
 ## Accessibility
 
@@ -117,7 +117,7 @@ Provide `accessibility-label` for icon-only toggles. Text in the default slot gi
 ## Platform notes
 
 - The component renders a Lynx `view` through the core primitive and responds to the Lynx `tap` event.
-- Lynx SVG does not inherit `currentColor`, so the theme places foreground classes directly on the built-in icon slot.
+- Lynx rasterizes each SVG, so a `text-*` class never reaches the glyph. The component bakes the pressed and unpressed fills into the built-in icon through the Icon `color` prop, and exposes the same hex to the default slot as `iconColor`.
 - The default theme uses vyui's semantic surface/text/border tokens, so it adapts automatically under dark mode (see [Theming → Dark Mode](/theming/dark-mode)).
 
 ## Built on `@vyui/core`

--- a/apps/examples/docs-playground/src/examples/toggle-group/ToggleGroupSelectBox.vue
+++ b/apps/examples/docs-playground/src/examples/toggle-group/ToggleGroupSelectBox.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { VyIcon, VyToggleGroup } from '@vyui/kit'
+
+const plan = ref('pro')
+const plans = [
+  { label: 'Starter', value: 'starter', description: 'Up to 3 projects' },
+  { label: 'Pro', value: 'pro', description: 'Unlimited projects and history' },
+  { label: 'Team', value: 'team', description: 'Shared workspaces and roles' },
+]
+</script>
+
+<template>
+  <VyToggleGroup
+    v-model="plan"
+    type="single"
+    orientation="vertical"
+    :items="plans"
+    :ui="{ root: 'gap-2 space-y-0', item: 'rounded-md p-4' }"
+  >
+    <template #default="{ item, iconColor }">
+      <view class="flex flex-row items-center justify-between w-full">
+        <view class="flex flex-col">
+          <text class="font-medium text-default group-ui-on:text-primary-600">
+            {{ item.label }}
+          </text>
+          <text class="text-xs text-muted">
+            {{ item.description }}
+          </text>
+        </view>
+        <VyIcon
+          v-if="plan === item.value"
+          name="i-lucide-check"
+          :size="20"
+          :color="iconColor"
+        />
+      </view>
+    </template>
+  </VyToggleGroup>
+</template>

--- a/packages/kit/src/components/Toggle.vue
+++ b/packages/kit/src/components/Toggle.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { ToggleProps as CoreToggleProps } from '@vyui/core'
-import theme from '../theme/toggle'
+import theme, { iconFg } from '../theme/toggle'
 import type { ThemeTV, VariantProps } from '../composables/useStyledComponent'
 
 type ToggleTV = ThemeTV<typeof theme>
@@ -36,13 +36,19 @@ export interface ToggleSlots {
     pressed: boolean
     /** Current disabled state */
     disabled: boolean
+    /** Resolved hex for the current state, for custom SVG icons. */
+    iconColor: string
   }): any
 }
 </script>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import { Toggle as CoreToggle, Icon as VyIcon } from '@vyui/core'
+import { useAppConfig } from '../composables/useAppConfig'
+import { useColorMode } from '../composables/useColorMode'
 import { useStyledComponent } from '../composables/useStyledComponent'
+import { resolveColorHex } from '../utils/resolveColor'
 
 const props = withDefaults(defineProps<ToggleProps>(), {
   modelValue: false,
@@ -57,6 +63,15 @@ const { ui } = useStyledComponent('toggle', theme, () => ({
   size: props.size,
   pressed: props.modelValue,
 }))
+
+const appConfig = useAppConfig()
+const { isDark } = useColorMode()
+
+// Fallbacks mirror the theme's `defaultVariants` (`primary` / `ghost`).
+const iconColor = computed(() => {
+  const fg = iconFg(props.color ?? 'primary', props.variant ?? 'ghost', props.modelValue, isDark.value)
+  return fg === 'white' ? 'white' : resolveColorHex(appConfig, fg.semantic, fg.shade)
+})
 </script>
 
 <template>
@@ -71,8 +86,9 @@ const { ui } = useStyledComponent('toggle', theme, () => ({
       :state="modelValue ? 'on' : 'off'"
       :pressed="modelValue"
       :disabled="disabled"
+      :icon-color="iconColor"
     >
-      <VyIcon v-if="icon" :name="icon" :class="ui.icon({ class: props.ui?.icon })" />
+      <VyIcon v-if="icon" :name="icon" :color="iconColor" :class="ui.icon({ class: props.ui?.icon })" />
     </slot>
   </CoreToggle>
 </template>

--- a/packages/kit/src/theme/toggle.test.ts
+++ b/packages/kit/src/theme/toggle.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import theme, { iconFg } from './toggle'
+import { COLORS } from './color-constants.js'
+
+const VARIANTS = ['solid', 'outline', 'soft', 'ghost'] as const
+
+/**
+ * The pressed surface has to REST, not only paint under a finger: `ghost` (the
+ * default variant) shipped with `active:`-only classes, so an icon-only toggle
+ * had no visible on-state at all — nothing changed between off and on.
+ */
+describe('pressed state is visible at rest', () => {
+  const pressedBase = (variant: string) =>
+    theme(COLORS).compoundVariants
+      .find(c => c.pressed && c.color === 'primary' && c.variant === variant)!
+      .class.base as string
+
+  it.each(VARIANTS)('%s paints a resting surface', (variant) => {
+    const resting = pressedBase(variant).split(/\s+/).filter(c => !c.startsWith('active:'))
+    expect(resting).not.toHaveLength(0)
+  })
+})
+
+// `text-*` on the icon slot is inert (Lynx rasterizes the SVG), so the on/off
+// difference has to come through as two different baked fills.
+describe('iconFg', () => {
+  it('differs between pressed and unpressed', () => {
+    for (const variant of VARIANTS) {
+      expect(iconFg('primary', variant, true)).not.toEqual(iconFg('primary', variant, false))
+    }
+  })
+
+  it('tracks the variant foreground', () => {
+    expect(iconFg('primary', 'solid', true)).toBe('white')
+    expect(iconFg('success', 'ghost', true)).toEqual({ semantic: 'success', shade: 500 })
+    expect(iconFg('primary', 'ghost', false)).toEqual({ semantic: 'neutral', shade: 700 })
+    expect(iconFg('primary', 'ghost', false, true)).toEqual({ semantic: 'neutral', shade: 200 })
+  })
+})

--- a/packages/kit/src/theme/toggle.ts
+++ b/packages/kit/src/theme/toggle.ts
@@ -13,6 +13,7 @@
  * Same convention as `button.ts`.
  */
 import type { Color } from './colors'
+import { type IconFg, iconFgFromToken } from './iconColor'
 
 const solid = (c: string) =>
   ({ base: `bg-${c}-500 active:bg-${c}-600 active:bg-${c}-600`, fg: 'text-white' })
@@ -21,16 +22,30 @@ const outline = (c: string) =>
   ({ base: `border border-${c}-300 active:bg-${c}-50 active:bg-${c}-100`, fg: `text-${c}-500` })
 
 const soft = (c: string) =>
-  ({ base: `bg-${c}-50 active:bg-${c}-100 active:bg-${c}-200`, fg: `text-${c}-500` })
+  ({ base: `bg-${c}-100 active:bg-${c}-100 active:bg-${c}-200`, fg: `text-${c}-500` })
 
+// The pressed surface has to REST on screen, not only under a finger: an
+// `active:` -only ghost is invisible the moment the tap ends, which left the
+// default variant with no on-state at all. Mirrors ToggleGroup's `ui-on:bg-50`.
 const ghost = (c: string) =>
-  ({ base: `active:bg-${c}-50 active:bg-${c}-100`, fg: `text-${c}-500` })
+  ({ base: `bg-${c}-50 active:bg-${c}-100`, fg: `text-${c}-500` })
 
 const VARIANT_BUILDERS = { solid, outline, soft, ghost } as const
 
-type Variant = keyof typeof VARIANT_BUILDERS
+export type Variant = keyof typeof VARIANT_BUILDERS
 
 const VARIANTS = Object.keys(VARIANT_BUILDERS) as Variant[]
+
+// Same Lynx constraint as `button.ts` / `toggleGroup.ts`: the `<svg>` rasterizes
+// its XML, so neither the pressed `text-{color}-500` nor the resting
+// `text-default` on the `icon` slot ever reaches the glyph — Toggle.vue bakes
+// the fill from the same `fg` strings so class and baked color can't drift.
+export function iconFg(color: string, variant: Variant, pressed: boolean, isDark = false): IconFg {
+  const suffix = pressed
+    ? VARIANT_BUILDERS[variant](color).fg.match(/^text-(\S+)/)?.[1]
+    : 'default'
+  return iconFgFromToken(suffix, isDark)
+}
 
 export default (colors: Color[]) => ({
   slots: {


### PR DESCRIPTION
`VyToggle` had no visual on-state — two independent causes, both already fixed in `ToggleGroup`.

- `ghost` (the default variant) carried only `active:` classes, so its pressed surface painted while the finger was down and vanished on release.
- The pressed/unpressed `text-*` on the `icon` slot never reached the glyph — Lynx rasterizes the SVG — so the icon color never changed either.
- Every variant now paints a resting pressed surface; `soft` moves to `bg-{c}-100` to stay distinct from ghost and match ToggleGroup's `ui-on:bg-{c}-100`.
- Icon fill is baked per state via a new `iconFg()` in `theme/toggle.ts`, the same pattern as Button/Tabs/ToggleGroup.
- The default slot gains `iconColor` so custom SVG icons don't hit the same dead end.
- Adds `theme/toggle.test.ts`: every variant has a non-`active:` pressed class, and `iconFg` differs between states.

Also documents the select-box pattern (seed-design's SelectBox) as a ToggleGroup recipe — vertical orientation plus the default slot — with a new playground example, rather than a new component.

Docs: corrected the toggle variant table, the slot table, and the platform note that described the dead `text-*` behavior as intended.

Needs `pnpm --filter @vyui/docs playground:build` to regenerate the playground registry for `toggle-group-select-box`.