### PR TITLE
fix(core): make FeedList survive a shrinking list

### DIFF
--- a/.changeset/tall-pears-repeat.md
+++ b/.changeset/tall-pears-repeat.md
@@ -1,0 +1,5 @@
+---
+"@vyui/core": patch
+---
+
+Fix FeedList pull-to-refresh never arming: the rubber-band was given the trigger threshold as its band width, so the painted offset saturated at exactly the threshold and `release to refresh` was only reachable on a knife-edge 2x-threshold drag. The band is now 2x the threshold, so a pull of `refreshThreshold` px arms the release.

--- a/apps/examples/kit-demo/src/App.vue
+++ b/apps/examples/kit-demo/src/App.vue
@@ -11,6 +11,7 @@ import DisplaySection from './sections/DisplaySection.vue'
 import GesturesSection from './sections/GesturesSection.vue'
 import SwipeDeckSection from './sections/SwipeDeckSection.vue'
 import ScrollViewSection from './sections/ScrollViewSection.vue'
+import FeedListSection from './sections/FeedListSection.vue'
 import IslandSection from './sections/IslandSection.vue'
 import OverlaySection from './sections/OverlaySection.vue'
 
@@ -104,6 +105,7 @@ const tabItems = [
   { value: 'gestures', label: 'Gestures', icon: 'icon-park-outline:hand-up',      slot: 'gestures', unmountOnHide: true },
   { value: 'swipe',   label: 'Swipe',  icon: 'icon-park-outline:check-one',       slot: 'swipe',    unmountOnHide: true },
   { value: 'scroll',  label: 'Scroll', icon: 'icon-park-outline:swipe',           slot: 'scroll',   unmountOnHide: true },
+  { value: 'feed',    label: 'Feed',  icon: 'icon-park-outline:list-two',         slot: 'feed',     unmountOnHide: true },
   { value: 'island',  label: 'Island', icon: 'icon-park-outline:pill',            slot: 'island' },
   { value: 'overlay', label: 'Modal', icon: 'icon-park-outline:application-menu', slot: 'overlay' },
 ]
