### PR TITLE
fix(slider): make the drag forgiving off-axis

### DIFF
--- a/.changeset/slider-forgiving-drag.md
+++ b/.changeset/slider-forgiving-drag.md
@@ -1,0 +1,6 @@
+---
+"@vyui/core": patch
+"@vyui/kit": patch
+---
+
+Make the Slider drag far more forgiving. The control now carries `hit-slop` and claims every slide angle, so a press no longer has to land inside the track's own thickness and an ancestor `<scroll-view>` no longer steals the gesture when the finger drifts off-axis. On Lynx web — which re-targets pointer events by position — a viewport-sized shield is raised for the length of a mouse drag, so the cursor can leave the control without stranding it. The kit theme pads the slider on its cross axis to give the thumb a finger-sized target.

--- a/docs/data-attributes.md
+++ b/docs/data-attributes.md
@@ -61,6 +61,7 @@ override. Each is the stable selector for that element.
 | `data-vyui-sheet-handle` | Sheet | drag handle |
 | `data-vyui-sheet-view` | Sheet | view container |
 | `data-vyui-slider-impl` | Slider | the track implementation node |
+| `data-vyui-slider-shield` | Slider | web-only pointer shield, present while dragging |
 | `data-vyui-sortable-root` | Sortable | root |
 | `data-vyui-sortable-item` | Sortable | each item |
 | `data-vyui-swipe-action` | SwipeAction | root |

