### PR TITLE
chore: fix the core build entry and clear post-cleanup leftovers

### DIFF
--- a/apps/docs/app/components/content/LynxPreview.vue
+++ b/apps/docs/app/components/content/LynxPreview.vue
@@ -67,7 +67,6 @@ function whenLoaded(run: () => void) {
   else window.addEventListener('load', () => run(), { once: true })
 }
 
-// ponytail: setTimeout fallback for Safari, which still lacks requestIdleCallback.
 function whenIdle(run: () => void) {
   if (typeof requestIdleCallback === 'function') requestIdleCallback(run, { timeout: 2000 })
   else setTimeout(run, 200)

--- a/apps/docs/content/1.getting-started/5.roadmap.md
+++ b/apps/docs/content/1.getting-started/5.roadmap.md
@@ -24,7 +24,7 @@ Expect breaking changes to component names, props, and slots. Don't ship this to
 - **`@vyui/cli`** is a shadcn-style CLI for copying styled components into an app, as in `pnpm dlx @vyui/cli add button`.
 - **Hosted registry seed.** `vyui.dev/r/*` manifests exist for the default, rounded, and shadcn styles, currently covering Accordion, Avatar, Button, Chip, and Toast.
 - **Generated component docs.** API tables and examples are generated from source so docs drift less between releases.
-- **Intl stopgaps.** Core exports `installIntlPolyfill`, `DateFormatter`, `useLocale`, and `useDirection` for the current Lynx runtime constraints.
+- **Intl stopgaps.** Core exports `installIntlPolyfill`, `DateFormatter`, and `useDirection` for the current Lynx runtime constraints.
 
 ## In progress
 

--- a/apps/docs/content/5.accessibility.md
+++ b/apps/docs/content/5.accessibility.md
@@ -58,7 +58,7 @@ A component can't guess a name for a control that has no text, such as an icon-o
 ```
 
 ::note
-Built-in icon controls already set a sensible default, so close buttons announce "Close", pagination announces "Next Page", and so on. Pass `accessibility-label` only when you want a more specific name.
+Controls announce their own child text, so a button reading "Done" announces "Done". Pass `accessibility-label` on icon-only controls, which have no text to announce.
 ::
 
 ## Why Lynx is different from the web

--- a/apps/docs/content/6.i18n.md
+++ b/apps/docs/content/6.i18n.md
@@ -9,7 +9,7 @@ navigation:
 Internationalization is only partially built. Vy UI has runtime-safe formatter and direction primitives today, but app-level message catalogs, overridable built-in strings, and full RTL polish are still [on the roadmap](/getting-started/roadmap).
 ::
 
-Vy UI components render their own text in only a few places: a close button's label, "Next Page" in pagination, the default screen-reader names covered in [a11y](/accessibility). Everything else is content you pass in, so most translation lives in your app, not the library. The goal for i18n is to make the few library-owned strings overridable and to format locale-sensitive values correctly.
+Vy UI components render almost no text of their own — the default screen-reader names covered in [a11y](/accessibility) are the exception. Everything else is content you pass in, so most translation lives in your app, not the library. The goal for i18n is to make the few library-owned strings overridable and to format locale-sensitive values correctly.
 
 ## What works today
 
@@ -17,7 +17,7 @@ Lynx runs your JavaScript on a real engine, but native PrimJS can ship incomplet
 
 - `installIntlPolyfill()` fills broken or missing `Intl.DateTimeFormat`, `Intl.NumberFormat`, `Intl.Collator`, and `Intl.Locale` pieces.
 - `DateFormatter` avoids the host formatter when it is not safe to use.
-- `ConfigProvider` accepts `locale` and `dir`. `useDirection()` feeds the RTL-aware primitives (Accordion, Tabs, Slider, Stepper, …); `useLocale()` exposes the locale for the components you build.
+- `ConfigProvider` accepts `locale` and `dir`. `useDirection()` feeds the RTL-aware primitives (Accordion, Tabs, Slider, Stepper, …).
 
 These APIs are meant to keep current components from crashing on native Lynx. They are not a complete localization system.
 

--- a/packages/core/src/components/Collapsible/CollapsibleContent.vue
+++ b/packages/core/src/components/Collapsible/CollapsibleContent.vue
@@ -72,14 +72,13 @@ const contentStyle = computed(() => {
   return { height: `${measuredHeight.value}px`, transitionProperty }
 })
 
-// ponytail: a close in the DEFAULT unmount mode still snaps — the content is
-// v-if'd out the instant `open` flips false, before the collapse can play.
-// Animating it needs the leave gated on the height `@transitionend` (keep the
-// node mounted through the tween, then unmount), i.e. wrapping this in
-// `Presence` the way `SheetContentImpl` does. That changes the synchronous
-// unmount timing every current Collapsible/Accordion test (and consumers) rely
-// on, so it's deferred; the kept-mounted path (`unmountOnHide: false`) morphs
-// both directions today.
+// A close in the DEFAULT unmount mode still snaps — the content is v-if'd out
+// the instant `open` flips false, before the collapse can play. Animating it
+// needs the leave gated on the height `@transitionend` (keep the node mounted
+// through the tween, then unmount), i.e. wrapping this in `Presence` the way
+// `SheetContentImpl` does. That changes the synchronous unmount timing every
+// current Collapsible/Accordion test (and consumers) rely on, so it's deferred;
+// the kept-mounted path (`unmountOnHide: false`) morphs both directions today.
 </script>
 
 <template>

--- a/packages/core/src/components/Input/KeyboardAwareRoot.vue
+++ b/packages/core/src/components/Input/KeyboardAwareRoot.vue
@@ -110,10 +110,11 @@ const emit = defineEmits<KeyboardAwareRootEmits>()
  * Distance from `bottom` (a viewport-relative rect edge) to the keyboard's
  * resting edge. Prefers the measured viewport height; falls back to the
  * screen-height math (with the Android status-bar correction).
+ *
+ * Assumes the LynxView's bottom edge sits at the screen bottom (true in
+ * Explorer and Sparkling); a bottom-inset container would also need the gap
+ * below the view subtracted.
  */
-// ponytail: assumes the LynxView's bottom edge sits at the screen bottom
-// (true in Explorer and Sparkling); a bottom-inset container would need the
-// gap below the view subtracted as well.
 async function marginToViewportBottom(bottom: number): Promise<number> {
   const viewportHeight = await measureViewportHeight()
   if (viewportHeight > 0)

--- a/packages/core/src/components/Tabs/TabsIndicator.vue
+++ b/packages/core/src/components/Tabs/TabsIndicator.vue
@@ -39,10 +39,9 @@ const indicatorStyle = ref<IndicatorStyle>({
 const ready = ref(false)
 
 // The list rect only moves on a layout change (or an orientation/dir flip), so
-// cache it and re-measure only then.
-// ponytail: assumes the list rect is stable between `layoutTick` bumps —
-// TabsList + TabsTrigger bump it from their own `@layoutchange`, so a list that
-// shifts without emitting one would read stale until the next bump.
+// cache it and re-measure only then. TabsList and TabsTrigger bump `layoutTick`
+// from their own `@layoutchange`; a list that shifts without emitting one reads
+// stale until the next bump.
 let cachedListRect: Awaited<ReturnType<typeof useElementRect>> | null = null
 
 /**

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -19,8 +19,6 @@
     "src/**/*.test.tsx",
     "src/**/*.test.vue",
     "src/__type-guards__/**",
-    "src/test-utils.ts",
-    "src/test/**",
     "src/**/*.story.vue",
     "src/**/story/**",
     "src/**/_*.vue"

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -41,7 +41,6 @@ export default defineConfig({
     lib: {
       entry: {
         index: resolve(src, 'index.ts'),
-        'date/index': resolve(src, 'date/index.ts'),
         'shared/index': resolve(src, 'shared/index.ts'),
       },
       formats: ['es'],


### PR DESCRIPTION
CI has been red on `main` since #202, which deleted `src/date` but left its Rollup entry behind. This restores the build and clears the other leftovers those deletion PRs (#200–#202) left in source and docs.

- `packages/core/vite.config.ts`: drop the `date/index` lib entry — `Could not resolve entry module "src/date/index.ts"` was the CI failure.
- `packages/core/tsconfig.build.json`: drop excludes for `src/test-utils.ts` and `src/test/**`, both deleted.
- Strip the `ponytail:` markers from four comments; the constraints they named stay as ordinary prose, and the one restating its own code is gone.
- Docs: `useLocale` and `Pagination` no longer exist, and `DialogClose` no longer forces `accessibility-label="Close"` — i18n, a11y, and roadmap pages said otherwise.

No changeset: the failing entry never shipped, and the removals it trails are already covered by `plain-moths-remove`.