@@ -212,6 +214,10 @@ const tabsUi = computed(() =>
 
         <template #scroll>
           <ScrollViewSection />
+        </template>
+
+        <template #feed>
+          <FeedListSection />
         </template>
 
         <template #island>

--- a/apps/examples/kit-demo/src/icons.generated.ts
+++ b/apps/examples/kit-demo/src/icons.generated.ts
@@ -80,6 +80,9 @@ export const iconParkOutline = {
     "like": {
       "body": "<path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"4\" d=\"M15 8C8.925 8 4 12.925 4 19c0 11 13 21 20 23.326C31 40 44 30 44 19c0-6.075-4.925-11-11-11c-3.72 0-7.01 1.847-9 4.674A10.99 10.99 0 0 0 15 8\"/>"
     },
+    "list-two": {
+      "body": "<g fill=\"none\" stroke=\"currentColor\" stroke-linejoin=\"round\" stroke-width=\"4\"><path d=\"M9 42a4 4 0 1 0 0-8a4 4 0 0 0 0 8Zm0-28a4 4 0 1 0 0-8a4 4 0 0 0 0 8Zm0 14a4 4 0 1 0 0-8a4 4 0 0 0 0 8Z\"/><path stroke-linecap=\"round\" d=\"M21 24h22M21 38h22M21 10h22\"/></g>"
+    },
     "list-view": {
       "body": "<g fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"4\"><rect width=\"40\" height=\"36\" x=\"4\" y=\"6\" rx=\"3\"/><path d=\"M4 14h40M20 24h16m-16 8h16m-24-8h2m-2 8h2\"/></g>"
     },

--- a/apps/examples/kit-demo/src/sections/FeedListSection.vue
+++ b/apps/examples/kit-demo/src/sections/FeedListSection.vue
@@ -1,0 +1,118 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { getViewportSize } from '@vyui/core'
+import { VyButton, VyFeedList } from '@vyui/kit'
+
+// FeedList — native `<list>` virtualization with load-more (scroll to the
+// bottom) and custom rubber-band pull-to-refresh (pull down at the top). PTR
+// rides `:main-thread-bindtouch*` worklets gated to the top edge — no native
+// `<refresh>`, no gesture-runtime. See @vyui/core FeedList/REFRESH-PHYSICS.md.
+//
+// The feed gets its own bounded height: the native `<list>` owns its vertical
+// scrolling, so it must not sit inside another vertical scroller (nesting two
+// breaks both scrollers' gesture routing). Hence its own tab, not SectionScroll.
+//
+// `<list>` also needs a DEFINITE height — `flex-1 min-h-0` + `h-full` measures
+// 0px and renders no rows at all. Measure the flex slot with a background-thread
+// `@layoutchange` and hand the list those pixels, falling back to a screen
+// fraction when the event doesn't arrive (the header prints which one is live).
+const MAX_ITEMS = 50
+let nextFeedId = 21
+const initialFeed = (): { id: number, title: string }[] =>
+  Array.from({ length: 20 }, (_, i) => ({ id: i + 1, title: `Item ${i + 1}` }))
+const feedItems = ref(initialFeed())
+const measuredHeight = ref(0)
+const fallbackHeight = Math.round((getViewportSize()?.height ?? 812) * 0.5)
+const listHeight = computed(() => measuredHeight.value || fallbackHeight)
+const noMoreData = ref(false)
+const refreshing = ref(false)
+
+function onSlotLayout(event: any): void {
+  const height = event?.detail?.height ?? event?.params?.height
+  if (typeof height === 'number' && height > 0) measuredHeight.value = Math.round(height)
+}
+
+function resetFeed(): void {
+  nextFeedId = 21
+  feedItems.value = initialFeed()
+  noMoreData.value = false
+}
+
+// FeedList sets `refreshing` true and emits `refresh`; reset, then flip it false.
+function onRefresh(): void {
+  setTimeout(() => {
+    resetFeed()
+    refreshing.value = false
+  }, 1000)
+}
+
+function onLoadMore(): void {
+  const base = feedItems.value.length
+  const remaining = MAX_ITEMS - base
+  if (remaining <= 0) {
+    noMoreData.value = true
+    return
+  }
+  const add = Math.min(10, remaining)
+  feedItems.value = [
+    ...feedItems.value,
+    ...Array.from({ length: add }, (_, i) => ({ id: nextFeedId + i, title: `Item ${base + i + 1}` })),
+  ]
+  nextFeedId += add
+  if (feedItems.value.length >= MAX_ITEMS) noMoreData.value = true
+}
+</script>
+
+<template>
+  <view class="flex flex-col flex-1 min-h-0">
+    <view class="bg-default border border-default rounded-lg p-3 flex flex-col flex-1 min-h-0 gap-2">
+      <view class="flex flex-row items-center justify-between">
+        <text class="text-highlighted text-base font-semibold">FeedList</text>
+        <text class="text-muted text-xs">{{ feedItems.length }} items · {{ listHeight }}px {{ measuredHeight ? 'measured' : 'fallback' }}</text>
+      </view>
+      <text class="text-muted text-xs">Pull down to refresh; scroll to the bottom to load more.</text>
+
+      <view class="flex-1 min-h-0" @layoutchange="onSlotLayout">
+        <view :style="{ height: `${listHeight}px` }">
+          <VyFeedList
+            v-model:refreshing="refreshing"
+            :items="feedItems"
+            :item-key="(it) => String(it.id)"
+            enable-refresh
+            enable-bounce
+            enable-load-more
+            :no-more-data="noMoreData"
+            class="w-full h-full"
+            @refresh="onRefresh"
+            @load-more="onLoadMore"
+          >
+            <template #refreshHeader="{ state, progress }">
+              <view class="h-full flex items-center justify-center">
+                <text
+                  class="text-dimmed text-xs"
+                  :style="{ opacity: String(Math.max(0.4, progress)) }"
+                >
+                  {{ state === 'refreshing' ? 'Refreshing…' : state === 'releaseReady' ? 'Release to refresh' : 'Pull to refresh' }}
+                </text>
+              </view>
+            </template>
+            <template #item="{ item }">
+              <view class="border-b border-muted h-14 flex flex-row items-center px-2">
+                <text class="text-highlighted text-sm">{{ item.title }}</text>
+              </view>
+            </template>
+            <template #noMoreDataFooter>
+              <view class="h-12 flex items-center justify-center">
+                <text class="text-dimmed text-xs">No more items ({{ MAX_ITEMS }} max)</text>
+              </view>
+            </template>
+          </VyFeedList>
+        </view>
+      </view>
+
+      <view class="flex flex-row items-center justify-center">
+        <VyButton variant="ghost" size="sm" label="Reset feed" @tap="resetFeed" />
+      </view>
+    </view>
+  </view>
+</template>

--- a/apps/examples/kit-demo/src/sections/FeedListSection.vue
+++ b/apps/examples/kit-demo/src/sections/FeedListSection.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { getViewportSize } from '@vyui/core'
+import { getViewportSize, useResizeObserver } from '@vyui/core'
 import { VyButton, VyFeedList } from '@vyui/kit'
 
 // FeedList — native `<list>` virtualization with load-more (scroll to the
@@ -27,10 +27,9 @@ const listHeight = computed(() => measuredHeight.value || fallbackHeight)
 const noMoreData = ref(false)
 const refreshing = ref(false)
 
-function onSlotLayout(event: any): void {
-  const height = event?.detail?.height ?? event?.params?.height
-  if (typeof height === 'number' && height > 0) measuredHeight.value = Math.round(height)
-}
+const { onLayoutChange } = useResizeObserver((rect) => {
+  if (rect.height > 0) measuredHeight.value = Math.round(rect.height)
+})
 
 function resetFeed(): void {
   nextFeedId = 21
@@ -72,7 +71,7 @@ function onLoadMore(): void {
       </view>
       <text class="text-muted text-xs">Pull down to refresh; scroll to the bottom to load more.</text>
 
-      <view class="flex-1 min-h-0" @layoutchange="onSlotLayout">
+      <view class="flex-1 min-h-0" @layoutchange="onLayoutChange">
         <view :style="{ height: `${listHeight}px` }">
           <VyFeedList
             v-model:refreshing="refreshing"

--- a/apps/examples/kit-demo/src/sections/ScrollViewSection.vue
+++ b/apps/examples/kit-demo/src/sections/ScrollViewSection.vue
@@ -1,37 +1,53 @@
 <script setup lang="ts">
-import { ScrollView } from '@vyui/core'
+import { computed, ref } from 'vue'
+import { getViewportSize, ScrollView } from '@vyui/core'
 
 // ScrollView — native vertical scrolling with iOS rubber-band overscroll (the
 // underlying element is a real UIScrollView, so bounce comes for free).
 //
+// Like <list>, the native <scroll-view> needs a DEFINITE height: `flex-1
+// min-h-0` + `h-full` measures 0px and nothing scrolls. Measure the flex slot,
+// fall back to a screen fraction (the header prints which one is live).
+//
 // NOTE: the custom main-thread bounce system (`enable-bounces` + bounce-item
 // slots) is currently not working on-device — the worklets receive touches but
 // don't drive the transform. Until that's fixed we demo the native path, which
-// scrolls and bounces. See ScrollView.vue for the custom-bounce caveat. This
-// region's tab renders a non-scrolling container so this is the only vertical
-// scroller (no nesting conflict).
+// scrolls and bounces.
+const measuredHeight = ref(0)
+const fallbackHeight = Math.round((getViewportSize()?.height ?? 812) * 0.5)
+const scrollHeight = computed(() => measuredHeight.value || fallbackHeight)
+
+function onSlotLayout(event: any): void {
+  const height = event?.detail?.height ?? event?.params?.height
+  if (typeof height === 'number' && height > 0) measuredHeight.value = Math.round(height)
+}
 </script>
 
 <template>
   <view class="flex flex-col flex-1 min-h-0">
     <view class="bg-default border border-default rounded-lg p-3 flex flex-col flex-1 min-h-0 gap-2">
-      <text class="text-highlighted text-base font-semibold">ScrollView</text>
+      <view class="flex flex-row items-center justify-between">
+        <text class="text-highlighted text-base font-semibold">ScrollView</text>
+        <text class="text-muted text-xs">{{ scrollHeight }}px {{ measuredHeight ? 'measured' : 'fallback' }}</text>
+      </view>
       <text class="text-muted text-xs">
         Scroll the panel; overscroll past either edge for the native rubber-band bounce.
       </text>
 
-      <view class="flex-1 min-h-0">
-        <ScrollView class="h-full">
-          <view class="flex flex-col">
-            <view
-              v-for="n in 24"
-              :key="n"
-              class="border-b border-muted h-12 flex flex-row items-center px-2"
-            >
-              <text class="text-highlighted text-sm">Row {{ n }}</text>
+      <view class="flex-1 min-h-0" @layoutchange="onSlotLayout">
+        <view :style="{ height: `${scrollHeight}px` }">
+          <ScrollView class="w-full h-full">
+            <view class="flex flex-col">
+              <view
+                v-for="n in 24"
+                :key="n"
+                class="border-b border-muted h-12 flex flex-row items-center px-2"
+              >
+                <text class="text-highlighted text-sm">Row {{ n }}</text>
+              </view>
             </view>
-          </view>
-        </ScrollView>
+          </ScrollView>
+        </view>
       </view>
     </view>
   </view>

--- a/apps/examples/kit-demo/src/sections/ScrollViewSection.vue
+++ b/apps/examples/kit-demo/src/sections/ScrollViewSection.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { getViewportSize, ScrollView } from '@vyui/core'
+import { getViewportSize, ScrollView, useResizeObserver } from '@vyui/core'
 
 // ScrollView — native vertical scrolling with iOS rubber-band overscroll (the
 // underlying element is a real UIScrollView, so bounce comes for free).
@@ -17,10 +17,9 @@ const measuredHeight = ref(0)
 const fallbackHeight = Math.round((getViewportSize()?.height ?? 812) * 0.5)
 const scrollHeight = computed(() => measuredHeight.value || fallbackHeight)
 
-function onSlotLayout(event: any): void {
-  const height = event?.detail?.height ?? event?.params?.height
-  if (typeof height === 'number' && height > 0) measuredHeight.value = Math.round(height)
-}
+const { onLayoutChange } = useResizeObserver((rect) => {
+  if (rect.height > 0) measuredHeight.value = Math.round(rect.height)
+})
 </script>
 
 <template>
@@ -34,7 +33,7 @@ function onSlotLayout(event: any): void {
         Scroll the panel; overscroll past either edge for the native rubber-band bounce.
       </text>
 
-      <view class="flex-1 min-h-0" @layoutchange="onSlotLayout">
+      <view class="flex-1 min-h-0" @layoutchange="onLayoutChange">
         <view :style="{ height: `${scrollHeight}px` }">
           <ScrollView class="w-full h-full">
             <view class="flex flex-col">

--- a/docs/upstream/vue-lynx-keyboard.md
+++ b/docs/upstream/vue-lynx-keyboard.md
@@ -121,12 +121,14 @@ Never combine the two, because the lifts stack.
 
 ## Open questions / upstream
 
-- **`GlobalEventEmitter` `keyboardstatuschanged` delivery is fixed upstream**
-  in vue-lynx PR #193 ("route LEPUS global events to GlobalEventEmitter",
-  ships after 0.4.2, plus a `useGlobalEvent` composable). vyui is pinned to
-  0.4.2 (0.5.x Draggable regression), so the element `keyboard` event remains
-  the primary signal; `useGlobalKeyboard` starts working on the day the pin
-  moves past that release.
+- **`GlobalEventEmitter` delivery, post-#193 (unverified on device).** vyui is
+  now on vue-lynx 0.5.1, which ships #193's `useGlobalEvent` plus
+  `onLifecycleEvent` routing. That routing only forwards events the *main
+  thread* emits (`globalEventFromLepus`); `keyboardstatuschanged` is emitted by
+  native straight into the background context, which is the delivery that
+  failed. So it is unproven that `useGlobalKeyboard` works on 0.5.1 — the
+  element `keyboard` event stays the primary signal until someone re-runs the
+  iOS-simulator check.
 - **`KeyboardAware*` rework:** DONE. The root's primary signal is the input's
   `keyboard` event relayed through the trigger context;
   `useGlobalKeyboard` is retained as a harmless fallback.

--- a/docs/upstream/vue-lynx-list-append-only.md
+++ b/docs/upstream/vue-lynx-list-append-only.md
@@ -1,0 +1,52 @@
+# vue-lynx's `<list>` bridge is append-only
+
+`<list>` children under vue-lynx 0.5.1 (and 0.4.x) can only ever grow at the
+tail. Removing a `<list-item>` — or inserting one before an existing sibling —
+never reaches the native list, so a list that shrinks keeps ghost rows and the
+next append fails with:
+
+```
+Error for duplicated list item-key. Last diff result is DiffResult:
+item_keys:[1,…,50,__vyui_feed_footer__,], insertions:[40,…,49], removals:[],
+Current diff result is DiffResult:
+item_keys:[1,…,50,__vyui_feed_footer__,21,…,30,], insertions:[51,…,60], removals:[],
+```
+
+(vyui repro: kit-demo's FeedList tab — load to 50 items, hit "Reset feed". The
+reset shrinks to 20 rows and drops the footer; native sees neither, then the
+follow-up load-more re-inserts keys 21–30 that it thinks are still there.)
+
+## Cause
+
+`main-thread/dist/list-apply.js`:
+
+- `insertListItem(parentId, child, childId)` **pushes**; the `anchorId` the
+  `INSERT` op carries is dropped on the floor for list parents.
+- `flushListUpdates()` only reports items past a `listItemsReported` **count**,
+  and hardcodes `removeAction: []` / `updateAction: []`.
+- `ops-apply.js`'s `REMOVE` case calls `__RemoveElement(parent, child)` for list
+  children — the list's own data source (`listItems`) is never touched, so the
+  row survives in the native diff.
+
+The `update-list-info` protocol supports all three actions; `@lynx-js/react`
+implements them in `runtime/lib/listUpdateInfo.js`
+(`ListUpdateInfoRecording.__toAttribute`): `removeAction` holds indices into the
+**old** child list, insertion `position` is the index in the **new** one.
+
+## Local fix
+
+`patches/vue-lynx@0.5.1.patch` extends `list-apply.js` / `ops-apply.js` to that
+contract: the anchor is honoured, `removeListItem` shrinks the array on
+`REMOVE`, and `flushListUpdates` diffs the reported key order against the
+current one. Pure reorders (same keys, new order) still emit nothing — the
+native list does not reorder, which is why FeedList documents "replace the keys
+rather than permuting existing ones".
+
+Re-port on any vue-lynx bump; drop it if upstream ships a real list diff.
+
+## Consumers are still on the unpatched runtime
+
+The patch only covers this repo (dev app, docs, CI). Anyone installing
+`@vyui/core` gets stock vue-lynx, so a `VyFeedList` whose `items` shrink
+(refresh, filter, delete-a-row) hits the same error until upstream fixes it or
+they apply the same patch.

--- a/docs/upstream/vue-lynx-mt-worklet-import-issue.md
+++ b/docs/upstream/vue-lynx-mt-worklet-import-issue.md
@@ -1,12 +1,21 @@
 # `worklet-loader-mt`: non-relative imports silently dropped from MT module graph, breaking aliased/package worklets at runtime
 
+> **Status (2026-08-29): fixed upstream; kept as the record of why the setup
+> looks the way it does.** Everything below the Summary describes vue-lynx
+> **≤ 0.4.1**. From 0.4.2 (#190) the loader resolves every specifier through
+> the bundler resolver, so aliases work by default and `node_modules`
+> packages are opted in with `includeWorkletPackages`. The live requirements
+> are in "VyUI status" and the addenda: the 0.5.1 loader patch, the
+> `@lynx-js/react` error patch, and the consumer-side
+> `includeWorkletPackages: ['@vyui/core', '@vyui/kit']`.
+
 ## Summary
 
 `extractLocalImports` in `plugin/dist/loaders/worklet-loader-mt.js` builds the main-thread (MT) module graph by re-emitting a processed module's imports as side-effect imports, but it filters specifiers with a regex that requires them to start with `.`. Any import using a path alias (`@/…`, `~/…`, tsconfig `paths`) or a bare package specifier (`@scope/pkg`) is silently excluded. The result is a `'main thread'` worklet that exists in the background bundle but whose `registerWorkletInternal(…)` call is never emitted into the MT bundle; at runtime, `_workletMap[id].bind(this)` throws `TypeError: cannot read property 'bind' of undefined`.
 
 ---
 
-## Loader behavior / root cause
+## Loader behavior / root cause (≤ 0.4.1)
 
 - The culprit is `extractLocalImports(source)` in `plugin/dist/loaders/worklet-loader-mt.js`.
 - It matches import specifiers using exactly two regexes:
@@ -20,7 +29,7 @@
 
 ---
 
-## Why `sideEffects` / tree-shaking can't fix it
+## Why `sideEffects` / tree-shaking couldn't fix it (≤ 0.4.1)
 
 - This is **not** a tree-shaking or `package.json#sideEffects` problem; those mechanisms operate at the bundler stage and cannot fix it.
 - The filtering happens at the **loader stage**, when the MT module's import list is generated, one stage before bundling and dead-code elimination run.
@@ -29,7 +38,7 @@
 
 ---
 
-## Reproduction
+## Reproduction (≤ 0.4.1)
 
 - Define a `'main thread'` worklet in a module `gesture.ts` (a touch handler that mutates a `useMainThreadRef` and updates a transform style via `runOnMainThread`).
 - Import it into an SFC using a **path alias** configured in tsconfig `paths` (e.g. `import { useGesture } from '@/gesture'`) and bind it with `:main-thread-bindtouchstart`.
@@ -42,14 +51,21 @@
 
 ---
 
-## Impact
+## Impact (≤ 0.4.1)
 
 - **Breaks aliased imports (near-universal pattern):** Any shared composable or module that defines `'main thread'` worklets and is consumed via `@/`/tsconfig path aliases, the standard project convention, silently fails at runtime with a confusing low-level error that is far from the root cause.
-- **Blocks published component libraries entirely:** A package consumed via a bare specifier (e.g. `@vyui/core`) cannot ship MT worklets to consumers, because the consumer's MT loader skips all imports into that package. A fully general solution needs upstream package traversal / allowlisting. VyUI currently carries a narrow local patch that follows only `@/…` plus `@vyui/core` / `@vyui/kit` imports; it is a stopgap for VyUI consumers, not a general npm-package traversal policy.
+- **Blocks published component libraries entirely:** A package consumed via a bare specifier (e.g. `@vyui/core`) cannot ship MT worklets to consumers, because the consumer's MT loader skips all imports into that package. A fully general solution needs upstream package traversal / allowlisting. VyUI carried a narrow local patch (follow `@/…` plus `@vyui/core` / `@vyui/kit`) until #190 landed; that patch is gone.
 
 ---
 
-## Proposed fix
+## Proposed fix — both tiers shipped in 0.4.2 (#190)
+
+`extractLocalImports` is now async: it keeps relative specifiers, resolves
+everything else through the bundler resolver, keeps whatever lands outside
+`node_modules` (aliases, workspace links), and keeps a `node_modules` hit only
+when its package root matches `includeWorkletPackages` (string or RegExp).
+Verified against the installed 0.5.1 dist. The original proposal, for the
+record:
 
 **Tier 1: aliases (internal projects):**
 - Replace the `^\.` regex check with resolution via the bundler's own resolver (webpack/rspack `this.resolve`) or by consulting the configured aliases and tsconfig `paths` directly.
@@ -63,7 +79,7 @@
 
 ## VyUI status (as shipped)
 
-`@vyui/core` and `@vyui/kit` now publish **per-file, source-shaped ESM** (Vite lib + Rollup `preserveModules`; see `docs/plans/vite-preserve-modules-dist.md`). Every worklet module ships with direct **named** `vue-lynx` imports and its own pre-compiled `registerWorkletInternal(...)` registrations, the shape the whole MT toolchain assumes. This removes the second failure mode (a bundle's `__WEBPACK_EXTERNAL_MODULE_vue_lynx_*` namespace being orphaned by the consumer's registration slicing). A `check-dist-shape` build gate keeps dist source-shaped.
+`@vyui/core` and `@vyui/kit` now publish **per-file, source-shaped ESM** (Vite lib + Rollup `preserveModules`; see `docs/plans/archive/vite-preserve-modules-dist.md`). Every worklet module ships with direct **named** `vue-lynx` imports and its own pre-compiled `registerWorkletInternal(...)` registrations, the shape the whole MT toolchain assumes. This removes the second failure mode (a bundle's `__WEBPACK_EXTERNAL_MODULE_vue_lynx_*` namespace being orphaned by the consumer's registration slicing). A `check-dist-shape` build gate keeps dist source-shaped.
 
 With source-shaped dist, the **only** remaining consumer-side requirement is the Tier-2 **traversal** fix so the consumer's MT loader walks into `@vyui/*` at all:
 - **RESOLVED:** #190 shipped in vue-lynx 0.4.2; the local patch is gone (we're on ^0.4.2). NPM consumers must set `pluginVueLynx({ includeWorkletPackages: ['@vyui/core', '@vyui/kit'] })`. In-repo demos don't need it, since they alias `@vyui/*` at workspace source (`apps/examples/_shared/vyui-aliases.ts`), which the loader follows by default.
@@ -94,7 +110,9 @@ When the `_wkltId`'s `registerWorkletInternal(...)` never reached the MT bundle 
 
 ## Environment
 
-- `vue-lynx` 0.4.0
+Originally reported against `vue-lynx` 0.4.0. Current (2026-08-29):
+
+- `vue-lynx` 0.5.1 (still the latest release; patched locally, see addenda)
 - `@lynx-js/rspeedy` 0.13.6
-- `@lynx-js/react` 0.116.5 (provides `worklet-runtime` and `@lynx-js/react/transform`)
+- `@lynx-js/react` 0.116.5 (provides `worklet-runtime` and `@lynx-js/react/transform`; patched locally)
 - `@lynx-js/types` 3.8.0

--- a/packages/core/src/components/FeedList/FeedList.test.ts
+++ b/packages/core/src/components/FeedList/FeedList.test.ts
@@ -165,4 +165,14 @@ describe('FeedList — inline rubber mirrors physics.ts', () => {
     // 1.5 is `scaleFactor` in physics.ts.
     expect(fn).toMatch(/return sign \* bounce \* 1\.5/)
   })
+
+  it('is called with a 2x-threshold band so a threshold-px drag reaches the trigger', async () => {
+    expect(body(await readSfc(), '_dragMove')).toMatch(/_rubber\([^)]*, threshold \* 2\)/)
+    const { rubberEffect } = await import('@/shared/gesture/physics')
+    const threshold = 64
+    expect(rubberEffect(threshold, threshold * 2)).toBe(threshold)
+    // The band saturates at its width: width === threshold put the trigger on
+    // the curve's asymptote, so a threshold-px pull never armed the release.
+    expect(rubberEffect(threshold, threshold)).toBeLessThan(threshold)
+  })
 })

--- a/packages/core/src/components/FeedList/FeedList.test.ts
+++ b/packages/core/src/components/FeedList/FeedList.test.ts
@@ -167,7 +167,7 @@ describe('FeedList — inline rubber mirrors physics.ts', () => {
   })
 
   it('is called with a 2x-threshold band so a threshold-px drag reaches the trigger', async () => {
-    expect(body(await readSfc(), '_dragMove')).toMatch(/_rubber\([^)]*, threshold \* 2\)/)
+    expect(body(await readSfc(), '_dragMove')).toMatch(/_rubber\(.*, threshold \* 2\)/)
     const { rubberEffect } = await import('@/shared/gesture/physics')
     const threshold = 64
     expect(rubberEffect(threshold, threshold * 2)).toBe(threshold)

--- a/packages/core/src/components/FeedList/FeedList.vue
+++ b/packages/core/src/components/FeedList/FeedList.vue
@@ -9,6 +9,14 @@
      native `bounces` off, nothing competes for the touch. Rationale +
      device-verify checklist: REFRESH-PHYSICS.md.
 
+     Shrinking `items` needs a vue-lynx whose `<list>` bridge applies removals —
+     stock 0.5.1 only appends, leaving ghost rows and a "duplicated list
+     item-key" crash on the next append (docs/upstream/vue-lynx-list-append-only.md).
+
+     The host must give this component a DEFINITE height — a native `<list>`
+     inside a `flex-1 min-h-0` box measures 0px and renders no rows. Measure the
+     container and pass pixels.
+
      Worklet rules: every `'main thread'` fn is inlined here (a `.ts`-resident
      worklet crashes the card at load) and defined before its callers; BG writes
      to `.current` are dropped, so config is pushed via `runOnMainThread`. -->
@@ -379,7 +387,11 @@ function _dragMove(y: number) {
   }
 
   const threshold = thresholdRef.current > 0 ? thresholdRef.current : 64
-  const offset = _rubber(startOffsetRef.current + (y - startYRef.current), threshold)
+  // Band width is 2x the threshold, NOT the threshold: `_rubber` saturates at
+  // its width, so width === threshold made `offset >= threshold` reachable only
+  // at the curve's exact asymptote (a 2x-threshold drag landing on equality).
+  // At 2x, a drag of exactly `threshold` px paints exactly `threshold` px.
+  const offset = _rubber(startOffsetRef.current + (y - startYRef.current), threshold * 2)
   offsetRef.current = offset
   _paint(offset)
 

--- a/patches/vue-lynx@0.5.1.patch
+++ b/patches/vue-lynx@0.5.1.patch
@@ -26,3 +26,121 @@ index 3bd4022..b65fff2 100644
          } else if ('(' === ch) depth++;
          else if (')' === ch) {
              depth--;
+diff --git a/main-thread/dist/list-apply.js b/main-thread/dist/list-apply.js
+index a24e191..a4ffd90 100644
+--- a/main-thread/dist/list-apply.js
++++ b/main-thread/dist/list-apply.js
+@@ -70,7 +70,7 @@ function isPlatformInfoAttr(key) {
+ function createListElement(id) {
+     listElementIds.add(id);
+     listItems.set(id, []);
+-    listItemsReported.set(id, 0);
++    listItemsReported.set(id, []);
+     const cbs = createListCallbacks(id);
+     const el = __CreateList(__WEBPACK_EXTERNAL_MODULE__element_registry_js_05e5c264__.pageUniqueId, cbs.componentAtIndex, cbs.enqueueComponent, {}, cbs.componentAtIndexes);
+     __SetCSSId([
+@@ -78,12 +78,31 @@ function createListElement(id) {
+     ], 0);
+     return el;
+ }
+-function insertListItem(parentId, child, childId) {
++function insertListItem(parentId, child, childId, anchorId) {
++    // vyui patch: honour the anchor (and drop any prior entry for this child) so
++    // a keyed insert / move lands where Vue put it, not always at the tail.
+     const items = listItems.get(parentId);
+-    if (items) items.push({
++    if (!items) return;
++    const existing = items.findIndex((entry)=>entry.bgId === childId);
++    if (-1 !== existing) items.splice(existing, 1);
++    const at = null == anchorId || -1 === anchorId ? -1 : items.findIndex((entry)=>entry.bgId === anchorId);
++    const entry = {
+         el: child,
+         bgId: childId
+-    });
++    };
++    if (-1 === at) items.push(entry);
++    else items.splice(at, 0, entry);
++}
++function removeListItem(parentId, childId) {
++    // vyui patch: REMOVE on a list parent has to shrink the item array. Without
++    // it the row stays in the native data source, so a shrunk list keeps ghost
++    // rows and the next append trips "duplicated list item-key".
++    const items = listItems.get(parentId);
++    if (!items) return;
++    const at = items.findIndex((entry)=>entry.bgId === childId);
++    if (-1 !== at) items.splice(at, 1);
++    itemKeyMap.delete(childId);
++    listItemPlatformInfo.delete(childId);
+ }
+ function setPlatformInfoProp(id, key, value) {
+     const info = listItemPlatformInfo.get(id);
+@@ -94,15 +113,24 @@ function setPlatformInfoProp(id, key, value) {
+     if ('item-key' === key) itemKeyMap.set(id, String(value));
+ }
+ function flushListUpdates() {
++    // vyui patch: diff the reported key order against the current one instead of
++    // only appending the tail. `removeAction` indexes the OLD list, insertion
++    // `position` indexes the NEW one — same contract as @lynx-js/react's
++    // ListUpdateInfoRecording.
+     for (const [bgId, items] of listItems){
+         var _listItemsReported_get;
+-        const reported = null != (_listItemsReported_get = listItemsReported.get(bgId)) ? _listItemsReported_get : 0;
+-        if (items.length <= reported) continue;
++        const reported = null != (_listItemsReported_get = listItemsReported.get(bgId)) ? _listItemsReported_get : [];
++        if (reported.length === items.length && reported.every((id, j)=>id === items[j].bgId)) continue;
+         const listEl = __WEBPACK_EXTERNAL_MODULE__element_registry_js_05e5c264__.elements.get(bgId);
+         if (!listEl) continue;
++        const currentIds = new Set(items.map((entry)=>entry.bgId));
++        const reportedIds = new Set(reported);
++        const removeAction = [];
++        for(let j = 0; j < reported.length; j++)if (!currentIds.has(reported[j])) removeAction.push(j);
+         const insertAction = [];
+-        for(let j = reported; j < items.length; j++){
++        for(let j = 0; j < items.length; j++){
+             const entry = items[j];
++            if (reportedIds.has(entry.bgId)) continue;
+             var _itemKeyMap_get;
+             const action = {
+                 position: j,
+@@ -115,10 +143,10 @@ function flushListUpdates() {
+         }
+         __SetAttribute(listEl, 'update-list-info', {
+             insertAction,
+-            removeAction: [],
++            removeAction,
+             updateAction: []
+         });
+-        listItemsReported.set(bgId, items.length);
++        listItemsReported.set(bgId, items.map((entry)=>entry.bgId));
+     }
+ }
+ function resetListState() {
+@@ -128,4 +156,4 @@ function resetListState() {
+     listItemPlatformInfo.clear();
+     listItemsReported.clear();
+ }
+-export { createListElement, flushListUpdates, insertListItem, isListParent, isPlatformInfoAttr, resetListState, setPlatformInfoProp };
++export { createListElement, flushListUpdates, insertListItem, isListParent, isPlatformInfoAttr, removeListItem, resetListState, setPlatformInfoProp };
+diff --git a/main-thread/dist/ops-apply.js b/main-thread/dist/ops-apply.js
+index fc2f444..52ad769 100644
+--- a/main-thread/dist/ops-apply.js
++++ b/main-thread/dist/ops-apply.js
+@@ -65,7 +65,7 @@ function applyOps(ops, flush = true) {
+                     const anchorId = ops[i++];
+                     const parent = __WEBPACK_EXTERNAL_MODULE__element_registry_js_05e5c264__.elements.get(parentId);
+                     const child = __WEBPACK_EXTERNAL_MODULE__element_registry_js_05e5c264__.elements.get(childId);
+-                    if (parent && child) if ((0, __WEBPACK_EXTERNAL_MODULE__list_apply_js_59c834d8__.isListParent)(parentId)) (0, __WEBPACK_EXTERNAL_MODULE__list_apply_js_59c834d8__.insertListItem)(parentId, child, childId);
++                    if (parent && child) if ((0, __WEBPACK_EXTERNAL_MODULE__list_apply_js_59c834d8__.isListParent)(parentId)) (0, __WEBPACK_EXTERNAL_MODULE__list_apply_js_59c834d8__.insertListItem)(parentId, child, childId, anchorId);
+                     else if (-1 === anchorId) __AppendElement(parent, child);
+                     else {
+                         const anchor = __WEBPACK_EXTERNAL_MODULE__element_registry_js_05e5c264__.elements.get(anchorId);
+@@ -79,7 +79,8 @@ function applyOps(ops, flush = true) {
+                     const childId = ops[i++];
+                     const parent = __WEBPACK_EXTERNAL_MODULE__element_registry_js_05e5c264__.elements.get(parentId);
+                     const child = __WEBPACK_EXTERNAL_MODULE__element_registry_js_05e5c264__.elements.get(childId);
+-                    if (parent && child) __RemoveElement(parent, child);
++                    if (parent && child) if ((0, __WEBPACK_EXTERNAL_MODULE__list_apply_js_59c834d8__.isListParent)(parentId)) (0, __WEBPACK_EXTERNAL_MODULE__list_apply_js_59c834d8__.removeListItem)(parentId, childId);
++                    else __RemoveElement(parent, child);
+                     break;
+                 }
+             case __WEBPACK_EXTERNAL_MODULE_vue_lynx_internal_ops_dc871e34__.OP.SET_PROP:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,7 +100,7 @@ catalogs:
 patchedDependencies:
   '@changesets/cli@2.31.0': 53cc2f61ee1b73408bf27081bc2cef5ece4d2ce0dabed8e15b6256928110c0fd
   '@lynx-js/react@0.116.5': 760c4f8541a2f7020d7cf8247f88d40f752e828f3afd6211ae12eba6f1dfdfb8
-  vue-lynx@0.5.1: 32c82cd1633e691fc46f2a44db69a0d54576d5aed418eac31842cc275312f700
+  vue-lynx@0.5.1: d5cbfc983c49b806b8d2814aa045aa7c174aea59fbedd7d90205d98de64544cb
 
 importers:
 
@@ -226,7 +226,7 @@ importers:
         version: 0.3.1(tailwindcss@3.4.19(tsx@4.22.3)(yaml@2.9.0))
       vue-lynx:
         specifier: 'catalog:'
-        version: 0.5.1(patch_hash=32c82cd1633e691fc46f2a44db69a0d54576d5aed418eac31842cc275312f700)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15))
+        version: 0.5.1(patch_hash=d5cbfc983c49b806b8d2814aa045aa7c174aea59fbedd7d90205d98de64544cb)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15))
     devDependencies:
       '@iconify-json/lucide':
         specifier: 'catalog:'
@@ -275,7 +275,7 @@ importers:
         version: link:../../../packages/kit
       vue-lynx:
         specifier: 'catalog:'
-        version: 0.5.1(patch_hash=32c82cd1633e691fc46f2a44db69a0d54576d5aed418eac31842cc275312f700)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15))
+        version: 0.5.1(patch_hash=d5cbfc983c49b806b8d2814aa045aa7c174aea59fbedd7d90205d98de64544cb)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15))
     devDependencies:
       '@iconify-json/lucide':
         specifier: 'catalog:'
@@ -324,7 +324,7 @@ importers:
         version: link:../../../packages/kit
       vue-lynx:
         specifier: 'catalog:'
-        version: 0.5.1(patch_hash=32c82cd1633e691fc46f2a44db69a0d54576d5aed418eac31842cc275312f700)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15))
+        version: 0.5.1(patch_hash=d5cbfc983c49b806b8d2814aa045aa7c174aea59fbedd7d90205d98de64544cb)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15))
     devDependencies:
       '@iconify-json/icon-park-outline':
         specifier: 'catalog:'
@@ -376,7 +376,7 @@ importers:
         version: link:../../../packages/kit
       vue-lynx:
         specifier: 'catalog:'
-        version: 0.5.1(patch_hash=32c82cd1633e691fc46f2a44db69a0d54576d5aed418eac31842cc275312f700)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15))
+        version: 0.5.1(patch_hash=d5cbfc983c49b806b8d2814aa045aa7c174aea59fbedd7d90205d98de64544cb)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15))
     devDependencies:
       '@iconify-json/icon-park-outline':
         specifier: 'catalog:'