--- a/packages/core/src/components/Slider/Slider.test.ts
+++ b/packages/core/src/components/Slider/Slider.test.ts
@@ -292,6 +292,23 @@ describe('Slider — nothing crosses BG -> MT by assignment', () => {
     expect(sfc).not.toMatch(/@layoutchange=|useResizeObserver\(/)
   })
 
+  // Forgiveness, per platform. Native loses the gesture to an ancestor
+  // `<scroll-view>` on off-axis drift and hit-tests only the track's own
+  // thickness; web re-targets pointer events by position, so a mouse drag that
+  // leaves the element strands. The shield answers the web half and must exist
+  // only there — a stuck full-screen view on native would eat every touch.
+  it('is forgiving off-axis: native slop and slide claim, a web-only shield', async () => {
+    const sfc = await readSfc('SliderImplMTS.vue')
+    expect(sfc).toMatch(/hit-slop="\d+px"/)
+    expect(sfc).toMatch(/:consume-slide-event="\[\[0, 360\]\]"/)
+    expect(sfc).toMatch(/v-if="mtBound && isWeb\(\)"/)
+    expect(body(sfc, 'isWeb')).toMatch(/SystemInfo\?\.platform === 'web'/)
+    expect(body(sfc, '_onMouseDown')).toMatch(/_setShield\(true\)/)
+    // Lowered AHEAD of the early return: a press that never became a drag
+    // (disabled, zero extent) would otherwise leave the shield over the page.
+    expect(body(sfc, '_dragEnd')).toMatch(/_setShield\(false\)[\s\S]*?activeIndexRef\.current === -1\) return/)
+  })
+
   it('keeps values sorted and re-tracks the active thumb every frame', async () => {
     const sfc = await readSfc('SliderImplMTS.vue')
     // Thumbs may cross mid-drag; the old BG path re-derived the active index

--- a/packages/core/src/components/Slider/SliderImplMTS.vue
+++ b/packages/core/src/components/Slider/SliderImplMTS.vue
@@ -110,6 +110,25 @@ const activeIndexRef = useMainThreadRef<number>(-1)
 const thumbElsRef = useMainThreadRef<any[]>([])
 const rangeElRef = useMainThreadRef<any>(null)
 
+// Drag shield — WEB ONLY, and rendered nowhere else.
+//
+// Lynx web re-targets pointer events by position (same root cause as the
+// `zIndex` in SortableItem), and the slider's box is barely thicker than its
+// track, so a mouse drag stranded the moment the cursor drifted off it. A
+// viewport-sized element raised for the length of the gesture keeps the cursor
+// over a bound element wherever it goes.
+//
+// Lynx native gets neither the element nor its bindings: it delivers the whole
+// gesture to the node the press started on, and a stuck full-screen view there
+// would eat every touch in the app.
+//
+// Read at render, not setup — `SystemInfo` can resolve late.
+function isWeb() {
+  return (globalThis as any).SystemInfo?.platform === 'web'
+}
+
+const shieldRef = useMainThreadRef<any>(null)
+
 function _resolveEls() {
   'main thread'
   const track = trackRef.current
@@ -302,6 +321,13 @@ function _paintRange(vals: number[]) {
   el.setStyleProperty(endName, `${100 - hi}%`)
 }
 
+function _setShield(up: boolean) {
+  'main thread'
+  const el = shieldRef.current as { setStyleProperty?: (k: string, v: string) => void } | null
+  if (!el?.setStyleProperty) return
+  el.setStyleProperty('display', up ? 'flex' : 'none')
+}
+
 // Coordinate-based gesture cores — take ELEMENT-LOCAL offsets. Every wrapper
 // below converts to them the same way: viewport coordinate minus the track
 // origin `_beginAt` captured for this gesture.
@@ -362,6 +388,9 @@ function _dragMove(localX: number, localY: number) {
 
 function _dragEnd() {
   'main thread'
+  // Ahead of the guard: a press that never became a drag (disabled root, zero
+  // extent) still raised the shield, and a stuck shield eats the whole page.
+  _setShield(false)
   if (activeIndexRef.current === -1) return
   // Already sorted and gap-checked by `_applyValue` on every frame, so this is
   // exactly what the commit will write — and therefore what the fill should be
@@ -415,6 +444,13 @@ function _beginAt(clientX: number, clientY: number) {
     .catch(() => {})
 }
 
+// The template's `hit-slop` / `consume-slide-event` are the native forgiveness
+// knobs (Lynx web ignores both). Slop because the element is only as thick as
+// the track — 9px at the kit's default size. Consuming every slide angle
+// because an ancestor `<scroll-view>` otherwise claims the gesture the moment
+// the finger drifts off-axis; the drift itself is harmless, `_valueFromTouch`
+// clamps the cross-axis away.
+
 function _onTouchStart(e: { touches: Array<{ clientX: number, clientY: number }> }) {
   'main thread'
   const t = e.touches[0]
@@ -448,6 +484,9 @@ function _onMouseDown(e: { clientX: number, clientY: number, buttons?: number })
   // Primary button only: a right/middle press would start a phantom drag that
   // the next hover move then "releases", teleporting the thumb.
   if (typeof e.buttons === 'number' && (e.buttons & 1) === 0) return
+  // Synchronously, not from `_beginAt`'s `boundingClientRect` continuation —
+  // the cursor can already be off the element by the time that resolves.
+  _setShield(true)
   _beginAt(e.clientX, e.clientY)
 }
 
@@ -492,6 +531,8 @@ function _commit(values: number[]) {
   <Primitive
     data-vyui-slider-impl
     v-bind="props"
+    hit-slop="16px"
+    :consume-slide-event="[[0, 360]]"
     :main-thread-ref="mtBound ? trackRef : undefined"
     :main-thread-bindtouchstart="mtBound ? _onTouchStart : undefined"
     :main-thread-bindtouchmove="mtBound ? _onTouchMove : undefined"
@@ -502,5 +543,13 @@ function _commit(values: number[]) {
     :main-thread-bindmouseup="mtBound ? _onMouseUp : undefined"
   >
     <slot />
+    <view
+      v-if="mtBound && isWeb()"
+      data-vyui-slider-shield
+      style="display: none; position: fixed; left: 0; top: 0; width: 100vw; height: 100vh; z-index: 9999;"
+      :main-thread-ref="shieldRef"
+      :main-thread-bindmousemove="_onMouseMove"
+      :main-thread-bindmouseup="_onMouseUp"
+    />
   </Primitive>
 </template>

--- a/packages/kit/src/theme/slider.ts
+++ b/packages/kit/src/theme/slider.ts
@@ -25,12 +25,16 @@ export default (colors: Color[]) => ({
       xl: { thumb: 'size-6' },
     },
     orientation: {
+      // Cross-axis padding IS the touch target — the thumb is absolutely
+      // positioned, so the root is otherwise as thin as the track. Padding
+      // rather than a height/width because the drag measures the root's
+      // main-axis extent, which cross-axis padding leaves alone.
       horizontal: {
-        root: 'w-full flex-row',
+        root: 'w-full flex-row py-2',
         range: 'h-full',
       },
       vertical: {
-        root: 'flex-col h-full',
+        root: 'flex-col h-full px-2',
         range: 'w-full',
       },
     },

--- a/packages/kit/src/theme/toggle.test.ts
+++ b/packages/kit/src/theme/toggle.test.ts
@@ -11,7 +11,7 @@ const VARIANTS = ['solid', 'outline', 'soft', 'ghost'] as const
  */
 describe('pressed state is visible at rest', () => {
   const pressedBase = (variant: string) =>
-    theme(COLORS).compoundVariants
+    theme([...COLORS]).compoundVariants
       .find(c => c.pressed && c.color === 'primary' && c.variant === variant)!
       .class.base as string
 


### PR DESCRIPTION
The slider only responded inside the track itself — 9px tall at the kit's default size — and any vertical drift ended the gesture.

- `hit-slop="16px"` on the impl node, so a press no longer has to land inside the track's own thickness
- `consume-slide-event="[[0, 360]]"`, so an ancestor `<scroll-view>` stops claiming the gesture when the finger drifts off-axis
- Web-only viewport shield raised for the length of a mouse drag: Lynx web re-targets pointer events by position, so leaving the control used to strand the drag (native gets neither the element nor its bindings — it latches the gesture to the pressed node, and a stuck full-screen view there would eat every touch)
- Kit theme pads the slider on its cross axis for a finger-sized target; the drag measures the main-axis extent, which that padding leaves alone

Value math is untouched — `_valueFromTouch` already clamps the cross-axis away.

Tested on device and in the browser. Note the kit padding adds 16px to the slider's footprint in flow; the control itself looks identical.

- Also fixes an unrelated typecheck break inherited from `main` (#192): `theme(COLORS)` in `toggle.test.ts` passes a readonly tuple to a `Color[]` parameter