@@ -431,7 +431,7 @@ importers:
         version: link:../../../packages/kit
       vue-lynx:
         specifier: 'catalog:'
-        version: 0.5.1(patch_hash=32c82cd1633e691fc46f2a44db69a0d54576d5aed418eac31842cc275312f700)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15))
+        version: 0.5.1(patch_hash=d5cbfc983c49b806b8d2814aa045aa7c174aea59fbedd7d90205d98de64544cb)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15))
     devDependencies:
       '@iconify-json/lucide':
         specifier: 'catalog:'
@@ -480,7 +480,7 @@ importers:
         version: link:../../../packages/kit
       vue-lynx:
         specifier: 'catalog:'
-        version: 0.5.1(patch_hash=32c82cd1633e691fc46f2a44db69a0d54576d5aed418eac31842cc275312f700)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15))
+        version: 0.5.1(patch_hash=d5cbfc983c49b806b8d2814aa045aa7c174aea59fbedd7d90205d98de64544cb)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15))
     devDependencies:
       '@iconify-json/icon-park-outline':
         specifier: 'catalog:'
@@ -538,7 +538,7 @@ importers:
         version: link:../../../packages/kit
       vue-lynx:
         specifier: 'catalog:'
-        version: 0.5.1(patch_hash=32c82cd1633e691fc46f2a44db69a0d54576d5aed418eac31842cc275312f700)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15))
+        version: 0.5.1(patch_hash=d5cbfc983c49b806b8d2814aa045aa7c174aea59fbedd7d90205d98de64544cb)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15))
     devDependencies:
       '@iconify-json/icon-park-outline':
         specifier: 'catalog:'
@@ -602,7 +602,7 @@ importers:
         version: 3.5.34(typescript@5.9.3)
       vue-lynx:
         specifier: 'catalog:'
-        version: 0.5.1(patch_hash=32c82cd1633e691fc46f2a44db69a0d54576d5aed418eac31842cc275312f700)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2)
+        version: 0.5.1(patch_hash=d5cbfc983c49b806b8d2814aa045aa7c174aea59fbedd7d90205d98de64544cb)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2)
       vue-tsc:
         specifier: 'catalog:'
         version: 3.3.10(typescript@5.9.3)
@@ -690,7 +690,7 @@ importers:
         version: 3.5.34(typescript@5.9.3)
       vue-lynx:
         specifier: 'catalog:'
-        version: 0.5.1(patch_hash=32c82cd1633e691fc46f2a44db69a0d54576d5aed418eac31842cc275312f700)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(lightningcss@1.32.0))
+        version: 0.5.1(patch_hash=d5cbfc983c49b806b8d2814aa045aa7c174aea59fbedd7d90205d98de64544cb)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(lightningcss@1.32.0))
       vue-tsc:
         specifier: 'catalog:'
         version: 3.3.10(typescript@5.9.3)
@@ -745,7 +745,7 @@ importers:
         version: 3.5.34(typescript@5.9.3)
       vue-lynx:
         specifier: 'catalog:'
-        version: 0.5.1(patch_hash=32c82cd1633e691fc46f2a44db69a0d54576d5aed418eac31842cc275312f700)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(lightningcss@1.32.0))
+        version: 0.5.1(patch_hash=d5cbfc983c49b806b8d2814aa045aa7c174aea59fbedd7d90205d98de64544cb)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(lightningcss@1.32.0))
       vue-tsc:
         specifier: 'catalog:'
         version: 3.3.10(typescript@5.9.3)
@@ -778,7 +778,7 @@ importers:
         version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.4)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)
       vue-lynx:
         specifier: 'catalog:'
-        version: 0.5.1(patch_hash=32c82cd1633e691fc46f2a44db69a0d54576d5aed418eac31842cc275312f700)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(lightningcss@1.32.0))
+        version: 0.5.1(patch_hash=d5cbfc983c49b806b8d2814aa045aa7c174aea59fbedd7d90205d98de64544cb)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(lightningcss@1.32.0))
     devDependencies:
       '@types/jsdom':
         specifier: ^28.0.3
@@ -19781,7 +19781,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-lynx@0.5.1(patch_hash=32c82cd1633e691fc46f2a44db69a0d54576d5aed418eac31842cc275312f700)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(lightningcss@1.32.0)):
+  vue-lynx@0.5.1(patch_hash=d5cbfc983c49b806b8d2814aa045aa7c174aea59fbedd7d90205d98de64544cb)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(lightningcss@1.32.0)):
     dependencies:
       '@lynx-js/css-extract-webpack-plugin': 0.7.1(@lynx-js/template-webpack-plugin@0.10.9(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(webpack@5.106.2(lightningcss@1.32.0))
       '@lynx-js/react': 0.116.5(patch_hash=760c4f8541a2f7020d7cf8247f88d40f752e828f3afd6211ae12eba6f1dfdfb8)(@lynx-js/types@3.8.0)(@types/react@18.3.28)
@@ -19799,7 +19799,7 @@ snapshots:
       - tslib
       - webpack
 
-  vue-lynx@0.5.1(patch_hash=32c82cd1633e691fc46f2a44db69a0d54576d5aed418eac31842cc275312f700)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15)):
+  vue-lynx@0.5.1(patch_hash=d5cbfc983c49b806b8d2814aa045aa7c174aea59fbedd7d90205d98de64544cb)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15)):
     dependencies:
       '@lynx-js/css-extract-webpack-plugin': 0.7.1(@lynx-js/template-webpack-plugin@0.10.9(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(webpack@5.106.2(postcss@8.5.15))
       '@lynx-js/react': 0.116.5(patch_hash=760c4f8541a2f7020d7cf8247f88d40f752e828f3afd6211ae12eba6f1dfdfb8)(@lynx-js/types@3.8.0)(@types/react@18.3.28)
@@ -19817,7 +19817,7 @@ snapshots:
       - tslib
       - webpack
 
-  vue-lynx@0.5.1(patch_hash=32c82cd1633e691fc46f2a44db69a0d54576d5aed418eac31842cc275312f700)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2):
+  vue-lynx@0.5.1(patch_hash=d5cbfc983c49b806b8d2814aa045aa7c174aea59fbedd7d90205d98de64544cb)(@lynx-js/lynx-core@0.1.3)(@lynx-js/types@3.8.0)(@rsbuild/core@1.7.3)(@rsbuild/plugin-vue@1.2.8(@rsbuild/core@1.7.3)(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(@types/react@18.3.28)(tslib@2.8.1)(webpack@5.106.2):
     dependencies:
       '@lynx-js/css-extract-webpack-plugin': 0.7.1(@lynx-js/template-webpack-plugin@0.10.9(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(webpack@5.106.2)
       '@lynx-js/react': 0.116.5(patch_hash=760c4f8541a2f7020d7cf8247f88d40f752e828f3afd6211ae12eba6f1dfdfb8)(@lynx-js/types@3.8.0)(@types/react@18.3.28)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,7 +30,9 @@ allowBuilds:
   vue-demi: false
 # 0.5.1's worklet-loader-mt registration scan chokes on comments inside worklet
 # bodies; patch makes findBalancedEnd comment-aware. Drop when upstream #287
-# (AST-span extraction) ships.
+# (AST-span extraction) ships. The same patch also makes the main-thread `<list>`
+# bridge honour removals and anchors — upstream only ever appends, so a shrunk
+# `items` keeps ghost rows and the next append throws "duplicated list item-key".
 patchedDependencies:
   '@changesets/cli@2.31.0': patches/@changesets__cli@2.31.0.patch
   '@lynx-js/react@0.116.5': patches/@lynx-js__react@0.116.5.patch


### PR DESCRIPTION
Fixes the two FeedList bugs found on device: pull-to-refresh never armed, and resetting a loaded list crashed with "duplicated list item-key".

- vue-lynx's main-thread `<list>` bridge only appends — `flushListUpdates` hardcodes `removeAction: []` and `insertListItem` drops the INSERT anchor, so a shrunk list keeps ghost rows and the next append throws.
- Patched it to `@lynx-js/react`'s `ListUpdateInfoRecording` contract: removals index the old child list, insert positions the new one; pure reorders still emit nothing.
- FeedList's rubber band now uses a 2x-threshold width, so a pull of `refreshThreshold` px actually arms the release.
- kit-demo gets a Feed tab; both it and the Scroll tab measure their flex slot for a definite height (native scrollers measure 0px inside `flex-1 min-h-0`), via core's `useResizeObserver`.
- Write-up of the upstream bug: `docs/upstream/vue-lynx-list-append-only.md`; the keyboard and MT-worklet-import notes are brought up to 0.5.1 in the same pass.

Not verified on device yet — the patch landed after the last device run. Note that npm consumers install stock vue-lynx, so `VyFeedList` with shrinking `items` stays broken for them until upstream ships a real list diff.
